### PR TITLE
chore: release v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mnemon",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Deep integration of Mnemon and DeepSeek Harness, providing DSH with complete local-first three-tier memory: Runtime Memory, searchable Documents, and supervised Memory Spaces.",
   "keywords": [
     "deepseek-harness",


### PR DESCRIPTION
## Release

- bump package version from `0.1.1` to `0.1.2`
- prepare the merged sidebar/buildin display-mode and multi-workspace memory changes for npm publication

## Verification

- `pnpm run verify` — 25 test files, 160 tests passed
- `npm pack --dry-run --json` — package recognized as `dsh-mnemon@0.1.2` with 194 files