### PR TITLE
docs: keep README images visible on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <p align="center"><strong>English</strong> · <a href="./README.zh-CN.md">简体中文</a></p>
 
 <p align="center">
-  <a href="./docs/en/ui-guide.md">
-    <img src="./docs/assets/media/dsh-mnemon-memory-system-demo-poster.jpg" alt="dsh-mnemon Sidebar Memory System with Memory Space catalog and relationship graph" width="760">
+  <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/main/docs/en/ui-guide.md">
+    <img src="https://raw.githubusercontent.com/omdsh-dev/dsh-mnemon/main/docs/assets/media/dsh-mnemon-memory-system-demo-poster.jpg" alt="dsh-mnemon Sidebar Memory System with Memory Space catalog and relationship graph" width="760">
   </a>
 </p>
 
@@ -22,7 +22,7 @@ Current user instructions, repository files, and live tool results always take p
 
 ## Live demo
 
-![dsh-mnemon Sidebar Memory System and in-conversation interaction demo](./docs/assets/media/dsh-mnemon-memory-system-demo.gif)
+![dsh-mnemon Sidebar Memory System and in-conversation interaction demo](https://raw.githubusercontent.com/omdsh-dev/dsh-mnemon/main/docs/assets/media/dsh-mnemon-memory-system-demo.gif)
 
 See the [Sidebar and conversation UI guide](./docs/en/ui-guide.md) for the complete visual walkthrough.
 
@@ -110,7 +110,7 @@ Add and edit use consistent dialogs, destructive actions require confirmation, l
 
 | Turn memory | Save to memory |
 |---|---|
-| [![Expanded Turn memory with exact tool links](./docs/assets/screenshots/conversation-turn-memory.png)](./docs/assets/screenshots/conversation-turn-memory.png) | [![Confirm save to memory dialog](./docs/assets/screenshots/conversation-save-dialog.png)](./docs/assets/screenshots/conversation-save-dialog.png) |
+| [![Expanded Turn memory with exact tool links](https://raw.githubusercontent.com/omdsh-dev/dsh-mnemon/main/docs/assets/screenshots/conversation-turn-memory.png)](https://github.com/omdsh-dev/dsh-mnemon/blob/main/docs/assets/screenshots/conversation-turn-memory.png) | [![Confirm save to memory dialog](https://raw.githubusercontent.com/omdsh-dev/dsh-mnemon/main/docs/assets/screenshots/conversation-save-dialog.png)](https://github.com/omdsh-dev/dsh-mnemon/blob/main/docs/assets/screenshots/conversation-save-dialog.png) |
 
 - **Turn memory** summarizes recalls, writes, and Document searches for the turn; expand it to jump to the matching page.
 - **Save to memory** loads an editable candidate. Only confirmation sends it to the memory subagent for qualification, deduplication, distillation, and writing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,8 +3,8 @@
 <p align="center"><a href="./README.md">English</a> · <strong>简体中文</strong></p>
 
 <p align="center">
-  <a href="./docs/zh-CN/ui-guide.md">
-    <img src="./docs/assets/media/dsh-mnemon-memory-system-demo-poster.jpg" alt="dsh-mnemon Sidebar 记忆系统：记忆体目录与关系图" width="760">
+  <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/main/docs/zh-CN/ui-guide.md">
+    <img src="https://raw.githubusercontent.com/omdsh-dev/dsh-mnemon/main/docs/assets/media/dsh-mnemon-memory-system-demo-poster.jpg" alt="dsh-mnemon Sidebar 记忆系统：记忆体目录与关系图" width="760">
   </a>
 </p>
 
@@ -22,7 +22,7 @@
 
 ## 实机演示
 
-![dsh-mnemon Sidebar 记忆系统与对话内交互演示](./docs/assets/media/dsh-mnemon-memory-system-demo.gif)
+![dsh-mnemon Sidebar 记忆系统与对话内交互演示](https://raw.githubusercontent.com/omdsh-dev/dsh-mnemon/main/docs/assets/media/dsh-mnemon-memory-system-demo.gif)
 
 完整逐页说明见 [Sidebar 与对话交互指南](./docs/zh-CN/ui-guide.md)。
 
@@ -110,7 +110,7 @@ dsh plugin --profile web add "link:/absolute/path/to/dsh-mnemon"
 
 | 本回合记忆 | 存入记忆 |
 |---|---|
-| [![展开本回合记忆并查看工具入口](./docs/assets/screenshots/conversation-turn-memory.png)](./docs/assets/screenshots/conversation-turn-memory.png) | [![确认存入记忆弹窗](./docs/assets/screenshots/conversation-save-dialog.png)](./docs/assets/screenshots/conversation-save-dialog.png) |
+| [![展开本回合记忆并查看工具入口](https://raw.githubusercontent.com/omdsh-dev/dsh-mnemon/main/docs/assets/screenshots/conversation-turn-memory.png)](https://github.com/omdsh-dev/dsh-mnemon/blob/main/docs/assets/screenshots/conversation-turn-memory.png) | [![确认存入记忆弹窗](https://raw.githubusercontent.com/omdsh-dev/dsh-mnemon/main/docs/assets/screenshots/conversation-save-dialog.png)](https://github.com/omdsh-dev/dsh-mnemon/blob/main/docs/assets/screenshots/conversation-save-dialog.png) |
 
 - **本回合记忆**汇总本轮的召回、沉淀与档案检索；展开后可以跳到对应页面。
 - **存入记忆**先加载可编辑候选，只有确认后才交给记忆子 Agent 判断、查重、提炼并写入。

--- a/scripts/verify-package-contents.mjs
+++ b/scripts/verify-package-contents.mjs
@@ -23,11 +23,22 @@ const unexpected = paths.filter(path => !allowedRootFiles.has(path) && !(/^lib\/
 const clientBundle = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
 const hostLeaks = ['require("node:', "require('node:", '#region src/version-updates.ts', '#region src/rpc.ts']
   .filter(pattern => clientBundle.includes(pattern))
+const readmeFiles = ['README.md', 'README.zh-CN.md']
+const relativeReadmeImages = readmeFiles.flatMap((path) => {
+  const source = readFileSync(new URL(`../${path}`, import.meta.url), 'utf8')
+  const markdownImages = [...source.matchAll(/!\[[^\]]*\]\(([^)\s]+)(?:\s+['"][^)]*['"])?\)/g)]
+  const htmlImages = [...source.matchAll(/<img\b[^>]*\bsrc=['"]([^'"]+)['"]/gi)]
+  return [...markdownImages, ...htmlImages]
+    .map(match => match[1])
+    .filter(source => !/^https:\/\//.test(source))
+    .map(source => `${path}: ${source}`)
+})
 
-if (missing.length > 0 || unexpected.length > 0 || hostLeaks.length > 0 || pack.unpackedSize > 1_500_000) {
+if (missing.length > 0 || unexpected.length > 0 || hostLeaks.length > 0 || relativeReadmeImages.length > 0 || pack.unpackedSize > 1_500_000) {
   if (missing.length > 0) console.error(`Missing package files:\n${missing.map(path => `- ${path}`).join('\n')}`)
   if (unexpected.length > 0) console.error(`Unexpected package files:\n${unexpected.map(path => `- ${path}`).join('\n')}`)
   if (hostLeaks.length > 0) console.error(`Host-only code leaked into lib/client.js:\n${hostLeaks.map(pattern => `- ${pattern}`).join('\n')}`)
+  if (relativeReadmeImages.length > 0) console.error(`README images must use absolute HTTPS URLs so npm can render assets excluded from the package:\n${relativeReadmeImages.map(image => `- ${image}`).join('\n')}`)
   if (pack.unpackedSize > 1_500_000) console.error(`Unpacked package is ${pack.unpackedSize} bytes; expected at most 1500000.`)
   process.exit(1)
 }


### PR DESCRIPTION
## Summary

- serve the English and Chinese README images from absolute GitHub URLs so npm can render them without shipping documentation media
- keep the README poster, animated demo, and conversation screenshots while preserving the lean runtime package
- reject future relative README image URLs during package verification

## Verification

- all four referenced image assets return HTTP 200
- `pnpm run verify:package`
- package remains at 49 files and approximately 192 KB packed
- `git diff --check`