### PR TITLE
feat: support DSH Headless profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **Cross-agent sharing**: Mnemon-enabled agents can read and reuse DSH's Mnemon Memory Spaces.
 - **Three cooperating tiers**: Runtime Memory, Project Documents, and Memory Spaces retain information at the right granularity.
 - **Supervised writes**: isolated memory subagents make semantic decisions; the Host enforces paths, permissions, capacity, locks, and revisions.
-- **Native DSH experience**: a Sidebar workbench by default, turn memory, a Save-to-memory dialog, bilingual copy, and global themes.
+- **Web and Headless**: a complete Sidebar workbench for interactive management, plus the same Agent tools, memory context, and cwd routing in one-shot Headless tasks.
 
 Current user instructions, repository files, and live tool results always take precedence over historical memory.
 
@@ -56,15 +56,25 @@ Expand-Archive -Path $archive -DestinationPath $installDir -Force
 
 ### 2. Install the plugin
 
+For the complete Web workbench:
+
 ```sh
 dsh plugin --profile web add dsh-mnemon
 dsh --profile web
+```
+
+DSH profiles have independent plugin rosters. Install it separately for one-shot Headless tasks:
+
+```sh
+dsh plugin --profile headless add dsh-mnemon
+dsh --profile headless "Check durable project context before answering this task."
 ```
 
 Use an absolute path for a local development checkout:
 
 ```sh
 dsh plugin --profile web add "link:/absolute/path/to/dsh-mnemon"
+dsh plugin --profile headless add "link:/absolute/path/to/dsh-mnemon"
 ```
 
 ### 3. Open Memory System
@@ -78,6 +88,8 @@ New installations use `sidebar` by default. Click **Memory System** in the DSH s
 5. Return to the conversation and expand **Turn memory** below the answer.
 
 See [Getting Started](./docs/en/getting-started.md) for provider requirements and complete verification.
+
+Headless has no workbench or conversation buttons. It still mounts Runtime context, Documents, Memory Space tools, lifecycle guidance, and supervised writes. With `storageScope=workspace`, its memory root follows the invocation directory. Because the process exits as soon as the one-shot Agent becomes idle, delayed background review is cancelled at shutdown; explicit or model-guided writes completed during the task remain durable.
 
 ## One workbench, three memory tiers
 
@@ -180,7 +192,7 @@ pnpm install
 pnpm run verify
 ```
 
-`verify` runs TypeScript checks, Vitest, a reproducible double build, and published-package validation. `lib/` is generated and intentionally not tracked.
+`verify` runs TypeScript checks, Vitest, a reproducible double build, an isolated real Headless-profile activation check, and published-package validation. `lib/` is generated and intentionally not tracked.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,7 @@
 - **跨 Agent 共享**：DSH 的 Mnemon 记忆体可以被其他支持 Mnemon 的 Agent 读取和复用。
 - **三层协作**：运行时记忆、项目档案、记忆体各自保存适合自己的信息粒度。
 - **受监督写入**：语义判断交给隔离的记忆子 Agent，路径、权限、容量、锁与 revision 由 Host 控制。
-- **DSH 原生体验**：默认 Sidebar 工作台、对话内回合记忆、存入记忆弹窗、双语界面与明暗主题。
+- **Web 与 Headless**：Web 提供完整 Sidebar 工作台；一次性 Headless 任务获得同一套 Agent 工具、记忆上下文和 cwd 路由。
 
 当前用户指令、仓库文件与实时工具结果始终高于历史记忆。
 
@@ -56,15 +56,25 @@ Expand-Archive -Path $archive -DestinationPath $installDir -Force
 
 ### 2. 安装插件
 
+完整 Web 工作台：
+
 ```sh
 dsh plugin --profile web add dsh-mnemon
 dsh --profile web
+```
+
+DSH 各 profile 的插件清单彼此独立；一次性 Headless 任务需要单独安装：
+
+```sh
+dsh plugin --profile headless add dsh-mnemon
+dsh --profile headless "回答前先检查持久化的项目上下文。"
 ```
 
 本地开发检出使用绝对路径：
 
 ```sh
 dsh plugin --profile web add "link:/absolute/path/to/dsh-mnemon"
+dsh plugin --profile headless add "link:/absolute/path/to/dsh-mnemon"
 ```
 
 ### 3. 打开记忆系统
@@ -78,6 +88,8 @@ dsh plugin --profile web add "link:/absolute/path/to/dsh-mnemon"
 5. 回到对话，展开回复下方的“本回合记忆”查看工具轨迹。
 
 更完整的安装、Provider 要求与验证步骤见[快速开始](./docs/zh-CN/getting-started.md)。
+
+Headless 没有工作台和对话按钮，但仍会挂载运行时上下文、档案、记忆体工具、生命周期提示和受监督写入。`storageScope=workspace` 时，记忆根跟随启动命令所在目录。一次性 Agent 进入 idle 后进程立即退出，因此延迟后台审查会在关闭时取消；任务内已经完成的显式或模型引导写入仍会持久化。
 
 ## 一个工作台，三层记忆
 
@@ -180,7 +192,7 @@ pnpm install
 pnpm run verify
 ```
 
-`verify` 依次运行 TypeScript 检查、Vitest、两次可复现构建和发布包校验。`lib/` 是生成目录，不再提交到仓库。
+`verify` 依次运行 TypeScript 检查、Vitest、两次可复现构建、隔离的真实 Headless profile 激活检查和发布包校验。`lib/` 是生成目录，不再提交到仓库。
 
 ## License
 

--- a/docs/assets/diagrams/en/project-architecture.svg
+++ b/docs/assets/diagrams/en/project-architecture.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1040" viewBox="0 0 1600 1040" role="img" aria-labelledby="title description" lang="en">
   <title id="title">dsh-mnemon runtime architecture</title>
-  <desc id="description">DSH Web, the root Agent, and tools and commands enter the dsh-mnemon control and supervision layer, which connects to Runtime Memory, Project Documents, and long-term Mnemon Memory Spaces.</desc>
+  <desc id="description">DSH Web or Headless root Agents enter the dsh-mnemon control and supervision layer through memory context, tools, and commands, which connect to Runtime Memory, Project Documents, and long-term Mnemon Memory Spaces.</desc>
   <style>
     text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Arial, sans-serif; fill: #172033; }
     .canvas { fill: #f7f9fc; }

--- a/docs/assets/diagrams/zh-CN/project-architecture.svg
+++ b/docs/assets/diagrams/zh-CN/project-architecture.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1040" viewBox="0 0 1600 1040" role="img" aria-labelledby="title description" lang="zh-CN">
   <title id="title">dsh-mnemon 运行时架构</title>
-  <desc id="description">DSH Web、主 Agent 和工具命令进入 dsh-mnemon 控制与监督层，再分别连接运行时热记忆、项目档案和 Mnemon 长期记忆体。</desc>
+  <desc id="description">DSH Web 或 Headless 的主 Agent 通过记忆上下文、工具和命令进入 dsh-mnemon 控制与监督层，再分别连接运行时热记忆、项目档案和 Mnemon 长期记忆体。</desc>
   <style>
     text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Microsoft YaHei", sans-serif; fill: #172033; }
     .canvas { fill: #f7f9fc; }

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -36,7 +36,13 @@ settings.register("mnemon")
   -> register RPC when a Web connection exists
 ```
 
-The Host declares dependencies on `tools`, `settings`, `commands`, `agents`, and `subagents`. The Web client additionally depends on slots, connection, and DSH locale services.
+The Host declares dependencies on `tools`, `settings`, `commands`, `agents`, and `subagents`. `workspaceRegistry` is discovered optionally through the Host service registry and is used only for authorized Web inspection. The Web client additionally depends on slots, connection, and DSH locale services.
+
+## Web and Headless Boundaries
+
+The core Host composition is profile-neutral. Both Web and Headless mount settings, Runtime context, Documents, Memory Space tools, lifecycle hooks, and supervised workers. Agent operations always derive `workspace` storage from the session cwd.
+
+Web additionally provides `workspaceRegistry`, client slots, and `connection`. Those services enable cross-workspace inspection, RPC, Sidebar / Buildin, settings UI, Turn memory, and Save to memory. Headless provides none of those browser services; its one-shot runner submits an ordinary user message, waits for Agent idle, flushes the session, prints the final answer, and exits. Plugin disposal cancels a pending delayed review, so Headless relies on explicit or model-guided writes completed inside the task rather than post-idle maintenance.
 
 ## Dual Paths for the Root Agent and Workers
 
@@ -91,7 +97,7 @@ whether a reusable artifact exists  UTF-8 capacity accounting
 
 Persona constraints must be distinguished from hard Host guarantees. For example, the MEMORY archival worker is instructed to cover every committed hot-memory item, but the Host can strictly validate only the structured action, revision, and byte budget; the Host does validate USER compaction source coverage item by item.
 
-## Web Boundary
+## Web RPC Boundary
 
 The WebUI does not start system processes or open SQLite directly:
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -77,6 +77,8 @@ Web workbench inspection: resolve(workspaceRegistry.get(selectedWorkspaceId).pat
 
 Each DSH workspace owns an independent three-tier memory root. Agents, model tools, commands, and lifecycle hooks route by the current session cwd and are unaffected by the Web workbench's inspection target. The workbench can select only Host-registered workspaces, never an arbitrary path. When inspection and execution differ, the header shows both paths and offers one-click alignment with the current session. Agent-backed actions are rejected while misaligned to prevent writes to the wrong project.
 
+Headless has no `workspaceRegistry`; its fresh session cwd is the directory from which `dsh --profile headless ...` was launched, so `workspace` resolves directly to `<invocation cwd>/.mnemon`.
+
 ### `custom`
 
 ```yaml

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -80,10 +80,11 @@ The existing Vitest suites cover:
 - worker tool isolation, the schema subset, and structured receipts;
 - lifecycle cues, scoring, idle debounce, cancellation, and watermark retention;
 - RPC authority, read-only behavior, and settings revisions;
-- the Web workspace, bilingual copy, and key interactions.
+- the Web workspace, bilingual copy, and key interactions;
+- core activation without Web-only services and Agent-cwd routing for Headless;
 - Client/Host source boundaries, deterministic build hashes, package contents, exports, and TypeScript resolution.
 
-These are primarily integration tests using temporary directories, fake runners, and a mock Host. They are not equivalent to automated end-to-end tests of the real DSH + Mnemon WebUI.
+These are primarily integration tests using temporary directories, fake runners, and a mock Host. In addition, `verify:headless` builds the package, installs it into an isolated real DSH Headless profile, serves a local mock model, and asserts that representative Mnemon tools reach the model request. Automated end-to-end testing of the real DSH + Mnemon WebUI remains separate.
 
 ## Real WebUI Verification
 
@@ -175,6 +176,7 @@ When the Web locale changes, the Chinese key set remains the type source of trut
 [ ] confirm the worktree contains no generated lib changes
 [ ] confirm package validation reports only runtime files, declarations, root documents, and cordis.patch.yml
 [ ] install the built/local bundle into an isolated Web profile
+[ ] confirm `verify:headless` activates the built bundle in an isolated Headless profile
 [ ] run real Mnemon CLI and WebUI smoke tests
 [ ] verify Chinese and English workspaces
 [ ] verify global/workspace/custom paths as applicable

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -8,7 +8,7 @@ This guide goes from a blank environment to the first verified recall. It uses S
 
 You need:
 
-- a DSH Web profile that starts successfully;
+- a DSH Web or Headless profile that starts successfully;
 - a locally executable `mnemon` CLI;
 - a DSH subagent provider for isolated memory tasks.
 
@@ -84,7 +84,7 @@ mnemon:
 
 ## 3. Install dsh-mnemon
 
-Install into the Web profile:
+Install into the Web profile for the complete workbench:
 
 ```sh
 dsh plugin --profile web add dsh-mnemon
@@ -110,6 +110,17 @@ dsh plugin --profile web remove dsh-mnemon
 ```
 
 Uninstall removes the plugin registration, not memory data in global, workspace, or custom roots.
+
+Profiles have independent plugin rosters. Install the package separately into Headless when one-shot tasks also need memory:
+
+```sh
+dsh plugin --profile headless add dsh-mnemon
+dsh --profile headless "Check durable project context before answering this task."
+```
+
+For a development checkout, replace the package name with `"link:/absolute/path/to/dsh-mnemon"`. Headless mounts the same Runtime context, Documents, Memory Space tools, lifecycle guidance, and supervised write path as a Web Agent. It does not mount the workbench, conversation buttons, RPC channels, or an interactive slash-command surface.
+
+With `storageScope=workspace`, Headless resolves `<invocation cwd>/.mnemon`; no Web workspace registry is required. The one-shot runner exits when its Agent becomes idle, so shutdown cancels any delayed score-based background review that has not started. Explicit or model-guided writes that finish during the task are durable.
 
 ## 4. Choose entry point and storage
 

--- a/docs/en/interfaces.md
+++ b/docs/en/interfaces.md
@@ -1,4 +1,4 @@
-# WebUI, Tools, Commands, and RPC
+# Web, Headless, Tools, Commands, and RPC
 
 [简体中文](../zh-CN/interfaces.md) | **English** | [Documentation hub](./README.md)
 
@@ -16,6 +16,19 @@ This page is an integration reference. For daily use, start with the [Sidebar an
 | Model tools | — | Structured Root Agent read/write entry |
 
 Sidebar and Buildin are live, mutually exclusive mounts that share functionality, data, and Host services. The two conversation entries can be disabled independently through `mnemon-ui` settings.
+
+## Profile surfaces
+
+| Capability | Web | Headless |
+|---|---:|---:|
+| Runtime context and lifecycle guidance | Yes | Yes |
+| Model tools and supervised subagents | Yes | Yes |
+| Agent-cwd routing for `workspace` scope | Yes | Yes |
+| Sidebar / Buildin / conversation actions | Yes | No |
+| Host-to-client RPC | Yes | No |
+| Delayed score-based review after Agent idle | While the Host remains alive | Cancelled when the one-shot process exits |
+
+Headless receives the full model-tool surface. Its task argument is submitted as an ordinary user message, so it does not provide an interactive slash-command dispatcher. Explicit and model-guided writes that finish before the Agent becomes idle are durable.
 
 ## Model tools
 
@@ -83,12 +96,14 @@ Both are additive and replace no official DSH rendering. The assistant-message c
 
 ## Workspace routing
 
-Workbench requests carry `sessionId` and an optional `workspaceId`. The Host accepts only IDs registered in `workspaceRegistry`:
+Web workbench requests carry `sessionId` and an optional `workspaceId`. The Host accepts only IDs registered in `workspaceRegistry`:
 
 - deterministic reads and manual maintenance may route to the inspected root selected by `workspaceId`;
 - Agents, tools, commands, and lifecycle hooks still route by the Agent cwd associated with `sessionId`;
 - `status.workspaceContext` returns selected / effective roots and `aligned`;
 - Agent-backed operations are rejected while misaligned.
+
+Profiles without a Web workspace registry, including Headless, have no arbitrary inspection target. Agent execution still routes `workspace` scope directly from the session cwd.
 
 ## RPC channels
 

--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -133,6 +133,7 @@ Report vulnerabilities privately through [SECURITY.md](../../SECURITY.md), not a
 | Symptom | Check and resolution |
 |---|---|
 | Mnemon unavailable | macOS/Linux: run `command -v mnemon`, `mnemon --version`. Windows PowerShell: run `Get-Command mnemon`, `Test-Path "$env:LOCALAPPDATA\Programs\mnemon\mnemon.exe"`. Set `MNEMON_CLI_PATH` or `mnemon.cliPath`, then restart |
+| Headless Agent has no Mnemon tools | Plugins are profile-local. Run `dsh plugin --profile headless add dsh-mnemon`; a Web-profile installation does not carry over |
 | Memory System missing from sidebar | Check `tabEnabled=true`, `displayMode=sidebar`; Buildin is in the conversation area; for a local link run `pnpm run build`, then restart |
 | Status healthy but recall empty | Check active spaces, storage scope, inspected root, effective session root, and query focus |
 | Header reports misalignment | The workbench is inspecting another workspace; align or keep deliberate read-only inspection; Agent-backed actions are rejected |

--- a/docs/en/project-overview.md
+++ b/docs/en/project-overview.md
@@ -64,7 +64,7 @@ The default `global` root, `~/.mnemon`, is the simplest choice for several local
 
 ## Architecture
 
-[![dsh-mnemon runtime architecture with DSH Web, Root Agent, supervised control, and three local tiers](../assets/diagrams/en/project-architecture.svg)](../assets/diagrams/en/project-architecture.svg)
+[![dsh-mnemon runtime architecture with DSH Web or Headless, Root Agent, supervised control, and three local tiers](../assets/diagrams/en/project-architecture.svg)](../assets/diagrams/en/project-architecture.svg)
 
 Four boundaries shape the system:
 

--- a/docs/zh-CN/architecture.md
+++ b/docs/zh-CN/architecture.md
@@ -36,7 +36,13 @@ settings.register("mnemon")
   -> register RPC when a Web connection exists
 ```
 
-Host 声明依赖 `tools`、`settings`、`commands`、`agents` 和 `subagents`。Web client 另外依赖 slots、connection 和 DSH locale 服务。
+Host 声明依赖 `tools`、`settings`、`commands`、`agents` 和 `subagents`。`workspaceRegistry` 通过 Host 服务目录可选发现，只用于 Web 的受权查看。Web client 另外依赖 slots、connection 和 DSH locale 服务。
+
+## Web 与 Headless 边界
+
+核心 Host 组合与 profile 无关。Web 和 Headless 都会挂载设置、运行时上下文、档案、记忆体工具、生命周期钩子和受监督 worker；Agent 操作始终根据 session cwd 解析 `workspace` 存储。
+
+Web 额外提供 `workspaceRegistry`、客户端 slots 和 `connection`，用于跨工作区查看、RPC、Sidebar / Buildin、设置界面、本回合记忆和存入记忆。Headless 不提供这些浏览器服务；一次性 runner 把任务作为普通用户消息提交，等待 Agent idle、flush session、输出最终答案后退出。插件销毁会取消尚未执行的延迟审查，因此 Headless 依赖任务内完成的显式或模型引导写入，而不是 idle 后维护。
 
 ## 主 Agent 与 worker 的双路径
 
@@ -91,7 +97,7 @@ whether a reusable artifact exists  UTF-8 capacity accounting
 
 必须区分“persona 约束”和“Host 硬保证”。例如 MEMORY 归档 worker 被要求覆盖每条已提交热记忆，但 Host 只能硬校验结构化 action、revision 和字节预算；USER 压缩的 source coverage 则由 Host 逐项验证。
 
-## Web 边界
+## Web RPC 边界
 
 WebUI 不启动系统进程，也不直接打开 SQLite：
 

--- a/docs/zh-CN/configuration.md
+++ b/docs/zh-CN/configuration.md
@@ -77,6 +77,8 @@ Web 工作台查看：resolve(workspaceRegistry.get(selectedWorkspaceId).path, "
 
 每个 DSH 工作区拥有独立的三层记忆根。Agent、模型工具、命令和生命周期按当前会话的 cwd 路由，不受 Web 工作台查看目标影响。工作台只能从 Host 已登记的工作区中选择，不能提交任意路径；查看目标与会话实际目录不一致时，顶部会显示两条路径并提供“一键对齐当前会话”。需要 Agent 子任务的操作在未对齐时会被 Host 拒绝，避免写入错误项目。
 
+Headless 没有 `workspaceRegistry`；其新 session 的 cwd 就是启动 `dsh --profile headless ...` 的目录，因此 `workspace` 直接解析为 `<启动命令 cwd>/.mnemon`。
+
 ### `custom`
 
 ```yaml

--- a/docs/zh-CN/development.md
+++ b/docs/zh-CN/development.md
@@ -80,10 +80,11 @@ Host 将所有 package dependency 保持为 external。Client 将 React、ReactD
 - worker 工具隔离、schema 子集、结构化回执；
 - 生命周期 cue、评分、idle debounce、取消和水位保留；
 - RPC authority、只读行为和设置 revision；
-- Web 工作台、双语文案和关键交互。
+- Web 工作台、双语文案和关键交互；
+- 不依赖 Web 专有服务的核心激活，以及 Headless 按 Agent cwd 路由；
 - Client/Host 源码边界、确定性构建 hash、发布包内容、exports 和 TypeScript 解析。
 
-这些主要是临时目录、fake runner 和 mock Host 集成测试，不等同于自动化的真实 DSH + Mnemon WebUI E2E。
+这些主要是临时目录、fake runner 和 mock Host 集成测试。此外，`verify:headless` 会构建包、安装到隔离的真实 DSH Headless profile、启动本地模拟模型，并断言代表性 Mnemon 工具进入模型请求。真实 DSH + Mnemon WebUI 的自动化端到端测试仍是独立工作。
 
 ## 真实 WebUI 验证
 
@@ -175,6 +176,7 @@ Web locale 变更时，中文键集合仍是类型事实源；英文词典必须
 [ ] 确认 worktree 中没有生成的 lib diff
 [ ] 确认发布包只包含运行时、声明、根文档和 cordis.patch.yml
 [ ] install the built/local bundle into an isolated Web profile
+[ ] confirm `verify:headless` activates the built bundle in an isolated Headless profile
 [ ] run real Mnemon CLI and WebUI smoke tests
 [ ] verify Chinese and English workspaces
 [ ] verify global/workspace/custom paths as applicable

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -8,7 +8,7 @@
 
 你需要：
 
-- 一个可以启动的 DSH Web profile；
+- 一个可以启动的 DSH Web 或 Headless profile；
 - 本地可执行的 `mnemon` CLI；
 - 一个可用于隔离记忆任务的 DSH subagent Provider。
 
@@ -84,7 +84,7 @@ mnemon:
 
 ## 3. 安装 dsh-mnemon
 
-安装到 Web profile：
+需要完整工作台时安装到 Web profile：
 
 ```sh
 dsh plugin --profile web add dsh-mnemon
@@ -110,6 +110,17 @@ dsh plugin --profile web remove dsh-mnemon
 ```
 
 卸载只移除插件注册，不删除全局、工作区或自定义目录中的记忆数据。
+
+不同 profile 的插件清单彼此独立。一次性任务也需要记忆时，应另行安装到 Headless：
+
+```sh
+dsh plugin --profile headless add dsh-mnemon
+dsh --profile headless "回答前先检查持久化的项目上下文。"
+```
+
+开发检出时把包名替换为 `"link:/absolute/path/to/dsh-mnemon"`。Headless 会挂载与 Web Agent 相同的运行时上下文、档案、记忆体工具、生命周期提示和受监督写入路径，但不会挂载工作台、对话按钮、RPC 通道或交互式斜杠命令界面。
+
+`storageScope=workspace` 时，Headless 直接解析 `<启动命令 cwd>/.mnemon`，不需要 Web 工作区目录。一次性 runner 会在 Agent 进入 idle 后退出，因此尚未开始的评分后台审查会在关闭时取消；任务内已经完成的显式或模型引导写入仍会持久化。
 
 ## 4. 选择入口与存储位置
 

--- a/docs/zh-CN/interfaces.md
+++ b/docs/zh-CN/interfaces.md
@@ -1,4 +1,4 @@
-# WebUI、工具、命令与 RPC
+# Web、Headless、工具、命令与 RPC
 
 **简体中文** | [English](../en/interfaces.md) | [文档中心](./README.md)
 
@@ -16,6 +16,19 @@
 | 模型工具 | — | Root Agent 的结构化读写入口 |
 
 Sidebar 与 Buildin 实时互斥挂载，共享功能、数据和 Host 服务。对话内两个入口可在 `mnemon-ui` 设置中分别关闭。
+
+## Profile 能力面
+
+| 能力 | Web | Headless |
+|---|---:|---:|
+| 运行时上下文与生命周期提示 | 是 | 是 |
+| 模型工具与受监督子 Agent | 是 | 是 |
+| `workspace` 范围按 Agent cwd 路由 | 是 | 是 |
+| Sidebar / Buildin / 对话操作 | 是 | 否 |
+| Host 到客户端 RPC | 是 | 否 |
+| Agent idle 后的延迟评分审查 | Host 持续运行时执行 | 一次性进程退出时取消 |
+
+Headless 会获得完整模型工具面。它把命令行任务作为普通用户消息提交，不提供交互式斜杠命令分发；Agent 进入 idle 前已经完成的显式和模型引导写入会持久化。
 
 ## 模型工具
 
@@ -83,12 +96,14 @@ worker 内调用同名工具时直接进入服务层，不再递归委派。
 
 ## 工作区路由
 
-工作台请求携带 `sessionId` 和可选 `workspaceId`。Host 只接受 `workspaceRegistry` 已登记的 ID：
+Web 工作台请求携带 `sessionId` 和可选 `workspaceId`。Host 只接受 `workspaceRegistry` 已登记的 ID：
 
 - 确定性读取与人工维护可以路由到 `workspaceId` 选择的查看根；
 - Agent、工具、命令和生命周期仍按 `sessionId` 对应 Agent cwd 路由；
 - `status.workspaceContext` 返回 selected / effective roots 与 `aligned`；
 - 需要 Agent 的操作在未对齐时拒绝。
+
+Headless 等没有 Web 工作区目录的 profile 不提供任意查看目标；Agent 执行仍直接根据 session cwd 路由 `workspace` 范围。
 
 ## RPC 通道
 

--- a/docs/zh-CN/operations.md
+++ b/docs/zh-CN/operations.md
@@ -133,6 +133,7 @@ Test-Path "$env:LOCALAPPDATA\Programs\mnemon\mnemon.exe"
 | 现象 | 检查与处理 |
 |---|---|
 | Mnemon 不可用 | macOS/Linux 运行 `command -v mnemon`、`mnemon --version`；Windows PowerShell 运行 `Get-Command mnemon`、`Test-Path "$env:LOCALAPPDATA\Programs\mnemon\mnemon.exe"`。设置 `MNEMON_CLI_PATH` 或 `mnemon.cliPath` 后重启 |
+| Headless Agent 没有 Mnemon 工具 | 插件按 profile 独立安装；运行 `dsh plugin --profile headless add dsh-mnemon`，Web profile 的安装不会自动带入 |
 | 左侧栏没有“记忆系统” | 检查 `tabEnabled=true`、`displayMode=sidebar`；Buildin 位于对话区；本地 link 先 `pnpm run build` 再重启 profile |
 | 状态正常但召回为空 | 检查 active 记忆体、存储范围、查看目录、会话实际目录和查询是否足够聚焦 |
 | 顶部提示目录未对齐 | 工作台正在查看另一个工作区；点击一键对齐，或有意保留只读查看；Agent-backed 操作在未对齐时拒绝 |

--- a/docs/zh-CN/project-overview.md
+++ b/docs/zh-CN/project-overview.md
@@ -64,7 +64,7 @@
 
 ## 总体架构
 
-[![dsh-mnemon 运行时架构：DSH Web、Root Agent、监督控制层与三层本地存储](../assets/diagrams/zh-CN/project-architecture.svg)](../assets/diagrams/zh-CN/project-architecture.svg)
+[![dsh-mnemon 运行时架构：DSH Web 或 Headless、Root Agent、监督控制层与三层本地存储](../assets/diagrams/zh-CN/project-architecture.svg)](../assets/diagrams/zh-CN/project-architecture.svg)
 
 架构由四个边界组成：
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-mnemon",
   "version": "0.1.6",
-  "description": "Cross-agent, local-first persistent memory plugin for DeepSeek Harness (DSH), powered by Mnemon. It shares long-term memory across Mnemon-enabled agents and adds runtime memory, searchable project documents, semantic recall, knowledge graph, and a Sidebar UI.",
+  "description": "Cross-agent, local-first persistent memory plugin for DeepSeek Harness (DSH), powered by Mnemon. It supports Web and Headless profiles with runtime memory, searchable project documents, semantic recall, knowledge graph, and an optional Sidebar UI.",
   "keywords": [
     "deepseek-harness",
     "deepseek-harness-plugin",
@@ -35,6 +35,7 @@
     "typescript",
     "cordis",
     "web-ui",
+    "headless",
     "sidebar"
   ],
   "repository": {
@@ -97,8 +98,9 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "verify:build": "node scripts/verify-deterministic-build.mjs",
+    "verify:headless": "node scripts/verify-headless-profile.mjs",
     "verify:package": "node scripts/verify-package-contents.mjs && pnpm run lint:package",
-    "verify": "pnpm run typecheck && pnpm run test && pnpm run verify:build && pnpm run verify:package"
+    "verify": "pnpm run typecheck && pnpm run test && pnpm run verify:build && pnpm run verify:headless && pnpm run verify:package"
   },
   "dependencies": {
     "fflate": "^0.8.3",

--- a/scripts/verify-headless-profile.mjs
+++ b/scripts/verify-headless-profile.mjs
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process'
 import { createServer } from 'node:http'
 import { existsSync } from 'node:fs'
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -93,6 +93,26 @@ try {
 
   const install = await run(['plugin', '--profile', 'headless', 'add', `link:${root}`], { env })
   assertSuccess('installing dsh-mnemon into the Headless profile', install)
+
+  // The verification exercises Mnemon composition, not DSH's native PTY
+  // transport. Disable the unrelated shell stack so the check remains
+  // hermetic on CI Node/platform combinations without a node-pty prebuild.
+  await writeFile(join(dshHome, 'profiles', 'headless', 'cordis.patch.yml'), `
+- id: subprocess
+  disabled: true
+- id: bash-sandbox
+  disabled: true
+- id: pwsh-sandbox
+  disabled: true
+- id: tool-bash
+  disabled: true
+- id: tool-pwsh
+  disabled: true
+- id: permission
+  disabled: true
+- id: tool-fs-search
+  disabled: true
+`.trimStart())
 
   const execution = await run(['--profile', 'headless', 'Verify that the Mnemon tool surface is available.'], {
     cwd: workspaceRoot,

--- a/scripts/verify-headless-profile.mjs
+++ b/scripts/verify-headless-profile.mjs
@@ -1,0 +1,116 @@
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:http'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const dshBin = join(root, 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js')
+const marker = 'HEADLESS_MNEMON_READY'
+
+function run(args, { cwd = root, env = process.env, timeoutMs = 30_000 } = {}) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(process.execPath, [dshBin, ...args], {
+      cwd,
+      env,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8').on('data', chunk => { stdout += chunk })
+    child.stderr.setEncoding('utf8').on('data', chunk => { stderr += chunk })
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`dsh Headless verification timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    child.on('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.on('exit', (code, signal) => {
+      clearTimeout(timeout)
+      resolveRun({ code, signal, stdout, stderr })
+    })
+  })
+}
+
+function assertSuccess(label, result) {
+  if (result.code === 0) return
+  throw new Error([
+    `${label} failed with code ${String(result.code)}${result.signal === null ? '' : ` (${result.signal})`}`,
+    result.stdout.trim(),
+    result.stderr.trim(),
+  ].filter(Boolean).join('\n'))
+}
+
+const requests = []
+const server = createServer(async (request, response) => {
+  try {
+    let body = ''
+    request.setEncoding('utf8')
+    for await (const chunk of request) body += chunk
+    requests.push(JSON.parse(body))
+    response.writeHead(200, {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    })
+    const id = `chatcmpl-${requests.length}`
+    response.write(`data: ${JSON.stringify({ id, choices: [{ index: 0, delta: { role: 'assistant', content: marker }, finish_reason: null }] })}\n\n`)
+    response.write(`data: ${JSON.stringify({ id, choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] })}\n\n`)
+    response.write(`data: ${JSON.stringify({ id, choices: [], usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 } })}\n\n`)
+    response.end('data: [DONE]\n\n')
+  } catch (error) {
+    response.writeHead(500, { 'content-type': 'application/json' })
+    response.end(JSON.stringify({ error: { message: error instanceof Error ? error.message : String(error) } }))
+  }
+})
+
+const temporaryRoot = await mkdtemp(join(tmpdir(), 'dsh-mnemon-headless-'))
+const dshHome = join(temporaryRoot, 'dsh-home')
+const storageRoot = join(temporaryRoot, 'mnemon-data')
+const workspaceRoot = join(temporaryRoot, 'workspace')
+await Promise.all([mkdir(dshHome), mkdir(storageRoot), mkdir(workspaceRoot)])
+
+try {
+  await new Promise((resolveListen, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolveListen)
+  })
+  const address = server.address()
+  if (address === null || typeof address === 'string') throw new Error('mock DeepSeek server did not expose a TCP port')
+  const env = {
+    ...process.env,
+    DSH_HOME: dshHome,
+    DSH_TELEMETRY_DISABLED: '1',
+    DEEPSEEK_API_KEY: 'headless-verification-key',
+    DEEPSEEK_BASE_URL: `http://127.0.0.1:${address.port}`,
+    MNEMON_DATA_DIR: storageRoot,
+  }
+
+  const install = await run(['plugin', '--profile', 'headless', 'add', `link:${root}`], { env })
+  assertSuccess('installing dsh-mnemon into the Headless profile', install)
+
+  const execution = await run(['--profile', 'headless', 'Verify that the Mnemon tool surface is available.'], {
+    cwd: workspaceRoot,
+    env,
+  })
+  assertSuccess('running the Headless profile', execution)
+  if (!execution.stdout.includes(marker)) throw new Error(`Headless output did not contain ${marker}:\n${execution.stdout}`)
+
+  const toolRequest = requests.find(request => Array.isArray(request.tools) && request.tools.length > 0)
+  if (toolRequest === undefined) throw new Error('Headless model request did not expose any tools')
+  const toolNames = new Set(toolRequest.tools.map(tool => tool?.function?.name).filter(name => typeof name === 'string'))
+  const required = ['mnemon_status', 'mnemon_recall', 'mnemon_document_search', 'mnemon_runtime_memory', 'mnemon_remember']
+  const missing = required.filter(name => !toolNames.has(name))
+  if (missing.length > 0) throw new Error(`Headless model request is missing Mnemon tools: ${missing.join(', ')}`)
+  if (!existsSync(join(storageRoot, 'runtime', 'memories.json'))) throw new Error('Headless plugin did not initialize isolated runtime memory')
+
+  console.log(`Verified Headless profile activation with ${toolNames.size} total tools and ${required.length} representative Mnemon tools.`)
+} finally {
+  await new Promise(resolveClose => server.close(resolveClose))
+  await rm(temporaryRoot, { recursive: true, force: true })
+}

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -175,10 +175,12 @@ export interface HostContextShape {
   tools: { register(definition: ToolDefinition): unknown }
   commands: CommandService
   settings: HostSettingsService
-  connection: HostConnectionHandle
+  /** Web-only transport; absent from non-Web profiles such as Headless. */
+  connection?: HostConnectionHandle
   agents: HostAgentsService
   subagents: HostSubagentsService
-  workspaceRegistry: HostWorkspaceRegistry
+  /** Web workbench catalog; Agent execution routes by session cwd without it. */
+  workspaceRegistry?: HostWorkspaceRegistry
   get(name: string): unknown
   inject(services: string[], callback: (ctx: HostContextShape) => void): unknown
   on(name: string, listener: (...args: never[]) => unknown): () => unknown

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,23 @@ import { registerTools } from './tools.ts'
 import { StorageScopeInspector } from './storage-scope.ts'
 import { MnemonPackManager } from './pack.ts'
 import { VersionUpdateManager } from './version-updates.ts'
+import type { HostWorkspaceRegistry } from './contracts.ts'
 
 export const name = 'dsh-mnemon'
-export const inject = ['tools', 'settings', 'commands', 'agents', 'subagents', 'workspaceRegistry']
+// workspaceRegistry belongs to the Web profile. Core tools, lifecycle hooks,
+// and per-Agent cwd routing must also mount in profiles such as Headless.
+export const inject = ['tools', 'settings', 'commands', 'agents', 'subagents']
 export { Config, InteractionConfig, resolveConfig, resolveInteractionConfig, DocumentManager, LiveMnemonRuntime, MnemonLifecycle, MnemonService, MnemonSubagentCoordinator, RuntimeMemoryController, StorageScopeInspector, MnemonPackManager, VersionUpdateManager, createRunner, createRuntimeGraph }
 export type { MnemonConfig }
+
+/** Resolve the optional Web workspace service at call time, not plugin-mount time. */
+function optionalWorkspaceRegistry(ctx: HostContextShape): HostWorkspaceRegistry {
+  const current = (): HostWorkspaceRegistry | undefined => ctx.get('workspaceRegistry') as HostWorkspaceRegistry | undefined
+  return {
+    get: id => current()?.get(id),
+    list: () => current()?.list() ?? [],
+  }
+}
 
 /** Mount native model tools on every DSH surface and UI RPC only when Web connection exists. */
 export function apply(rawContext: unknown, config: MnemonConfig = {}): void {
@@ -33,7 +45,7 @@ export function apply(rawContext: unknown, config: MnemonConfig = {}): void {
     },
   })
   const initialSettings = settings.get()
-  const runtime = new LiveMnemonRuntime(prepared.get(initialSettings) ?? createRuntimeGraph(resolveConfig(initialSettings)), ctx.workspaceRegistry, ctx.agents)
+  const runtime = new LiveMnemonRuntime(prepared.get(initialSettings) ?? createRuntimeGraph(resolveConfig(initialSettings)), optionalWorkspaceRegistry(ctx), ctx.agents)
   const resolved = runtime.config
   ctx.on('settings/updated', ((namespace: string, next: Config) => {
     if (namespace !== 'mnemon') return
@@ -51,6 +63,9 @@ export function apply(rawContext: unknown, config: MnemonConfig = {}): void {
   registerGuidance(ctx, resolved)
   registerRuntimeMemoryContext(ctx, runtime.runtimeMemory)
   ctx.inject(['connection'], (webContext) => {
+    // `inject` guarantees the service at runtime; retain the defensive guard
+    // because HostContextShape also models profiles where it is absent.
+    if (webContext.connection === undefined) return
     registerRpc(webContext.connection, runtime, lifecycle)
     registerSettingsRpc(webContext.connection, ctx.settings)
   })

--- a/tests/lifecycle.spec.ts
+++ b/tests/lifecycle.spec.ts
@@ -162,6 +162,24 @@ describe('Mnemon DSH lifecycle integration', () => {
     expect(value.lifecycle.snapshot('session-1').current?.reviewActivity).toMatchObject({ score: 6, turnCount: 3 })
   })
 
+  it('cancels delayed review work when a one-shot Host disposes the plugin', async () => {
+    vi.useFakeTimers()
+    const value = fixture(resolveConfig({ idleReviewMs: 5_000 }))
+    await value.preStep([userMessage('x'.repeat(150))], 1)
+    value.events.push({ type: 'turn/end', data: { turn: 1 } })
+    await value.turnStopping(1)
+    await value.preStep([userMessage('threshold turn')], 2)
+    value.events.push({ type: 'turn/end', data: { turn: 2 } })
+    await value.turnStopping(2)
+    expect(value.lifecycle.snapshot('session-1').current?.idleReviewPending).toBe(true)
+
+    value.stop()
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(value.coordinator.review).not.toHaveBeenCalled()
+    expect(value.lifecycle.snapshot('session-1').activeAgents).toBe(0)
+  })
+
   it('counts completed tool results and unique tool names with QoderWork weights', async () => {
     vi.useFakeTimers()
     const value = fixture(resolveConfig({ idleReviewMs: 5_000 }))

--- a/tests/live-runtime.spec.ts
+++ b/tests/live-runtime.spec.ts
@@ -84,4 +84,27 @@ describe('LiveMnemonRuntime workspace routing', () => {
     expect(customRuntime.forAgent(sessionAgent)).toBe(customRuntime.snapshot())
     expect(customRuntime.route({ sessionId: 'session-1' })).toMatchObject({ selectedRoot: customRoot, effectiveRoot: customRoot, aligned: true })
   })
+
+  it('routes Headless workspace storage by Agent cwd without a Web workspace registry', () => {
+    const initialRoot = temporaryDirectory('headless-initial')
+    const workspace = temporaryDirectory('headless-workspace')
+    const sessionAgent = agent('headless-session', workspace)
+    const agents = {
+      get: (id: string) => id === sessionAgent.id ? sessionAgent : undefined,
+      roots: () => [sessionAgent],
+    } satisfies HostAgentsService
+    const runtime = new LiveMnemonRuntime(
+      createRuntimeGraph(resolveConfig({ storageScope: 'workspace', cliPath: '/fake/mnemon' }), initialRoot),
+      undefined,
+      agents,
+    )
+
+    expect(runtime.forAgent(sessionAgent).runner.effectiveDataDir()).toBe(join(workspace, '.mnemon'))
+    expect(runtime.route({ sessionId: sessionAgent.id })).toMatchObject({
+      selectedRoot: join(workspace, '.mnemon'),
+      effectiveRoot: join(workspace, '.mnemon'),
+      aligned: true,
+    })
+    expect(() => runtime.forWorkspaceId('web-only-selection')).toThrow('selected DSH workspace is unavailable')
+  })
 })

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -20,7 +20,7 @@ function dataDir(): string {
   return directory
 }
 
-function context() {
+function context(options: { connection?: boolean; workspaceRegistry?: boolean } = {}) {
   const tools: unknown[] = []
   const sections: unknown[] = []
   const channels: unknown[] = []
@@ -41,27 +41,66 @@ function context() {
         return { get: () => (args[2] as { base?: object } | undefined)?.base ?? {} }
       }),
     },
-    connection,
     agents: { get: vi.fn(), roots: vi.fn(() => []) },
-    workspaceRegistry: { get: vi.fn(), list: vi.fn(() => []) },
     subagents: {
       list: vi.fn(() => ['spawn']),
       getProvider: vi.fn(() => ({ capabilities: { outputSchema: true, depthLimit: true, toolFilter: true, persona: true } })),
       start: vi.fn(),
     },
-    get: vi.fn((name: string) => name === 'systemPrompt'
-      ? { section: (section: unknown) => { sections.push(section) } }
-      : undefined),
-    inject: vi.fn((_services: string[], callback: (value: unknown) => void) => { callback(ctx) }),
+    get: vi.fn((name: string) => {
+      if (name === 'systemPrompt') return { section: (section: unknown) => { sections.push(section) } }
+      if (name === 'workspaceRegistry' && 'workspaceRegistry' in ctx) return ctx.workspaceRegistry
+      return undefined
+    }),
+    inject: vi.fn((services: string[], callback: (value: unknown) => void) => {
+      if (services.includes('connection') && !('connection' in ctx)) return
+      callback(ctx)
+    }),
     on: vi.fn((...args: unknown[]) => { listeners.push(args); return () => {} }),
     effect: vi.fn((callback: () => unknown) => { callback(); return () => {} }),
   }
+  if (options.connection !== false) Object.assign(ctx, { connection })
+  if (options.workspaceRegistry !== false) Object.assign(ctx, { workspaceRegistry: { get: vi.fn(), list: vi.fn(() => []) } })
   return { ctx, tools, sections, channels, registrations, commands, listeners }
 }
 
 describe('dsh-mnemon plugin composition', () => {
-  it('requests the Host workspace registry for authorized per-workspace routing', () => {
-    expect(inject).toEqual(['tools', 'settings', 'commands', 'agents', 'subagents', 'workspaceRegistry'])
+  it('keeps Web-only workspace and connection services out of its core dependencies', () => {
+    expect(inject).toEqual(['tools', 'settings', 'commands', 'agents', 'subagents'])
+  })
+
+  it('mounts its complete Agent surface without Web-only Host services', () => {
+    const fixture = context({ connection: false, workspaceRegistry: false })
+    apply(fixture.ctx as never, { cliPath: '/fake/mnemon', dataDir: dataDir() })
+
+    expect(fixture.tools).toHaveLength(13)
+    expect(fixture.sections).toEqual([
+      expect.objectContaining({ name: 'mnemon:routing' }),
+      expect.objectContaining({ name: 'mnemon:runtime-memory' }),
+    ])
+    expect(fixture.commands).toEqual([expect.objectContaining({ name: 'mnemon' })])
+    expect(fixture.channels).toEqual([])
+  })
+
+  it('discovers a Web workspace registry that becomes available after core activation', async () => {
+    const fixture = context({ workspaceRegistry: false })
+    const workspace = dataDir()
+    apply(fixture.ctx as never, { cliPath: '/fake/mnemon', storageScope: 'workspace' })
+    Object.assign(fixture.ctx, {
+      workspaceRegistry: {
+        get: (id: string) => id === 'late-workspace' ? { id, title: 'Late Workspace', path: workspace } : undefined,
+        list: () => [{ id: 'late-workspace', title: 'Late Workspace', path: workspace }],
+      },
+    })
+
+    const readRegistration = fixture.channels.find(channel => (channel as unknown[])[0] === '/dsh-mnemon-read') as [
+      string,
+      (endpoint: string, payload: unknown) => Promise<{ ok: boolean; value?: { directory: string } }>,
+    ]
+    await expect(readRegistration[1]('runtime-memory', { workspaceId: 'late-workspace' })).resolves.toMatchObject({
+      ok: true,
+      value: { directory: join(workspace, '.mnemon', 'runtime') },
+    })
   })
 
   it('exports a DSH Web client with its ordering dependencies', () => {


### PR DESCRIPTION
## Summary

- mount Mnemon Agent tools, runtime context, lifecycle guidance, and cwd-based workspace routing without Web-only services
- discover the Web workspace registry lazily so existing workbench routing remains stable
- define one-shot shutdown semantics for delayed review and document Web/Headless capability boundaries in English and Chinese
- add an isolated real Headless-profile verification using a local mock model

## Verification

- `pnpm run verify`
- 206 tests passed, 1 Windows-only smoke test skipped
- deterministic double build passed
- real Headless profile activation exposed representative Mnemon tools
- package contents, publint, and type exports passed