### PR TITLE
fix: stop passing toolFilter for structured-output subagents (fixes #14)

### DIFF
--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -645,7 +645,18 @@ ${indentedText(request.content ?? '')}`
         ...(operation === 'migration' ? { agentOptions: { maxTokens: 16_384 } } : operation === 'compaction' || operation === 'document-archive' ? { agentOptions: { maxTokens: 8_192 } } : {}),
         outputSchema,
         maxDepth: 1,
-        toolFilter: { allow: tools },
+        // Structured-output children answer through the `structured_output`
+        // tool that DSH registers into the child's OWN tool layer, after
+        // `applyChildComposition` has already applied `toolFilter`. A
+        // `toolFilter.allow` mask matches the child's INHERITED (global +
+        // ancestor) tools only, so it does not admit `structured_output`, and
+        // on DSH 0.1.0-rc.6 the child then completes without a captured
+        // structured result — `readResult` forces `stopReason` to
+        // `"error"`, which surfaces as "memory subagent stopped with error"
+        // (see omdsh-dev/dsh-mnemon#14). Omit the filter so the
+        // structured-output instrumentation stays reachable; isolation for
+        // these judgment subagents is already enforced by the child's fixed
+        // delegation scope and persona.
         persona,
       })
       const result = await run.result


### PR DESCRIPTION
## Summary

Fixes #14 (`mnemon_recall` / `mnemon_remember` / `mnemon_related` / `mnemon_forget` … 报 `memory subagent stopped with error`)。

## Root cause

`MnemonSubagentCoordinator.delegate()` 启动结构化输出（structured-output）子代理时，同时传了 `toolFilter: { allow: tools }` 和 `outputSchema`。

DSH 的 `dsh-subagent-in-process-driver` 在 `startInProcessRun` 的 `setup` 里按以下顺序执行：

1. `applyChildComposition(childCtx, parent, { toolFilter })` → `tools.restrict({ allow: [...] })`
2. 之后才 `attachStructuredRuntime(childCtx, outputSchema)` → 往 child 的 **own** 工具层注册 `structured_output` 工具。

`structured_output` 是 child **自己层**注册的工具，不在 `restrict` 的 allow 白名单里（allow 只匹配 child 的 inherited = global + ancestor 工具）。在 DSH 0.1.0-rc.6 下，子代理完成推理后拿不到 `structured_output` 的捕获结果，于是 `readResult` 里这段逻辑把 `stopReason` 强制置为 `"error"`：

```js
if (structured !== void 0) {
  if (structured.captured !== void 0) return { output, structured: ..., stopReason };
  if (stopReason === "completed") return { output, stopReason: cancelled ? "aborted" : "error" };
}
```

最终 dsh-mnemon 收到 `stopReason: "error"`，抛出 `memory subagent stopped with error`。

## Fix

当这些判断子代理需要结构化输出（本函数所有调用点都传了 `outputSchema`）时，不再传 `toolFilter`，让 DSH 的结构化输出机制保持可达。

工具隔离改由两层既有机制承担：
- 子代理固定的 delegation scope（启动时锁定、不可从会话内放宽，见 `SUBAGENT_DELEGATION_CONTEXT`）
- 各 persona 的显式约束（如 `ANSWER_PERSONA` / `WRITE_PERSONA` 明确「不调用工具、不再委托」）

## Verification

- `pnpm run typecheck`（`tsc -p tsconfig.json --noEmit`）通过。
- `tsdown` 打包成功（`lib/index.js` 254KB），产物中 `toolFilter: { allow` 已无残留。
- 在 DSH 0.1.0-rc.6 独立实例（`dsh --profile web --port 3081`）上实测：standard preset 会话调用 `mnemon_recall(query="dsh 重启", limit=3)` 成功返回 3 条来自「dsh 运维与踩坑记录」空间（`5b5eb1a4`）的 insight（含 score/confidence/importance/entity 匹配），不再报 `memory subagent stopped with error`。

## Notes

这是一个**治标**修复：它让 dsh-mnemon 在 DSH 0.1.0-rc.6 下恢复可用，但代价是判断子代理失去了 `toolFilter` 的硬工具白名单（改由 delegation scope + persona 软约束）。**治本**修复应在 DSH 核心侧：`dsh-subagent` / `dsh-subagent-in-process-driver` 的 `tools.restrict()` 应豁免「child 自己层注册的 structured-output 机器工具」（其注释已声明这一意图：`That exemption is what a per-child capability filter has to keep intact`，但当前实现未兑现）。若上游 DSH 修复了 restrict 豁免，可再恢复 `toolFilter`。

关联：closes #14