### PR TITLE
fix: preserve prompt cache across runtime memory writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center"><strong>English</strong> · <a href="./README.zh-CN.md">简体中文</a></p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.4-5b5bd6" alt="release v0.2.4">
+  <img src="https://img.shields.io/badge/release-v0.2.5-5b5bd6" alt="release v0.2.5">
   <img src="https://img.shields.io/badge/memory-3%20tiers-087c5b" alt="three memory tiers">
   <img src="https://img.shields.io/badge/providers-9-c66a09" alt="nine providers">
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A520-43853d" alt="Node.js 20 or newer">
@@ -22,7 +22,7 @@
 <p align="center">
   <a href="./docs/en/capabilities.md"><strong>Explore the capability map</strong></a> ·
   <a href="./docs/en/getting-started.md">Start in five minutes</a> ·
-  <a href="./docs/en/releases/v0.2.4.md">Read the v0.2.4 notes</a> ·
+  <a href="./docs/en/releases/v0.2.5.md">Read the v0.2.5 notes</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">Watch the widescreen demo</a>
 </p>
 
@@ -190,7 +190,7 @@ See [Operations, security, and troubleshooting](./docs/en/operations.md) for bac
 | Configure scope, routing, and model selection | [Configuration](./docs/en/configuration.md) |
 | Back up, update, or troubleshoot | [Operations](./docs/en/operations.md) |
 | Integrate tools, commands, or RPC | [Interface reference](./docs/en/interfaces.md) |
-| Review the release | [v0.2.4 release notes](./docs/en/releases/v0.2.4.md) |
+| Review the release | [v0.2.5 release notes](./docs/en/releases/v0.2.5.md) |
 
 See the [documentation hub](./docs/en/README.md) for the full map.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 <p align="center"><a href="./README.md">English</a> · <strong>简体中文</strong></p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.4-5b5bd6" alt="发布版本 v0.2.4">
+  <img src="https://img.shields.io/badge/release-v0.2.5-5b5bd6" alt="发布版本 v0.2.5">
   <img src="https://img.shields.io/badge/%E8%AE%B0%E5%BF%86-3%20%E5%B1%82-087c5b" alt="三层记忆">
   <img src="https://img.shields.io/badge/Provider-9-c66a09" alt="九种 Provider">
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A520-43853d" alt="Node.js 20 或更新版本">
@@ -22,7 +22,7 @@
 <p align="center">
   <a href="./docs/zh-CN/capabilities.md"><strong>先看能力地图</strong></a> ·
   <a href="./docs/zh-CN/getting-started.md">5 分钟开始</a> ·
-  <a href="./docs/zh-CN/releases/v0.2.4.md">v0.2.4 升级说明</a> ·
+  <a href="./docs/zh-CN/releases/v0.2.5.md">v0.2.5 升级说明</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">观看宽屏实机演示</a>
 </p>
 
@@ -190,7 +190,7 @@ dsh plugin --profile headless add "link:/absolute/path/to/dsh-mnemon"
 | 配置范围、路由与模型 | [配置参考](./docs/zh-CN/configuration.md) |
 | 备份、更新或排障 | [运维指南](./docs/zh-CN/operations.md) |
 | 接入工具、命令或 RPC | [接口参考](./docs/zh-CN/interfaces.md) |
-| 查看本次升级 | [v0.2.4 发布说明](./docs/zh-CN/releases/v0.2.4.md) |
+| 查看本次升级 | [v0.2.5 发布说明](./docs/zh-CN/releases/v0.2.5.md) |
 
 完整目录见[文档中心](./docs/zh-CN/README.md)。
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -215,7 +215,7 @@ lifecycleEnabled=false
 
 routingGuidance=false
   -> removes only mnemon:routing
-  -> runtime-memory prompt section remains
+  -> runtime-memory context remains
 ```
 
 ## Display Mode and the `tabEnabled` UI Switch

--- a/docs/en/releases/v0.2.5.md
+++ b/docs/en/releases/v0.2.5.md
@@ -1,0 +1,28 @@
+# v0.2.5: Cache-Stable Runtime Memory
+
+[简体中文](../../zh-CN/releases/v0.2.5.md) | **English** | [Capability map](../capabilities.md)
+
+v0.2.5 projects Runtime Memory through DSH's native runtime-context snapshots. Updating `USER.md` or `MEMORY.md` no longer rewrites the system prompt and invalidates its reusable prefix.
+
+## Improved
+
+- Global and per-Agent `mnemon:runtime-memory` contributions now use `systemPrompt.context()` instead of a mutable system-prompt section.
+- DSH reevaluates Runtime Memory before each model step and appends a new user-role snapshot only when the projected context changes. The stable system prompt, tools, and preceding conversation remain cacheable.
+- Per-Agent workspace routing stays lazy, so writes made through `mnemon_runtime_memory` are visible on the next model step without rebuilding the system prompt.
+
+## Compatibility
+
+- Storage layout, schemas, and tool contracts are unchanged; no data migration is required.
+- Literal `{{...}}` text continues to bypass placeholder interpolation.
+- Runtime Memory now follows DSH's standard runtime-context configuration and suppression behavior.
+
+## Verification
+
+- The full verification suite covers system-prompt stability, runtime snapshot refreshes, literal brace handling, and Agent-scoped workspace routing.
+- Deterministic builds, headless checks, package checks, and CI on Ubuntu and Windows pass.
+
+## Upgrading
+
+Update dsh-mnemon and restart the affected DSH profile. Existing Runtime Memory data remains unchanged.
+
+See the [v0.2.4 release notes](./v0.2.4.md) for the previous patch release.

--- a/docs/en/workflows.md
+++ b/docs/en/workflows.md
@@ -4,10 +4,10 @@
 
 ## Per-Turn Context
 
-The plugin registers two system prompt sections:
+The plugin registers stable routing guidance and a dynamic runtime-context contribution:
 
-- `mnemon:routing`: when `routingGuidance=true`, provides concise boundaries for tiered queries;
-- `mnemon:runtime-memory`: reads the latest `USER.md` and `MEMORY.md` whenever a prompt is assembled and includes admission rules for saving content.
+- `mnemon:routing`: a system prompt section that, when `routingGuidance=true`, provides concise boundaries for tiered queries;
+- `mnemon:runtime-memory`: a DSH runtime-context snapshot that reads the latest `USER.md` and `MEMORY.md` whenever model input is assembled and includes admission rules for saving content. Changes are appended at the message tail instead of rewriting the stable system-prompt prefix.
 
 Lifecycle hooks do not unconditionally read the Memory Space catalog or run recall at the start of every turn:
 
@@ -286,5 +286,5 @@ conservative maintenance decision
 - `recallMode=off`: stops injecting recall cues; explicit `mnemon_recall` remains available.
 - `writebackMode=off`: disables writeback cues and scored background review; explicit writes are still governed by `writeEnabled`.
 - `lifecycleEnabled=false`: disables lifecycle reminders and review without removing explicit tools or Web entry points.
-- `routingGuidance=false`: removes only the additional routing section; the Runtime Memory section remains registered.
+- `routingGuidance=false`: removes only the additional routing section; the Runtime Memory context remains registered.
 - `writeEnabled=false`: removes semantic write tools and write RPC, and rejects write commands; it does not guarantee a read-only file-system mount.

--- a/docs/zh-CN/configuration.md
+++ b/docs/zh-CN/configuration.md
@@ -215,7 +215,7 @@ lifecycleEnabled=false
 
 routingGuidance=false
   -> removes only mnemon:routing
-  -> runtime-memory prompt section remains
+  -> runtime-memory context remains
 ```
 
 ## 展示形态与 `tabEnabled` 界面开关

--- a/docs/zh-CN/releases/v0.2.5.md
+++ b/docs/zh-CN/releases/v0.2.5.md
@@ -1,0 +1,28 @@
+# v0.2.5：缓存稳定的运行时记忆
+
+**简体中文** | [English](../../en/releases/v0.2.5.md) | [能力地图](../capabilities.md)
+
+v0.2.5 通过 DSH 原生 runtime context snapshot 投射运行时记忆。更新 `USER.md` 或 `MEMORY.md` 时，不再重写 system prompt，也不会使其可复用前缀失效。
+
+## 改进
+
+- 全局及 Agent 级 `mnemon:runtime-memory` 贡献改用 `systemPrompt.context()`，不再使用可变的 system prompt section。
+- DSH 会在每个模型步骤前重新计算运行时记忆，并且只在投射内容发生变化时追加新的 user-role snapshot；稳定的 system prompt、工具定义和之前的会话内容仍可缓存。
+- Agent 级工作区路由继续按需解析，因此通过 `mnemon_runtime_memory` 写入的内容会在下一个模型步骤可见，而无需重建 system prompt。
+
+## 兼容性
+
+- 存储布局、schema 和工具契约均未改变，无需迁移数据。
+- 字面量 `{{...}}` 文本仍会跳过占位符插值。
+- 运行时记忆现在遵循 DSH 标准的 runtime context 配置与抑制行为。
+
+## 验证
+
+- 完整验证套件覆盖 system prompt 稳定性、runtime snapshot 刷新、花括号字面量处理和 Agent 级工作区路由。
+- 确定性构建、headless 检查、包检查以及 Ubuntu、Windows CI 均通过。
+
+## 升级
+
+更新 dsh-mnemon 后重启对应 DSH profile。现有运行时记忆数据保持不变。
+
+上一个补丁版本见 [v0.2.4 发布说明](./v0.2.4.md)。

--- a/docs/zh-CN/workflows.md
+++ b/docs/zh-CN/workflows.md
@@ -4,10 +4,10 @@
 
 ## 每轮上下文
 
-插件注册两个 system prompt section：
+插件会注册稳定的路由指导和动态 runtime-context 贡献：
 
-- `mnemon:routing`：当 `routingGuidance=true` 时提供简短的分层查询边界；
-- `mnemon:runtime-memory`：每次组装 prompt 时读取最新 `USER.md` 和 `MEMORY.md`，并附带保存准入规则。
+- `mnemon:routing`：system prompt section；当 `routingGuidance=true` 时提供简短的分层查询边界；
+- `mnemon:runtime-memory`：DSH runtime-context snapshot；每次组装模型输入时读取最新 `USER.md` 和 `MEMORY.md`，并附带保存准入规则。内容变化时会追加到消息尾部，不再重写稳定的 system-prompt 前缀。
 
 生命周期 hook 不会在每轮开始无条件读取记忆体目录或执行 recall：
 
@@ -286,5 +286,5 @@ conservative maintenance decision
 - `recallMode=off`：不再注入 recall cue，显式 `mnemon_recall` 仍可用。
 - `writebackMode=off`：关闭写回 cue 和评分后台审查，显式写入仍由 `writeEnabled` 决定。
 - `lifecycleEnabled=false`：关闭生命周期提醒和审查，不移除显式工具或 Web 入口。
-- `routingGuidance=false`：只移除额外路由 section；Runtime Memory section 仍注册。
+- `routingGuidance=false`：只移除额外路由 section；Runtime Memory context 仍注册。
 - `writeEnabled=false`：移除语义写工具和写 RPC，拒绝写命令；它不是文件系统只读挂载保证。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mnemon",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Three-tier memory control plane for DeepSeek Harness: persistent runtime context, searchable project documents, pluggable long-term memory, smart routing, supervised agent workflows, WebUI, and headless tools.",
   "keywords": [
     "deepseek-harness",

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -3,13 +3,14 @@ import type { ResolvedConfig } from './config.ts'
 import type { RuntimeMemoryController } from './runtime-memory.ts'
 
 export const GUIDANCE_SECTION_NAME = 'mnemon:routing'
-export const RUNTIME_MEMORY_SECTION_NAME = 'mnemon:runtime-memory'
+export const RUNTIME_MEMORY_CONTEXT_NAME = 'mnemon:runtime-memory'
 export const ROUTING_GUIDANCE = 'Use memory only by need. For substantial project records, search active Mnemon Documents before deep recall. Call mnemon_recall when durable history may matter or an exact prior detail is missing; never infer a missing historical rule. New explicit reusable facts normally go to mnemon_runtime_memory. A write completes only with a tool receipt.'
 const RUNTIME_MEMORY_EMPTY_BRACES_VARIABLE = 'mnemon_runtime_memory_empty_braces'
 const LITERAL_EMPTY_BRACES = '{{}}'
 
 interface SystemPromptRegistry {
   section?: (value: { name: string; order: number; text: string | (() => string) }) => unknown
+  context?: (value: { name: string; order: number; text: string | (() => string) }) => unknown
   variable?: (name: string, provider: () => string) => unknown
 }
 
@@ -36,12 +37,12 @@ export function registerGuidance(ctx: HostContextShape, config?: Pick<ResolvedCo
   })
 }
 
-/** Inject the latest committed USER.md/MEMORY.md projections on every prompt assembly. */
+/** Project the latest committed USER.md/MEMORY.md as DSH's durable runtime-context snapshot. */
 export function registerRuntimeMemoryContext(ctx: HostContextShape, runtimeMemory: RuntimeMemoryController): void {
   const prompt = systemPrompt(ctx)
   prompt?.variable?.(RUNTIME_MEMORY_EMPTY_BRACES_VARIABLE, () => LITERAL_EMPTY_BRACES)
-  prompt?.section?.({
-    name: RUNTIME_MEMORY_SECTION_NAME,
+  prompt?.context?.({
+    name: RUNTIME_MEMORY_CONTEXT_NAME,
     order: 145,
     text: () => runtimeMemoryPromptText(runtimeMemory),
   })
@@ -49,8 +50,8 @@ export function registerRuntimeMemoryContext(ctx: HostContextShape, runtimeMemor
 
 /** Shadow the global fallback with the current Agent workspace's hot memory. */
 export function registerAgentRuntimeMemoryContext(agent: HostAgent, runtimeMemory: () => RuntimeMemoryController): () => void {
-  const dispose = scopedSystemPrompt(agent)?.section?.({
-    name: RUNTIME_MEMORY_SECTION_NAME,
+  const dispose = scopedSystemPrompt(agent)?.context?.({
+    name: RUNTIME_MEMORY_CONTEXT_NAME,
     order: 145,
     text: () => runtimeMemoryPromptText(runtimeMemory()),
   })

--- a/tests/guidance.spec.ts
+++ b/tests/guidance.spec.ts
@@ -1,60 +1,70 @@
 import { describe, expect, it, vi } from 'vitest'
-import { renderPrompt, type PromptAssembly } from '@deepseek-ai/dsh-system-prompt'
+import { renderContextSnapshot, renderPrompt, type PromptAssembly } from '@deepseek-ai/dsh-system-prompt'
 import type { HostAgent, HostContextShape } from '../src/contracts.ts'
-import { registerAgentRuntimeMemoryContext, registerRuntimeMemoryContext, RUNTIME_MEMORY_SECTION_NAME } from '../src/guidance.ts'
+import { registerAgentRuntimeMemoryContext, registerRuntimeMemoryContext, RUNTIME_MEMORY_CONTEXT_NAME } from '../src/guidance.ts'
 import type { RuntimeMemoryController } from '../src/runtime-memory.ts'
 
 describe('runtime memory prompt interpolation', () => {
-  it('preserves literal {{}} while leaving legal variables and other sections intact', () => {
-    const sections: Array<{ name: string; order: number; text: () => string }> = []
+  it('keeps the system prompt stable while runtime-memory snapshots change', () => {
+    const contexts: Array<{ name: string; order: number; text: () => string }> = []
     const variables = new Map<string, () => string>()
     const prompt = {
-      section: vi.fn((section: { name: string; order: number; text: () => string }) => { sections.push(section) }),
+      section: vi.fn(),
+      context: vi.fn((context: { name: string; order: number; text: () => string }) => { contexts.push(context) }),
       variable: vi.fn((name: string, provider: () => string) => { variables.set(name, provider) }),
     }
     const ctx = {
       get: vi.fn((name: string) => name === 'systemPrompt' ? prompt : undefined),
     } as unknown as HostContextShape
+    let memoryText = 'Remember the exact literal {{}} and the active model {{model}}.'
     const controller = {
-      contextText: vi.fn(() => 'Remember the exact literal {{}} and the active model {{model}}.'),
+      contextText: vi.fn(() => memoryText),
     } as unknown as RuntimeMemoryController
 
     registerRuntimeMemoryContext(ctx, controller)
-    const runtimeSection = sections.find(section => section.name === RUNTIME_MEMORY_SECTION_NAME)!
-    const assembly: PromptAssembly = {
-      sections: [
-        { name: 'other', text: 'Other section uses {{model}}.' },
-        { name: runtimeSection.name, text: runtimeSection.text() },
-      ],
-      contexts: [],
+    const runtimeContext = contexts.find(context => context.name === RUNTIME_MEMORY_CONTEXT_NAME)!
+    const assemble = (): PromptAssembly => ({
+      sections: [{ name: 'other', text: 'Other section uses {{model}}.' }],
+      contexts: [{ name: runtimeContext.name, text: runtimeContext.text() }],
       tools: [],
       variables: {
         model: 'deepseek',
         ...Object.fromEntries([...variables].map(([name, provider]) => [name, provider()])),
       },
-    }
+    })
 
-    expect(() => renderPrompt(assembly)).not.toThrow()
-    expect(renderPrompt(assembly)).toBe([
-      'Other section uses deepseek.',
+    const first = assemble()
+    expect(() => renderPrompt(first)).not.toThrow()
+    expect(renderPrompt(first)).toBe('Other section uses deepseek.')
+    expect(renderContextSnapshot(first)).toBe([
+      'Current runtime context. This snapshot supersedes earlier runtime-context snapshots.',
       'Remember the exact literal {{}} and the active model deepseek.',
     ].join('\n\n'))
+
+    memoryText = 'Updated workspace memory.'
+    const second = assemble()
+    expect(renderPrompt(second)).toBe(renderPrompt(first))
+    expect(renderContextSnapshot(second)).toBe([
+      'Current runtime context. This snapshot supersedes earlier runtime-context snapshots.',
+      'Updated workspace memory.',
+    ].join('\n\n'))
+    expect(prompt.section).not.toHaveBeenCalled()
   })
 })
 
 describe('agent-scoped runtime memory context', () => {
-  it('registers a same-named per-Agent prompt section that resolves the current workspace lazily', () => {
+  it('registers a same-named per-Agent runtime context that resolves the current workspace lazily', () => {
     const dispose = vi.fn()
-    const section = vi.fn((_value: { name: string; order: number; text: () => string }) => dispose)
+    const context = vi.fn((_value: { name: string; order: number; text: () => string }) => dispose)
     const agent = {
-      ctx: { get: vi.fn((name: string) => name === 'systemPrompt' ? { section } : undefined) },
+      ctx: { get: vi.fn((name: string) => name === 'systemPrompt' ? { context } : undefined) },
     } as unknown as HostAgent
     let text = 'workspace-one memory'
     const controller = { contextText: vi.fn(() => text) } as unknown as RuntimeMemoryController
 
     const stop = registerAgentRuntimeMemoryContext(agent, () => controller)
-    const registered = section.mock.calls[0]![0]
-    expect(registered).toMatchObject({ name: RUNTIME_MEMORY_SECTION_NAME, order: 145 })
+    const registered = context.mock.calls[0]![0]
+    expect(registered).toMatchObject({ name: RUNTIME_MEMORY_CONTEXT_NAME, order: 145 })
     expect(registered?.text()).toBe('workspace-one memory')
     text = 'workspace-two memory'
     expect(registered?.text()).toBe('workspace-two memory')

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -23,6 +23,7 @@ function dataDir(): string {
 function context(options: { connection?: boolean; workspaceRegistry?: boolean } = {}) {
   const tools: unknown[] = []
   const sections: unknown[] = []
+  const contexts: unknown[] = []
   const channels: unknown[] = []
   const connection = {
     rpc: {
@@ -48,7 +49,13 @@ function context(options: { connection?: boolean; workspaceRegistry?: boolean } 
       start: vi.fn(),
     },
     get: vi.fn((name: string) => {
-      if (name === 'systemPrompt') return { section: (section: unknown) => { sections.push(section) } }
+      if (name === 'systemPrompt') {
+        return {
+          section: (section: unknown) => { sections.push(section) },
+          context: (context: unknown) => { contexts.push(context) },
+          variable: vi.fn(),
+        }
+      }
       if (name === 'workspaceRegistry' && 'workspaceRegistry' in ctx) return ctx.workspaceRegistry
       return undefined
     }),
@@ -61,7 +68,7 @@ function context(options: { connection?: boolean; workspaceRegistry?: boolean } 
   }
   if (options.connection !== false) Object.assign(ctx, { connection })
   if (options.workspaceRegistry !== false) Object.assign(ctx, { workspaceRegistry: { get: vi.fn(), list: vi.fn(() => []) } })
-  return { ctx, tools, sections, channels, registrations, commands, listeners }
+  return { ctx, tools, sections, contexts, channels, registrations, commands, listeners }
 }
 
 describe('dsh-mnemon plugin composition', () => {
@@ -74,10 +81,8 @@ describe('dsh-mnemon plugin composition', () => {
     apply(fixture.ctx as never, { cliPath: '/fake/mnemon', dataDir: dataDir() })
 
     expect(fixture.tools).toHaveLength(13)
-    expect(fixture.sections).toEqual([
-      expect.objectContaining({ name: 'mnemon:routing' }),
-      expect.objectContaining({ name: 'mnemon:runtime-memory' }),
-    ])
+    expect(fixture.sections).toEqual([expect.objectContaining({ name: 'mnemon:routing' })])
+    expect(fixture.contexts).toEqual([expect.objectContaining({ name: 'mnemon:runtime-memory' })])
     expect(fixture.commands).toEqual([expect.objectContaining({ name: 'mnemon' })])
     expect(fixture.channels).toEqual([])
   })
@@ -138,8 +143,8 @@ describe('dsh-mnemon plugin composition', () => {
       expect.objectContaining({ output: expect.objectContaining({ schema: { type: 'object', additionalProperties: true } }) }),
     ]))
     expect(fixture.tools.every(tool => (tool as { output: { schema: { type: string } } }).output.schema.type !== 'json')).toBe(true)
-    expect(fixture.sections).toEqual([
-      expect.objectContaining({ name: 'mnemon:routing' }),
+    expect(fixture.sections).toEqual([expect.objectContaining({ name: 'mnemon:routing' })])
+    expect(fixture.contexts).toEqual([
       expect.objectContaining({ name: 'mnemon:runtime-memory', text: expect.any(Function) }),
     ])
     const guidance = (fixture.sections[0] as { text: () => string }).text()
@@ -189,7 +194,7 @@ describe('dsh-mnemon plugin composition', () => {
       expect.arrayContaining(['/dsh-mnemon-activation', expect.anything(), { authority: 'trusted-host' }]),
       expect.arrayContaining(['/dsh-mnemon-pack', expect.anything(), { authority: 'loopback' }]),
     ]))
-    expect(fixture.sections).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'mnemon:runtime-memory' })]))
+    expect(fixture.contexts).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'mnemon:runtime-memory' })]))
   })
 
   it('offers compact recent-document suggestions when a cross-language query has no exact match', async () => {
@@ -228,8 +233,8 @@ describe('dsh-mnemon plugin composition', () => {
     apply(fixture.ctx as never, { cliPath: '/fake/mnemon', dataDir: dataDir(), routingGuidance: false, tabEnabled: false })
     expect(fixture.sections).toEqual([
       expect.objectContaining({ name: 'mnemon:routing', text: expect.any(Function) }),
-      expect.objectContaining({ name: 'mnemon:runtime-memory' }),
     ])
+    expect(fixture.contexts).toEqual([expect.objectContaining({ name: 'mnemon:runtime-memory' })])
     expect((fixture.sections[0] as { text: () => string }).text()).toBe('')
     expect(fixture.channels).toHaveLength(5)
   })


### PR DESCRIPTION
## Summary

- project Runtime Memory through DSH's native `systemPrompt.context()` snapshot path instead of a mutable system-prompt section
- preserve literal `{{}}` interpolation and per-Agent workspace overrides
- document the cache-stable tail-snapshot behavior in English and Chinese

## Why

Runtime Memory writes changed the system prompt at the start of every request, invalidating the reusable prefix containing tools and conversation history. DSH runtime-context snapshots keep that prefix stable and append a new user-role snapshot only when the projection changes.

## Verification

- `pnpm run verify`
- 324 tests passed; 1 Windows-only test skipped on macOS
- deterministic build, Headless activation, and package checks passed

Closes #26