### PR TITLE
fix: refresh Memory Space cards over trusted read RPC

### DIFF
--- a/docs/en/interfaces.md
+++ b/docs/en/interfaces.md
@@ -122,7 +122,8 @@ authority: trusted-host
 | `versions` | Check installed/latest Mnemon and dsh-mnemon versions and installation sources |
 | `runtime-memory` | Runtime snapshot |
 | `documents` / `document` / `document-search` | Directory, body, and deterministic search |
-| `graph` / `bodies` | Active multi-space graph projection and provider-capability catalog |
+| `graph` / `bodies` / `body-directory` | Active multi-space graph projection, provider-capability catalog, and fast directory projection |
+| `body-reconnect` | Invalidate transient health state and refresh one Memory Space without changing persistent data |
 | `provider-services` | Redacted Provider service catalog; configured-secret names may be present, secret values never are |
 | `list` / `entities` | Durable content list and entity aggregation |
 | `search` / `agent-search` / `related` | Direct retrieval, evidence answer, and relation traversal |
@@ -155,6 +156,7 @@ authority: loopback (`trusted-host` when `remoteAccess=trusted-host`)
 | `document` | create / update / archive |
 | `remember` / `link` / `forget` | Durable semantic write, relation, and soft deletion |
 | `body-create` / `body-update` / `body-delete` | Create/connect, edit, or confirm Native deletion / remote disconnection |
+| `body-reconnect` | Legacy compatibility route for clients released before reconnect moved to the read channel |
 | `provider-services` / `provider-service-update` | Read private Provider settings for the local settings UI, or update one service |
 | `version-update` | Update a named component with Host-fixed commands and arguments |
 

--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -119,7 +119,7 @@ Recommended migration: export from the old scope → switch and confirm the new 
 
 - Read RPC and the activation-only Memory Space control are always `trusted-host`; broader write, settings, and backup RPC remain `loopback` unless local Host configuration explicitly sets `remoteAccess: trusted-host`.
 - The trusted-host read-side Provider catalog is redacted. Saved credential values are returned only through the management channel after its configured authority check succeeds.
-- The WebUI follows the Host's settings capability result instead of inferring authority from transport locality. An unavailable settings channel renders an explicit diagnostic rather than an empty page.
+- The WebUI follows the Host's settings capability result instead of inferring authority from transport locality. Activation and read-only card health refresh remain available through trusted-host channels; an unavailable settings channel renders an explicit diagnostic rather than an empty page.
 - The WebUI neither reads SQLite, starts processes, calls remote providers, nor supplies arbitrary update commands; provider network access remains inside the Host.
 - Workers use persona, tool allowlists, structured output, and `maxDepth: 1`.
 - Queries, candidates, Document bodies, and historical memory are treated as untrusted data.

--- a/docs/zh-CN/interfaces.md
+++ b/docs/zh-CN/interfaces.md
@@ -122,7 +122,8 @@ authority: trusted-host
 | `versions` | 检查 Mnemon 与 dsh-mnemon 当前 / 最新版本和安装来源 |
 | `runtime-memory` | 运行时快照 |
 | `documents` / `document` / `document-search` | 档案目录、正文与确定性搜索 |
-| `graph` / `bodies` | active 多空间图谱投影与含 Provider 能力的记忆体目录 |
+| `graph` / `bodies` / `body-directory` | active 多空间图谱投影、含 Provider 能力的记忆体目录与快速目录投影 |
+| `body-reconnect` | 清除短期健康状态并刷新单个记忆体，不修改持久数据 |
 | `provider-services` | 脱敏的 Provider 服务目录；可包含已配置的凭据字段名，绝不包含凭据值 |
 | `list` / `entities` | 内容列表与实体聚合 |
 | `search` / `agent-search` / `related` | 直接检索、证据回答与关系遍历 |
@@ -155,6 +156,7 @@ authority: loopback（`remoteAccess=trusted-host` 时为 trusted-host）
 | `document` | create / update / archive |
 | `remember` / `link` / `forget` | 长期语义写入、关系与软删除 |
 | `body-create` / `body-update` / `body-delete` | 记忆体创建/连接、编辑，以及确认后的 Native 删除或远程断开 |
+| `body-reconnect` | 为迁移到读通道前发布的旧客户端保留的兼容入口 |
 | `provider-services` / `provider-service-update` | 为本地设置 UI 读取 Provider 私密配置，或更新单个服务 |
 | `version-update` | 更新明确组件；Host 固定命令与参数 |
 

--- a/docs/zh-CN/operations.md
+++ b/docs/zh-CN/operations.md
@@ -119,7 +119,7 @@ Test-Path "$env:LOCALAPPDATA\Programs\mnemon\mnemon.exe"
 
 - 读 RPC 与仅含记忆体激活的控制通道始终为 `trusted-host`；更宽泛的写、设置与备份 RPC 默认仍为 `loopback`，只有 Host 本地配置显式设置 `remoteAccess: trusted-host` 才会提升。
 - trusted-host 读侧 Provider 目录始终脱敏；已保存凭据只会在管理通道通过已配置的权限检查后返回。
-- WebUI 依据 Host 返回的设置能力，不再根据传输是否 loopback 猜测权限；设置通道不可用时会显示明确诊断，而不是空白页。
+- WebUI 依据 Host 返回的设置能力，不再根据传输是否 loopback 猜测权限；激活与只读的单卡健康刷新仍通过 trusted-host 通道可用，设置通道不可用时会显示明确诊断，而不是空白页。
 - WebUI 不直接读取 SQLite、启动进程、调用远程 Provider 或指定任意更新命令；Provider 网络访问只发生在 Host。
 - worker 使用 persona、工具白名单、结构化输出与 `maxDepth: 1`。
 - 查询、候选、档案正文与历史记忆全部按不可信数据处理。

--- a/src/client/MnemonView.tsx
+++ b/src/client/MnemonView.tsx
@@ -1113,7 +1113,7 @@ function OverviewPage(props: { client: MnemonClient; metadataClient: MnemonClien
   }
 
   const reconnect = async (body: MemoryBodyView) => {
-    if (!props.writeEnabled || reconnectingBody !== null || editingBody !== null || deletingBody !== null) return
+    if (reconnectingBody !== null || editingBody !== null || deletingBody !== null) return
     setReconnectingBody(body.id); setError(null)
     setCatalog(current => current === null ? current : {
       ...current,
@@ -1318,7 +1318,7 @@ function OverviewPage(props: { client: MnemonClient; metadataClient: MnemonClien
         </div>
         <div className={css.bodyGrid}>
           {catalog?.items.map(body => (
-            <article key={body.id} className={css.bodyCard} data-provider={body.provider.id} data-active={body.active || undefined} data-healthy={!body.statusLoading && body.healthy || undefined} data-status-loading={body.statusLoading || undefined} data-reconnectable={props.writeEnabled || undefined} data-reconnecting={reconnectingBody === body.id || undefined} data-mnemon-default={body.mnemonDefault || undefined} data-editing={(appearance.surface === 'buildin' && editingBody === body.id) || undefined} tabIndex={props.writeEnabled ? 0 : undefined} aria-label={props.writeEnabled ? t('overview.reconnectAria', { name: body.name }) : undefined} title={reconnectingBody === body.id ? t('overview.reconnecting') : body.error ?? (props.writeEnabled ? t('overview.reconnectHint') : undefined)} onClick={event => {
+            <article key={body.id} className={css.bodyCard} data-provider={body.provider.id} data-active={body.active || undefined} data-healthy={!body.statusLoading && body.healthy || undefined} data-status-loading={body.statusLoading || undefined} data-reconnectable="" data-reconnecting={reconnectingBody === body.id || undefined} data-mnemon-default={body.mnemonDefault || undefined} data-editing={(appearance.surface === 'buildin' && editingBody === body.id) || undefined} tabIndex={0} aria-label={t('overview.reconnectAria', { name: body.name })} title={reconnectingBody === body.id ? t('overview.reconnecting') : body.error ?? t('overview.reconnectHint')} onClick={event => {
               if (event.target instanceof Element && event.target.closest('button, input, textarea, select, label, a, [role="switch"]') !== null) return
               void reconnect(body)
             }} onKeyDown={event => {

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -275,7 +275,7 @@ export class MnemonClient {
   }
 
   reconnectBody(memoryBodyId: string): Promise<MemoryBodyView> {
-    return this.call(MNEMON_WRITE_CHANNEL, 'body-reconnect', this.scoped({ memoryBodyId }))
+    return this.call(MNEMON_READ_CHANNEL, 'body-reconnect', this.scoped({ memoryBodyId }))
   }
 
   maintainBodyMetadata(memoryBodyIds: string[]): Promise<MemoryBodyMetadataMaintenanceResult> {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -225,6 +225,8 @@ export function createReadHandler(input: RuntimeInput, lifecycle?: MnemonLifecyc
           return success(await service.bodies())
         case 'body-directory':
           return success(service.bodyDirectory())
+        case 'body-reconnect':
+          return success(await service.reconnectBody(String(payload.memoryBodyId ?? '')))
         case 'provider-services':
           return success(service.memoryBodies.providerServices())
         case 'list':
@@ -549,6 +551,8 @@ export function createWriteHandler(input: RuntimeInput, lifecycle?: MnemonLifecy
             service.updateBodyMetadata(maintained.updates)
             return success(maintained)
           }
+        // Compatibility route for clients released before card reconnect was
+        // correctly classified as a trusted-host read operation.
         case 'body-reconnect':
           return success(await service.reconnectBody(String(payload.memoryBodyId ?? '')))
         case 'body-delete':

--- a/src/service.ts
+++ b/src/service.ts
@@ -469,7 +469,6 @@ export class MnemonService {
   }
 
   async reconnectBody(id: string, signal?: AbortSignal): Promise<MemoryBodyView> {
-    this.assertWritable()
     const body = this.memoryBodies.list().find(candidate => candidate.id === id)
     if (body === undefined) throw new Error(`unknown memory body: ${id}`)
     if (body.provider.id !== 'mnemon-native') {

--- a/tests/client-api.spec.ts
+++ b/tests/client-api.spec.ts
@@ -121,13 +121,13 @@ describe('MnemonClient turn activity batching', () => {
     expect(call).toHaveBeenCalledWith(expect.any(String), 'task-agent-models', {})
   })
 
-  it('routes a card-level Memory Space reconnect with the active scope', async () => {
+  it('routes a card-level Memory Space reconnect through the trusted-host read channel with the active scope', async () => {
     const call = vi.fn(async () => ({ ok: true as const, value: { id: 'mem0-body', healthy: true } }))
     const client = new MnemonClient({ rpc: { call } } as ClientConnectionHandle, 'session-1', 'workspace-1')
 
     await client.reconnectBody('mem0-body')
 
-    expect(call).toHaveBeenCalledWith(expect.any(String), 'body-reconnect', {
+    expect(call).toHaveBeenCalledWith('/dsh-mnemon-read', 'body-reconnect', {
       memoryBodyId: 'mem0-body', sessionId: 'session-1', workspaceId: 'workspace-1',
     })
   })

--- a/tests/client.spec.tsx
+++ b/tests/client.spec.tsx
@@ -458,6 +458,9 @@ describe('MnemonView', () => {
     expect((screen.getByRole('button', { name: '编辑项目记忆体' }) as HTMLButtonElement).disabled).toBe(true)
     expect((screen.getByRole('button', { name: '删除项目记忆体' }) as HTMLButtonElement).disabled).toBe(true)
 
+    fireEvent.click(screen.getByRole('article', { name: '重新连接项目记忆体' }))
+    await waitFor(() => expect(call).toHaveBeenCalledWith('/dsh-mnemon-read', 'body-reconnect', { memoryBodyId: 'project', sessionId: 'session-1' }))
+
     const toggle = screen.getByRole('switch', { name: '偏好记忆体读取开关' }) as HTMLButtonElement
     expect(toggle.disabled).toBe(false)
     fireEvent.click(toggle)

--- a/tests/rpc.spec.ts
+++ b/tests/rpc.spec.ts
@@ -63,6 +63,7 @@ describe('Mnemon RPC', () => {
     await expect(createReadHandler(service)('graph', {})).resolves.toMatchObject({ ok: true, value: { nodes: [] } })
     await expect(createReadHandler(service)('bodies', {})).resolves.toMatchObject({ ok: true, value: { items: [], total: 0 } })
     await expect(createReadHandler(service)('body-directory', {})).resolves.toMatchObject({ ok: true, value: { total: 1 } })
+    await expect(createReadHandler(service)('body-reconnect', { memoryBodyId: 'project' })).resolves.toMatchObject({ ok: true, value: { id: 'project', healthy: true } })
     await expect(createReadHandler(service)('status-summary', {})).resolves.toMatchObject({ ok: true, value: { healthy: true } })
     await expect(createReadHandler(service)('provider-services', {})).resolves.toMatchObject({ ok: true, value: { items: [] } })
     await expect(createReadHandler(service)('list', { category: 'decision' })).resolves.toMatchObject({ ok: true, value: { total: 0 } })
@@ -71,6 +72,7 @@ describe('Mnemon RPC', () => {
       ok: false,
       error: { code: 'bad-request', message: 'unknown read endpoint: nope', details: { issues: [] } },
     })
+    expect(service.reconnectBody).toHaveBeenCalledWith('project')
   })
 
   it('keeps Provider secret values on the loopback channel while preserving a redacted trusted-host catalog', async () => {
@@ -183,7 +185,7 @@ describe('Mnemon RPC', () => {
     expect(service.updateBody).not.toHaveBeenCalled()
   })
 
-  it('reconnects one Memory Space through the loopback write channel', async () => {
+  it('keeps the legacy loopback reconnect route for older clients', async () => {
     const service = fakeService()
     await expect(createWriteHandler(service)('body-reconnect', { memoryBodyId: 'project' })).resolves.toMatchObject({ ok: true, value: { id: 'project', healthy: true } })
     expect(service.reconnectBody).toHaveBeenCalledWith('project')

--- a/tests/service.spec.ts
+++ b/tests/service.spec.ts
@@ -30,7 +30,7 @@ function populatedDataDir(): string {
   return dataDir
 }
 
-function fixture(): { service: MnemonService; process: ReturnType<typeof vi.fn<ProcessRunner>>; dataDir: string } {
+function fixture(writeEnabled = true): { service: MnemonService; process: ReturnType<typeof vi.fn<ProcessRunner>>; dataDir: string } {
   const process = vi.fn<ProcessRunner>(async (_command, args) => {
     if (args.includes('--version')) return { stdout: 'mnemon version 0.1.2\n', stderr: '', exitCode: 0 }
     if (args.includes('status')) return {
@@ -69,6 +69,7 @@ function fixture(): { service: MnemonService; process: ReturnType<typeof vi.fn<P
     store: 'work',
     timeoutMs: 4321,
     defaultRecallLimit: 7,
+    writeEnabled,
   })
   const runner = createRunner(config, process)
   return { service: new MnemonService(runner, config, new MemoryBodyRegistry(runner, true)), process, dataDir }
@@ -232,6 +233,12 @@ describe('MnemonService', () => {
     expect(provider.discover).toHaveBeenCalledOnce()
     expect(provider.status).toHaveBeenCalledOnce()
     expect(provider.status).toHaveBeenCalledWith(expect.objectContaining({ id: body.id, provider: expect.objectContaining({ settings: expect.objectContaining({ bankId: 'bank-1' }) }) }), undefined)
+  })
+
+  it('refreshes one Memory Space health status in read-only mode', async () => {
+    const { service } = fixture(false)
+
+    await expect(service.reconnectBody('work')).resolves.toMatchObject({ id: 'work', healthy: true })
   })
 
   it('keeps the previous provider projection untouched when reconnect discovery fails', async () => {


### PR DESCRIPTION
## Summary

- route card-level Memory Space reconnects through the trusted-host read channel
- allow the read-only health refresh in remote and read-only WebUI sessions
- retain the previous loopback write endpoint as an older-client compatibility route
- document the corrected RPC boundary in English and Chinese

## Root cause

The overview full sync used the trusted-host read channel, but clicking a Memory Space card sent the status refresh to the loopback-only write channel. Non-loopback WebUI connections therefore surfaced a transport-level `Failed to fetch` even though the full sync succeeded. The operation only invalidates transient health cache state and reads one Provider status; it does not mutate persistent data.

## Verification

- `pnpm run verify`
- 319 tests passed; 1 conditional Windows smoke test skipped
- deterministic build, Headless profile, package contents, publint, and package type checks passed