### PR TITLE
fix: converge reliability and UI interaction debt

### DIFF
--- a/docs/en/roadmap.md
+++ b/docs/en/roadmap.md
@@ -21,6 +21,8 @@ The Roadmap records work beyond the current implementation; it is not a commitme
 - [ ] **Repair and rebuild tools**: detect damaged JSON, missing projections, orphaned Documents, missing databases, and registry/disk inconsistencies.
 - [ ] **Schema migration**: add explicit upgrade and rollback strategies for Runtime, the Documents index, and the Memory Space registry.
 - [ ] **Compatibility matrix**: document and automatically test supported combinations of DSH, the Mnemon CLI, Node, and data formats.
+- [ ] **Cordis / DSH capability contract tests**: add host-integration coverage for service injection, hot reload and disposal, and late-registered tools; in particular, verify that structured-output tools remain available inside a subagent scope when `toolFilter` isolation is enabled, using [issue #14](https://github.com/omdsh-dev/dsh-mnemon/issues/14) / [PR #17](https://github.com/omdsh-dev/dsh-mnemon/pull/17) as the regression scenario. Preserve least-privilege tool access instead of removing the filter without a host contract.
+- [ ] **Explicit host capability declarations**: have Cordis / DSH authoritatively expose writability, trusted control-plane access, directory selection, and structured-output support, gradually replacing plugin-side permission inference from loopback state, service names, or transport location.
 - [ ] **Explicit Documents workspace ownership**: record the source workspace under shared storage scopes or provide a configurable isolation strategy.
 
 ## P2: Observability, Experience, and Release Engineering
@@ -29,6 +31,7 @@ The Roadmap records work beyond the current implementation; it is not a commitme
 - [ ] **Switch to DSH's shared directory picker** (blocked on [dsh-external/issues#603](https://github.com/dsh-external/issues/issues/603)): custom storage temporarily uses a manually entered Host path because remote `browse` deployments cannot invoke the `native` picker; once DSH exposes a reusable directory-picker service for plugins, move to the provider-selected native / browse flow and retain manual entry only as a fallback if needed.
 - [ ] **Complete internationalization**: cover commands, tool cards, Host errors, compatibility default metadata, and confirmation copy.
 - [ ] **Multi-Memory-Space E2E**: cover automatic space creation, cross-space recall, one-pass migration routing, multiple relationship types, merge, and controlled forget.
+- [ ] **URL-subpath deployment matrix**: add real reverse-proxy E2E for the DSH shell, static assets, plugin assets, RPC/API, and WebSocket under `/prefix/`; keep the dsh-mnemon client transport-neutral through the host `connection`, while the host supplies one coherent base URL so root-relative assets cannot leave the deployment half functional.
 - [ ] **Capacity and fault injection**: exercise real USER/MEMORY boundaries, Document LRU, revision conflicts, CLI timeouts, and mid-operation Host restarts.
 - [ ] **Documentation consistency checks**: add relative links, external links, bilingual file mirroring, configuration-key matching, and code-block matching to CI.
 - [ ] **Release completion**: establish stable versions, a changelog, upgrade/uninstall/data-retention guides, artifact checksums, and a minimum-support policy.

--- a/docs/zh-CN/roadmap.md
+++ b/docs/zh-CN/roadmap.md
@@ -21,6 +21,8 @@ Roadmap 记录当前实现之外的工作，不是已交付能力承诺。优先
 - [ ] **修复与重建工具**：检测损坏 JSON、缺失投影、孤儿 Document、缺失 DB 和 registry/磁盘不一致。
 - [ ] **schema migration**：为 Runtime、Documents index 和 Memory Space registry 增加显式升级与回滚策略。
 - [ ] **兼容矩阵**：记录并自动测试支持的 DSH、Mnemon CLI、Node 和数据格式组合。
+- [ ] **Cordis / DSH 能力契约测试**：围绕服务注入、热重载与 dispose、延迟注册工具建立宿主集成测试；特别验证结构化输出工具不会因 `toolFilter` 隔离而从子 Agent 作用域消失，并以 [issue #14](https://github.com/omdsh-dev/dsh-mnemon/issues/14) / [PR #17](https://github.com/omdsh-dev/dsh-mnemon/pull/17) 作为回归场景。插件仍保留最小工具权限，不在缺乏宿主契约时通过移除过滤来规避。
+- [ ] **显式宿主能力声明**：由 Cordis / DSH 提供可写性、受信任控制面、目录选择和结构化输出等权威能力，逐步替代插件根据 loopback、服务名或传输位置推断权限的做法。
 - [ ] **明确 Documents workspace ownership**：在共享 storage scope 中记录来源工作区或提供可配置隔离策略。
 
 ## P2：可观测性、体验与发布工程
@@ -29,6 +31,7 @@ Roadmap 记录当前实现之外的工作，不是已交付能力承诺。优先
 - [ ] **切换到 DSH 通用目录选择器**（等待 [dsh-external/issues#603](https://github.com/dsh-external/issues/issues/603)）：当前自定义存储暂用手动填写 Host 路径，以避开远端 `browse` 部署无法调用 `native` picker 的问题；DSH 暴露插件可复用的 directory-picker 服务后，改用由能力提供方统一选择 native / browse 的流程，并仅在必要时保留手动输入作为兜底。
 - [ ] **完整国际化**：覆盖命令、工具卡、Host 错误、兼容默认元数据和确认文案。
 - [ ] **多记忆体 E2E**：覆盖自动建空间、跨空间召回、一次迁移分流、多种边、合并和受控 forget。
+- [ ] **URL 子路径部署矩阵**：为 `/prefix/` 下的 DSH 外壳、静态资源、插件资源、RPC/API 和 WebSocket 建立真实反代 E2E；dsh-mnemon 客户端继续只通过宿主 `connection` 通信，宿主则需提供统一 base URL，避免根路径资源导致“页面可开、插件请求失败”的半可用状态。
 - [ ] **容量与故障注入**：真实触发 USER/MEMORY 边界、Document LRU、revision 冲突、CLI 超时和 Host 中途重启。
 - [ ] **文档一致性检查**：相对链接、外链、双语文件镜像、配置键和代码块一致性进入 CI。
 - [ ] **发布收口**：稳定版本号、变更日志、升级/卸载/数据保留指南、artifact 校验和最小支持策略。

--- a/src/client/MnemonView.tsx
+++ b/src/client/MnemonView.tsx
@@ -45,6 +45,7 @@ import { MnemonClient } from './api.ts'
 import { translateZh, type MnemonKey, type MnemonTranslate } from './locales.ts'
 import { MnemonLogo } from './MnemonLogo.tsx'
 import { ProviderIcon } from './ProviderIcon.tsx'
+import { useRequestVersion } from './use-request-version.ts'
 import {
   appearanceClass,
   MnemonViewAppearanceProvider,
@@ -1950,8 +1951,10 @@ function DocumentsPage(props: { client: MnemonClient; revision: number; writeEna
   const [description, setDescription] = useState('')
   const [content, setContent] = useState('')
   const [sources, setSources] = useState('')
+  const displayRequests = useRequestVersion()
 
   const display = useCallback(async (nextQuery: string, nextStatus: 'active' | 'archived') => {
+    const request = displayRequests.begin()
     setLoading(true); setError(null); setVisibleLimit(pageSize)
     try {
       const current = await props.client.documents()
@@ -1959,15 +1962,17 @@ function DocumentsPage(props: { client: MnemonClient; revision: number; writeEna
         ? current.documents
         : (await props.client.searchDocuments(nextQuery, nextStatus === 'archived')).results
       const filtered = records.filter(record => record.status === nextStatus)
+      if (!displayRequests.isCurrent(request)) return
       setSnapshot(current)
       setItems(filtered)
       setSelectedId(previous => previous !== null && filtered.some(record => record.id === previous) ? previous : filtered[0]?.id ?? null)
     } catch (reason) {
+      if (!displayRequests.isCurrent(request)) return
       setError(message(reason)); setSnapshot(null); setItems([]); setSelectedId(null)
     } finally {
-      setLoading(false)
+      if (displayRequests.isCurrent(request)) setLoading(false)
     }
-  }, [pageSize, props.client])
+  }, [displayRequests, pageSize, props.client])
 
   useEffect(() => { void display(query, status) }, [display, props.revision, status])
   useEffect(() => {

--- a/src/client/MnemonView.tsx
+++ b/src/client/MnemonView.tsx
@@ -1413,11 +1413,13 @@ function ExplorePage(props: { client: MnemonClient; agentClient: MnemonClient; a
   const [relatedLoading, setRelatedLoading] = useState(false)
   const [visibleResultLimit, setVisibleResultLimit] = useState(pageSize)
   const [visibleRelatedLimit, setVisibleRelatedLimit] = useState(pageSize)
+  const relatedRequests = useRequestVersion()
 
   useEffect(() => { if (props.seed !== '') setQuery(props.seed) }, [props.seed])
 
   const runSearch = async (withAgent: boolean) => {
     if (query.trim() === '') return
+    relatedRequests.begin()
     setSearchKind(withAgent ? 'agent' : 'direct'); setSearched(true); setError(null); setRelatedTo(null); setAgentAnswer(null); setVisibleResultLimit(pageSize); setVisibleRelatedLimit(pageSize)
     try {
       const request = { query, mode, ...(category === '' ? {} : { category }), limit: props.status?.defaultRecallLimit ?? 10 }
@@ -1442,9 +1444,17 @@ function ExplorePage(props: { client: MnemonClient; agentClient: MnemonClient; a
   const searching = searchKind !== null
 
   const showRelated = async (insight: Insight) => {
+    const request = relatedRequests.begin()
     setRelatedTo(insight); setRelated([]); setRelatedLoading(true); setError(null); setVisibleRelatedLimit(pageSize)
-    if (typeof window.requestAnimationFrame === 'function') window.requestAnimationFrame(() => document.getElementById('mnemon-related-pane')?.scrollIntoView({ block: 'nearest', behavior: 'smooth' }))
-    try { setRelated(await props.client.related(insight.id, insight.memoryBodyId)) } catch (reason) { setError(message(reason)) } finally { setRelatedLoading(false) }
+    if (typeof window.requestAnimationFrame === 'function') window.requestAnimationFrame(() => document.getElementById('mnemon-related-pane')?.scrollIntoView?.({ block: 'nearest', behavior: 'smooth' }))
+    try {
+      const response = await props.client.related(insight.id, insight.memoryBodyId)
+      if (relatedRequests.isCurrent(request)) setRelated(response)
+    } catch (reason) {
+      if (relatedRequests.isCurrent(request)) setError(message(reason))
+    } finally {
+      if (relatedRequests.isCurrent(request)) setRelatedLoading(false)
+    }
   }
 
   const forget = async (insight: Insight) => {
@@ -1477,7 +1487,7 @@ function ExplorePage(props: { client: MnemonClient; agentClient: MnemonClient; a
       {results.length > 0 && (
         <div className={relatedTo === null ? css.singleColumn : css.resultLayout}>
           <section className={css.results}><div className={css.sectionHeading}><div><h3>{t('search.results')}</h3></div><strong>{results.length}</strong></div>{visibleResults.map(insight => <InsightCard key={insightKey(insight)} insight={insight} writeEnabled={props.writeEnabled} onForget={forget} onRelated={item => void showRelated(item)} />)}{appearance.surface === 'sidebar' && <ProgressiveFooter visible={visibleResults.length} total={results.length} pageSize={pageSize} onMore={() => setVisibleResultLimit(value => value + pageSize)} />}</section>
-          {relatedTo !== null && <aside id="mnemon-related-pane" className={css.relatedPane}><div className={css.sectionHeading}><div><h3>{t('search.related')}</h3></div><button type="button" onClick={() => setRelatedTo(null)} aria-label={t('search.closeRelated')}>×</button></div><p className={css.relatedSource}>{relatedTo.content}</p>{relatedLoading && <div className={css.loading}>{t('search.traversing')}</div>}{!relatedLoading && related.length === 0 && <div className={css.muted}>{t('search.noRelated')}</div>}{visibleRelated.map(insight => <InsightCard key={insightKey(insight)} insight={insight} writeEnabled={props.writeEnabled} onForget={forget} onRelated={item => void showRelated(item)} />)}{appearance.surface === 'sidebar' && !relatedLoading && <ProgressiveFooter visible={visibleRelated.length} total={related.length} pageSize={pageSize} onMore={() => setVisibleRelatedLimit(value => value + pageSize)} />}</aside>}
+          {relatedTo !== null && <aside id="mnemon-related-pane" className={css.relatedPane}><div className={css.sectionHeading}><div><h3>{t('search.related')}</h3></div><button type="button" onClick={() => { relatedRequests.begin(); setRelatedTo(null); setRelatedLoading(false) }} aria-label={t('search.closeRelated')}>×</button></div><p className={css.relatedSource}>{relatedTo.content}</p>{relatedLoading && <div className={css.loading}>{t('search.traversing')}</div>}{!relatedLoading && related.length === 0 && <div className={css.muted}>{t('search.noRelated')}</div>}{visibleRelated.map(insight => <InsightCard key={insightKey(insight)} insight={insight} writeEnabled={props.writeEnabled} onForget={forget} onRelated={item => void showRelated(item)} />)}{appearance.surface === 'sidebar' && !relatedLoading && <ProgressiveFooter visible={visibleRelated.length} total={related.length} pageSize={pageSize} onMore={() => setVisibleRelatedLimit(value => value + pageSize)} />}</aside>}
         </div>
       )}
       </div>
@@ -1496,12 +1506,21 @@ function EntitiesPage(props: { client: MnemonClient; revision: number; writeEnab
   const [error, setError] = useState<string | null>(null)
   const [visibleEntityLimit, setVisibleEntityLimit] = useState(entityPageSize)
   const [visibleInsightLimit, setVisibleInsightLimit] = useState(insightPageSize)
+  const entityRequests = useRequestVersion()
 
   const load = useCallback(async (selected?: string) => {
+    const request = entityRequests.begin()
     setLoading(true); setError(null); setVisibleInsightLimit(insightPageSize)
     if (selected === undefined) setVisibleEntityLimit(entityPageSize)
-    try { setView(await props.client.entities(selected, 20)) } catch (reason) { setError(message(reason)) } finally { setLoading(false) }
-  }, [entityPageSize, insightPageSize, props.client])
+    try {
+      const response = await props.client.entities(selected, 20)
+      if (entityRequests.isCurrent(request)) setView(response)
+    } catch (reason) {
+      if (entityRequests.isCurrent(request)) setError(message(reason))
+    } finally {
+      if (entityRequests.isCurrent(request)) setLoading(false)
+    }
+  }, [entityPageSize, entityRequests, insightPageSize, props.client])
 
   useEffect(() => { void load() }, [load, props.revision])
   const submit = (event: FormEvent) => { event.preventDefault(); if (entity.trim() !== '') void load(entity) }

--- a/src/client/ProviderSettingsSection.tsx
+++ b/src/client/ProviderSettingsSection.tsx
@@ -10,6 +10,7 @@ import type {
 import { MnemonClient } from './api.ts'
 import { GlobalLocationSetting } from './GlobalLocationSetting.tsx'
 import css from './MnemonSettingsCard.module.css'
+import { useRequestVersion } from './use-request-version.ts'
 import type { MnemonKey, MnemonTranslate } from './locales.ts'
 import { ProviderIcon } from './ProviderIcon.tsx'
 
@@ -383,21 +384,25 @@ export function ProviderSettingsSection(props: ProviderSettingsSectionProps): JS
   const [catalog, setCatalog] = useState<MemoryProviderServiceCatalog>(() => initialCatalog ?? EMPTY_PROVIDER_CATALOG)
   const [loading, setLoading] = useState(client !== null && initialCatalog === undefined)
   const [failed, setFailed] = useState<string | null>(null)
+  const loadRequests = useRequestVersion()
 
   const load = useCallback(async (quiet = false) => {
     if (client === null) return
+    const request = loadRequests.begin()
     if (!quiet) setLoading(true)
     setFailed(null)
     try {
       const next = await client.providerServices()
+      if (!loadRequests.isCurrent(request)) return
       cacheCatalog(props.connection, routeKey, next)
       setCatalog(next)
     } catch (reason) {
+      if (!loadRequests.isCurrent(request)) return
       setFailed(message(reason))
     } finally {
-      if (!quiet) setLoading(false)
+      if (!quiet && loadRequests.isCurrent(request)) setLoading(false)
     }
-  }, [client, props.connection, routeKey])
+  }, [client, loadRequests, props.connection, routeKey])
 
   useEffect(() => {
     const cached = cachedCatalog(props.connection, routeKey)

--- a/src/client/use-request-version.ts
+++ b/src/client/use-request-version.ts
@@ -1,0 +1,14 @@
+import { useEffect, useMemo, useRef } from 'react'
+
+/**
+ * Guards UI state against responses from an older request or an unmounted
+ * component. Starting a request invalidates every earlier version.
+ */
+export function useRequestVersion(): { begin: () => number; isCurrent: (version: number) => boolean } {
+  const current = useRef(0)
+  useEffect(() => () => { current.current += 1 }, [])
+  return useMemo(() => ({
+    begin: () => { current.current += 1; return current.current },
+    isCurrent: (version: number) => current.current === version,
+  }), [])
+}

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -96,6 +96,7 @@ export abstract class HttpMemoryProvider {
     const label = memoryProviderDescriptor(this.id).label
     if (endpoint === '') throw new Error(`${label} endpoint is not configured`)
     if (!path.startsWith('/')) throw new Error(`${label} request path must be absolute`)
+    options.signal?.throwIfAborted()
     const controller = new AbortController()
     const relay = () => controller.abort(options.signal?.reason)
     options.signal?.addEventListener('abort', relay, { once: true })

--- a/src/providers/openviking.ts
+++ b/src/providers/openviking.ts
@@ -45,7 +45,7 @@ function number(value: unknown): number | undefined {
 }
 
 function delay(ms: number, signal?: AbortSignal): Promise<void> {
-  if (signal?.aborted === true) return Promise.reject(signal.reason)
+  if (signal?.aborted === true) return Promise.reject(signal.reason ?? new Error('OpenViking request aborted'))
   return new Promise((resolve, reject) => {
     const aborted = () => { clearTimeout(timer); reject(signal?.reason ?? new Error('OpenViking request aborted')) }
     const timer = setTimeout(() => {
@@ -278,6 +278,7 @@ export class OpenVikingProvider implements MemoryProviderAdapter {
   }
 
   private async requestConnection(connection: MemoryProviderConnection | OpenVikingBodyConnection, path: string, init: RequestInit = {}, options: OpenVikingRequestOptions = {}): Promise<unknown> {
+    options.signal?.throwIfAborted()
     const controller = new AbortController()
     const relay = () => controller.abort(options.signal?.reason)
     options.signal?.addEventListener('abort', relay, { once: true })

--- a/tests/client-platform-boundary.spec.ts
+++ b/tests/client-platform-boundary.spec.ts
@@ -4,15 +4,19 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 describe('browser bundle platform boundary', () => {
-  it('routes every Client parent import through the shared contract', () => {
+  const clientSources = () => {
     const directory = new URL('../src/client/', import.meta.url)
     const directoryPath = fileURLToPath(directory)
-    const violations = readdirSync(directory, { recursive: true })
+    return readdirSync(directory, { recursive: true })
       .filter(path => /\.[jt]sx?$/.test(String(path)))
-      .flatMap(path => {
-        const source = readFileSync(join(directoryPath, String(path)), 'utf8')
+      .map(path => ({ path: String(path), source: readFileSync(join(directoryPath, String(path)), 'utf8') }))
+  }
+
+  it('routes every Client parent import through the shared contract', () => {
+    const violations = clientSources()
+      .flatMap(({ path, source }) => {
         return [...source.matchAll(/(?:from|import)\s*['"](\.\.\/[^'"]+)['"]/gu)]
-          .map(match => `${String(path)}: ${match[1]}`)
+          .map(match => `${path}: ${match[1]}`)
       })
       .filter(imported => !imported.endsWith('../shared/contracts.ts'))
     expect(violations).toEqual([])
@@ -21,5 +25,13 @@ describe('browser bundle platform boundary', () => {
   it('keeps the shared browser contract free of Node runtime imports', () => {
     const contract = readFileSync(new URL('../src/shared/contracts.ts', import.meta.url), 'utf8')
     expect(contract).not.toMatch(/from\s*['"]node:/u)
+  })
+
+  it('delegates deployment URLs and transport to the host connection', () => {
+    const forbidden = /\bfetch\s*\(|\bXMLHttpRequest\b|\bWebSocket\b|\bEventSource\b|['"]\/(?:api|m\/api|plugins|assets)(?:\/|['"])/gu
+    const violations = clientSources().flatMap(({ path, source }) => {
+      return [...source.matchAll(forbidden)].map(match => `${path}: ${match[0]}`)
+    })
+    expect(violations).toEqual([])
   })
 })

--- a/tests/client-settings.spec.tsx
+++ b/tests/client-settings.spec.tsx
@@ -5,10 +5,57 @@ import { MnemonSettingsCard } from '../src/client/MnemonSettingsCard.tsx'
 import { translateEn } from '../src/client/locales.ts'
 import type { ClientConnectionHandle, ClientSettingsScope } from '../src/contracts.ts'
 import type { Config, InteractionConfig } from '../src/config.ts'
+import { MEMORY_PROVIDER_CATALOG } from '../src/providers/catalog.ts'
 
 afterEach(cleanup)
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(next => { resolve = next })
+  return { promise, resolve }
+}
+
 describe('MnemonSettingsCard', () => {
+  it('ignores a Provider catalog response from the previously selected workspace', async () => {
+    const snapshot = {
+      status: 'ready' as const,
+      value: { storageScope: 'workspace' as const },
+      base: {}, user: {}, revision: 0, writable: true, mode: 'host' as const,
+    }
+    const scope = {
+      getSnapshot: () => snapshot,
+      subscribe: () => () => {},
+      set: vi.fn(async () => {}), unset: vi.fn(async () => {}), setPath: vi.fn(async () => {}), unsetPath: vi.fn(async () => {}),
+    } satisfies ClientSettingsScope<Config>
+    const provider = MEMORY_PROVIDER_CATALOG.find(candidate => candidate.id === 'openviking')!
+    const catalog = (endpoint: string) => ({
+      ok: true as const,
+      value: {
+        providers: [provider],
+        items: [{ providerId: 'openviking' as const, enabled: true, configured: true, settings: { endpoint }, configuredSecrets: [] }],
+        generatedAt: '2026-08-17T00:00:00.000Z',
+      },
+    })
+    const firstWorkspace = deferred<ReturnType<typeof catalog>>()
+    const call = vi.fn(async (channel: string, endpoint: string, payload?: { workspaceId?: string }) => {
+      if (channel === '/dsh-mnemon-write' && endpoint === 'provider-services') {
+        return payload?.workspaceId === 'workspace-1' ? firstWorkspace.promise : catalog('https://workspace-2.example')
+      }
+      if (channel === '/dsh-mnemon-pack' && endpoint === 'target') return { ok: true as const, value: { root: '/workspace/.mnemon', scope: 'workspace' as const } }
+      throw new Error(`unexpected ${channel} ${endpoint}`)
+    })
+    const connection = { rpc: { call } } as ClientConnectionHandle
+    const view = render(<MnemonSettingsCard scope={scope} connection={connection} workspaceId="workspace-1" workspaceLabel="One" />)
+
+    view.rerender(<MnemonSettingsCard scope={scope} connection={connection} workspaceId="workspace-2" workspaceLabel="Two" />)
+    await screen.findByText('OpenViking')
+    fireEvent.click(screen.getByText('OpenViking'))
+    await waitFor(() => expect((screen.getByLabelText('服务地址') as HTMLInputElement).value).toBe('https://workspace-2.example'))
+
+    await act(async () => { firstWorkspace.resolve(catalog('https://workspace-1.example')); await firstWorkspace.promise })
+    expect((screen.getByLabelText('服务地址') as HTMLInputElement).value).toBe('https://workspace-2.example')
+  })
+
   it('uses the Host settings grant instead of transport locality on a trusted remote connection', async () => {
     const snapshot = {
       status: 'ready' as const,

--- a/tests/client-settings.spec.tsx
+++ b/tests/client-settings.spec.tsx
@@ -48,13 +48,14 @@ describe('MnemonSettingsCard', () => {
     const view = render(<MnemonSettingsCard scope={scope} connection={connection} workspaceId="workspace-1" workspaceLabel="One" />)
 
     view.rerender(<MnemonSettingsCard scope={scope} connection={connection} workspaceId="workspace-2" workspaceLabel="Two" />)
-    await screen.findByText('OpenViking')
-    fireEvent.click(screen.getByText('OpenViking'))
-    await waitFor(() => expect((screen.getByLabelText('服务地址') as HTMLInputElement).value).toBe('https://workspace-2.example'))
+    await waitFor(() => expect(call).toHaveBeenCalledWith('/dsh-mnemon-write', 'provider-services', { workspaceId: 'workspace-2' }))
+    const providerGroup = await screen.findByRole('group', { name: 'OpenViking 服务配置' }, { timeout: 5_000 })
+    fireEvent.click(within(providerGroup).getByRole('button'))
+    await waitFor(() => expect((screen.getByLabelText('服务地址') as HTMLInputElement).value).toBe('https://workspace-2.example'), { timeout: 5_000 })
 
     await act(async () => { firstWorkspace.resolve(catalog('https://workspace-1.example')); await firstWorkspace.promise })
     expect((screen.getByLabelText('服务地址') as HTMLInputElement).value).toBe('https://workspace-2.example')
-  })
+  }, 10_000)
 
   it('uses the Host settings grant instead of transport locality on a trusted remote connection', async () => {
     const snapshot = {

--- a/tests/client.spec.tsx
+++ b/tests/client.spec.tsx
@@ -20,7 +20,7 @@ describe('MnemonView', () => {
     unsetPath: async () => {},
   } satisfies ClientSettingsScope<Config>
 
-  function createConnection(options: { isLoopback?: boolean; withInactiveBody?: boolean; withSecondActiveBody?: boolean; metadataFailureBodyId?: string; withPlacement?: boolean; withProviderSources?: boolean; listCount?: number; searchCount?: number; entityCount?: number; entityInsightCount?: number; documentCount?: number; runtimeCount?: number; longContent?: boolean; workspaceMismatch?: boolean; nativeUnhealthy?: boolean; graphPending?: boolean; statusPending?: boolean; directoryPending?: boolean; reconnectPending?: boolean } = {}) {
+  function createConnection(options: { isLoopback?: boolean; withInactiveBody?: boolean; withSecondActiveBody?: boolean; metadataFailureBodyId?: string; withPlacement?: boolean; withProviderSources?: boolean; listCount?: number; searchCount?: number; entityCount?: number; entityInsightCount?: number; documentCount?: number; runtimeCount?: number; longContent?: boolean; workspaceMismatch?: boolean; nativeUnhealthy?: boolean; graphPending?: boolean; statusPending?: boolean; directoryPending?: boolean; reconnectPending?: boolean; relatedDeferred?: boolean } = {}) {
     const body = {
       id: 'project',
       name: '项目记忆体',
@@ -128,6 +128,7 @@ describe('MnemonView', () => {
     }
     const memory = { id: 'memory-12345678', content: options.longContent === true ? '这是一段非常长的记忆内容，用于验证图谱检查器对超长文本的截断展示，以及全文预览窗口的打开与关闭。'.repeat(6) : '项目选择 SQLite，因为需要单文件部署。', category: 'decision', importance: 4, tags: ['architecture'], entities: ['SQLite'], color: '#e74c3c', memoryBodyId: body.id, memoryBodyName: body.name, graphId: `${body.id}:memory-12345678` }
     const secondaryMemory = { id: 'preference-1', content: '用户偏好简洁中文回答。', category: 'preference', importance: 4, tags: ['style'], entities: ['DSH'], color: '#9b59b6', memoryBodyId: secondaryBody.id, memoryBodyName: secondaryBody.name, graphId: `${secondaryBody.id}:preference-1` }
+    const relatedResolvers: Array<(response: { ok: true; value: Array<typeof memory> }) => void> = []
     const providerSources = options.withProviderSources === true ? {
       graph: [
         { memoryBodyId: body.id, memoryBodyName: body.name, providerId: 'mnemon-native', providerLabel: 'Mnemon Native', mode: 'graph', status: 'ready', itemCount: 2, edgeCount: 2 },
@@ -276,7 +277,10 @@ describe('MnemonView', () => {
           delegation: { runId: 'answer-child-1', provider: 'spawn' },
         },
       }
-      if (endpoint === 'related') return { ok: true, value: [] }
+      if (endpoint === 'related') {
+        if (options.relatedDeferred === true) return await new Promise<{ ok: true; value: Array<typeof memory> }>(resolve => relatedResolvers.push(resolve))
+        return { ok: true, value: [] }
+      }
       if (endpoint === 'supervise') return { ok: true, value: { delegated: true, sessionId: 'session-1', runId: 'child-1', provider: 'spawn', summary: '已提炼并写入项目交付约束。', action: 'stored', memoryBodyIds: ['project'] } }
       if (endpoint === 'remember') return { ok: true, value: { delegated: true, runId: 'child-2', provider: 'spawn', summary: '已按高级约束写入。', action: 'stored', memoryBodyIds: ['project'] } }
       if (endpoint === 'forget') return { ok: true, value: { action: 'forgotten' } }
@@ -300,7 +304,11 @@ describe('MnemonView', () => {
       if (endpoint === 'body-create') return { ok: true, value: { ...body, id: 'new-body', name: String(payload?.name ?? '') } }
       return { ok: false, error: { code: 'unexpected', message: endpoint } }
     })
-    return { connection: { rpc: { call }, ...(options.isLoopback === undefined ? {} : { isLoopback: options.isLoopback }) } as unknown as ClientConnectionHandle, call }
+    return {
+      connection: { rpc: { call }, ...(options.isLoopback === undefined ? {} : { isLoopback: options.isLoopback }) } as unknown as ClientConnectionHandle,
+      call,
+      resolveRelated: (index: number, content: string) => relatedResolvers[index]?.({ ok: true, value: [{ ...memory, id: `related-${index}`, graphId: `${body.id}:related-${index}`, content }] }),
+    }
   }
 
   it('shows the live graph and all eight Mnemon workspaces', async () => {
@@ -1287,6 +1295,25 @@ describe('MnemonView', () => {
     fireEvent.click(screen.getByRole('button', { name: '确认忘记' }))
     await waitFor(() => expect(screen.queryByText('项目选择 SQLite，因为需要单文件部署。')).toBeNull())
     expect(call).toHaveBeenCalledWith(expect.anything(), 'forget', { id: 'memory-12345678', memoryBodyId: 'project', sessionId: 'session-1' })
+  })
+
+  it('keeps the newest related-memory response when requests finish out of order', async () => {
+    const { connection, resolveRelated } = createConnection({ relatedDeferred: true })
+    render(<MnemonView connection={connection} settingsScope={settingsScope} sessionId="session-1" />)
+    await waitFor(() => expect(screen.getByText('已连接 · 1 个已激活')).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: /检索 意图增强召回/ }))
+    fireEvent.change(screen.getByRole('textbox', { name: '记忆查询' }), { target: { value: 'SQLite' } })
+    fireEvent.click(screen.getByRole('button', { name: '直接检索' }))
+    await waitFor(() => expect(screen.getByText('项目选择 SQLite，因为需要单文件部署。')).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: '查看关联' }))
+    fireEvent.click(screen.getByRole('button', { name: '查看关联' }))
+    await act(async () => { resolveRelated(1, '较新的关联响应') })
+    expect(await screen.findByText('较新的关联响应')).toBeTruthy()
+    await act(async () => { resolveRelated(0, '已经过期的关联响应') })
+    expect(screen.getByText('较新的关联响应')).toBeTruthy()
+    expect(screen.queryByText('已经过期的关联响应')).toBeNull()
   })
 
   it('shows an Agent answer above the raw direct-recall evidence', async () => {

--- a/tests/openviking-provider.spec.ts
+++ b/tests/openviking-provider.spec.ts
@@ -49,6 +49,16 @@ function ok(result: unknown): Response {
 }
 
 describe('OpenVikingProvider', () => {
+  it('does not start discovery after cancellation', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    const controller = new AbortController()
+    controller.abort(new Error('workspace changed'))
+    const { provider } = await bodyAndRegistry(fetchMock)
+
+    await expect(provider.discover({ endpoint: 'https://memory.example.com', apiKey: 'private-key', account: 'acme' }, controller.signal)).rejects.toThrow('workspace changed')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('discovers every registered user namespace in the configured account', async () => {
     const fetchMock = vi.fn<typeof fetch>(async (url) => {
       expect(new URL(String(url)).pathname).toBe('/api/v1/admin/accounts/acme/users')

--- a/tests/remote-providers.spec.ts
+++ b/tests/remote-providers.spec.ts
@@ -39,6 +39,16 @@ function response(payload: unknown, status = 200): Response {
 }
 
 describe('third-party remote memory providers', () => {
+  it('does not start generic Provider HTTP requests after cancellation', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    const controller = new AbortController()
+    controller.abort(new Error('navigation cancelled'))
+    const honcho = await providerBody('honcho', { endpoint: 'https://honcho.example', workspace: 'old', userId: 'user', agentId: 'agent' })
+
+    await expect(new HonchoProvider(honcho.registry, { fetch: fetchMock }).discover({ endpoint: 'https://honcho.example' }, controller.signal)).rejects.toThrow('navigation cancelled')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('discovers provider-native namespaces and maps their upstream titles and descriptions', async () => {
     const fetchMock = vi.fn<typeof fetch>(async (url) => {
       const path = new URL(String(url)).pathname


### PR DESCRIPTION
## 摘要

- 让 HTTP/OpenViking Provider 对预先取消的请求立即终止，统一取消语义
- 引入请求版本守卫，避免工作区 Provider、档案、关联记忆与实体页面被旧响应覆盖
- 锁定浏览器端部署 URL 边界，禁止插件绕过宿主 connection 或拼接根路径资源
- 将 Cordis/DSH structured output、toolFilter、显式能力契约和 URL 子路径 E2E 建议写入双语 roadmap
- 稳定新增的异步竞态回归测试

## 真实 WebUI 验证

- 重载本地 link profile 的最新构建，检查状态、记忆体概览、内容与实体页面
- 点击 default 记忆体卡片更新：保持已连接，无 Failed to fetch、无页面 alert、无浏览器 error/warn
- 快速切换内容/实体及连续选择实体：最终状态保持在最后一次选择
- 请求子路径入口并检查启动 HTML：确认当前 DSH 宿主仍生成根相对静态/插件 URL；插件保持 base-path-neutral，宿主统一 base URL 工作已进入 roadmap

## 验证

- pnpm run verify
- 330 tests passed，1 Windows-only test skipped locally
- deterministic build、headless profile、package contents、publint、类型检查均通过
