### PR TITLE
fix(client): honor trusted remote management grant

### DIFF
--- a/src/client/MnemonSaveAction.tsx
+++ b/src/client/MnemonSaveAction.tsx
@@ -1,6 +1,6 @@
-import { memo, useEffect, useRef, useState, type JSX } from 'react'
+import { memo, useEffect, useRef, useState, useSyncExternalStore, type JSX } from 'react'
 import { Button, IconDataOutline16, Modal, Tooltip } from '@deepseek-ai/dsh-client-ui-primitives'
-import type { ClientConnectionHandle } from '../shared/contracts.ts'
+import type { ClientConnectionHandle, ClientSettingsScope, Config } from '../shared/contracts.ts'
 import { MnemonClient } from './api.ts'
 import type { MnemonKey } from './locales.ts'
 import css from './MnemonSaveAction.module.css'
@@ -11,6 +11,7 @@ export interface MnemonSaveActionProps {
   /** Injected by the slot host: the session this message belongs to. */
   sessionId?: string
   connection: ClientConnectionHandle
+  settingsScope: ClientSettingsScope<Config>
   t: (key: MnemonKey, params?: Record<string, unknown>) => string
 }
 
@@ -22,7 +23,9 @@ interface SuperviseOutcome {
 const PREVIEW_LIMIT = 8000
 
 /** Save-to-memory action on finalized assistant messages, routed through the supervised writeback gate. */
-export const MnemonSaveAction = memo(function MnemonSaveAction({ messageId, sessionId, connection, t }: MnemonSaveActionProps): JSX.Element {
+export const MnemonSaveAction = memo(function MnemonSaveAction({ messageId, sessionId, connection, settingsScope, t }: MnemonSaveActionProps): JSX.Element {
+  const settingsSnapshot = useSyncExternalStore(settingsScope.subscribe, settingsScope.getSnapshot, settingsScope.getSnapshot)
+  const managementWritable = settingsSnapshot.status === 'ready' && settingsSnapshot.writable
   const [open, setOpen] = useState(false)
   const [writeEnabled, setWriteEnabled] = useState<boolean | undefined>(undefined)
   const [candidate, setCandidate] = useState<string | undefined>(undefined)
@@ -58,7 +61,7 @@ export const MnemonSaveAction = memo(function MnemonSaveAction({ messageId, sess
     setSubmitting(submitActiveRef.current)
     const client = new MnemonClient(connection, sessionId)
     client.status()
-      .then(status => { if (alive && requestVersionRef.current === requestVersion) setWriteEnabled(status.writeEnabled && connection.isLoopback !== false) })
+      .then(status => { if (alive && requestVersionRef.current === requestVersion) setWriteEnabled(status.writeEnabled && managementWritable) })
       .catch(() => { if (alive && requestVersionRef.current === requestVersion) setWriteEnabled(false) })
     client.assistantMessageText(messageId)
       .then(result => {
@@ -71,7 +74,7 @@ export const MnemonSaveAction = memo(function MnemonSaveAction({ messageId, sess
       })
       .catch(() => { if (alive && requestVersionRef.current === requestVersion) setMissing(true) })
     return () => { alive = false }
-  }, [open, connection, sessionId, messageId])
+  }, [open, connection, sessionId, messageId, managementWritable])
 
   const submit = (): void => {
     const content = textareaRef.current?.value.trim() ?? ''

--- a/src/client/MnemonView.tsx
+++ b/src/client/MnemonView.tsx
@@ -2493,7 +2493,7 @@ function MnemonWorkspace({ connection, settingsScope, sessionId, workspaceId, wo
   }, [appearance.surface, openRemember, selectPage])
   const refreshAll = () => { setRevision(value => value + 1); void loadStatus() }
   const activationEnabled = status?.writeEnabled === true
-  const writeEnabled = activationEnabled && connection.isLoopback !== false
+  const writeEnabled = activationEnabled && settingsSnapshot.status === 'ready' && settingsSnapshot.writable
   const stats = status?.stats
   const catalogKnown = status?.memoryBodies !== undefined
   const memoryBodies = useMemo(() => (status?.memoryBodies ?? []).map(normalizeMemoryBody), [status])

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -20,7 +20,7 @@ export const inject = ['slots', 'sessions', 'workspaces', 'connection', 'locale'
 /** Interaction surfaces: slot name, settings toggle, and the registrations it owns. */
 type MnemonNamespace = 'mnemon'
 type InteractionSlot = 'conversation.chat.turnTail' | 'conversation.chat.assistant-actions'
-type InteractionRegister = (ctx: MnemonClientContext, namespace: MnemonNamespace, translate: (key: MnemonKey, params?: Record<string, unknown>) => string) => () => void
+type InteractionRegister = (ctx: MnemonClientContext, namespace: MnemonNamespace, translate: (key: MnemonKey, params?: Record<string, unknown>) => string, settings: MnemonSettingsScope<Config>) => () => void
 
 interface InteractionUnit {
   slot: InteractionSlot
@@ -48,15 +48,16 @@ const INTERACTION_UNITS: Record<'turnBar' | 'saveAction', InteractionUnit> = {
   saveAction: {
     slot: 'conversation.chat.assistant-actions',
     enabled: (value: unknown): boolean => enabledOf(value, 'saveAction'),
-    register(ctx: MnemonClientContext, namespace: MnemonNamespace, translate: (key: MnemonKey, params?: Record<string, unknown>) => string): () => void {
+    register(ctx: MnemonClientContext, namespace: MnemonNamespace, translate: (key: MnemonKey, params?: Record<string, unknown>) => string, settings: MnemonSettingsScope<Config>): () => void {
       return ctx.slots.register({
         name: 'conversation.chat.assistant-actions',
         id: 'mnemon-save',
         order: 90,
         locale: namespace,
-        inject: (sessionId: unknown): { sessionId?: string; connection: ClientConnectionHandle; t: (key: MnemonKey, params?: Record<string, unknown>) => string } => ({
+        inject: (sessionId: unknown): { sessionId?: string; connection: ClientConnectionHandle; settingsScope: MnemonSettingsScope<Config>; t: (key: MnemonKey, params?: Record<string, unknown>) => string } => ({
           ...(typeof sessionId === 'string' && sessionId !== '' ? { sessionId } : {}),
           connection: ctx.connection,
+          settingsScope: settings,
           t: translate as (key: MnemonKey, params?: Record<string, unknown>) => string,
         }),
       }, MnemonSaveAction)
@@ -176,7 +177,7 @@ export function apply(rawContext: unknown): void {
       const unit = INTERACTION_UNITS[key]
       const enabled = unit.enabled(value)
       if (enabled && !active.has(key)) {
-        active.set(key, ctx.slots.inject(unit.slot, () => unit.register(ctx, namespace, translate)))
+        active.set(key, ctx.slots.inject(unit.slot, () => unit.register(ctx, namespace, translate, settings)))
       } else if (!enabled && active.has(key)) {
         active.get(key)!()
         active.delete(key)

--- a/tests/client-apply.spec.ts
+++ b/tests/client-apply.spec.ts
@@ -29,9 +29,15 @@ describe('Mnemon Web client composition', () => {
     expect(slots.find(options => options.name === 'conversation.view')).toBeUndefined()
     expect(slots).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'settings.section', id: 'mnemon', order: 20 })]))
     const settingsEntry = slots.find(options => options.name === 'settings.section')
-    const settingsInject = settingsEntry?.inject as (() => { t: (key: keyof typeof zh) => string }) | undefined
+    const settingsInject = settingsEntry?.inject as (() => { scope: unknown; t: (key: keyof typeof zh) => string }) | undefined
     expect(settingsInject?.().t('config.scope')).toBe('存储范围')
     expect((settingsEntry?.label as () => string)()).toBe('记忆系统')
+    await vi.waitFor(() => expect(slots).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'conversation.chat.assistant-actions', id: 'mnemon-save' }),
+    ])))
+    const saveEntry = slots.find(options => options.name === 'conversation.chat.assistant-actions')
+    const saveProps = (saveEntry?.inject as (sessionId: string) => { settingsScope: unknown })('session-1')
+    expect(saveProps.settingsScope).toBe(settingsInject?.().scope)
     active = 'en'
     expect((settingsEntry?.label as () => string)()).toBe('Memory System')
     expect(settingsInject?.().t('config.scope')).toBe('Storage scope')

--- a/tests/client-interaction-surfaces.spec.tsx
+++ b/tests/client-interaction-surfaces.spec.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { ClientConnectionHandle } from '../src/contracts.ts'
+import type { ClientConnectionHandle, ClientSettingsScope } from '../src/contracts.ts'
+import type { Config } from '../src/config.ts'
 import { MnemonSaveAction } from '../src/client/MnemonSaveAction.tsx'
 import { MnemonTurnTail, memoryPageForTool } from '../src/client/MnemonTurnTail.tsx'
 import { consumeMnemonAnchor, dispatchMnemonAnchor, subscribeMnemonAnchor } from '../src/client/anchor.ts'
@@ -12,6 +13,17 @@ afterEach(() => {
 })
 
 const translate = (key: string): string => key
+const writableSettingsSnapshot = { status: 'ready' as const, value: {}, writable: true, mode: 'host' as const }
+const readOnlySettingsSnapshot = { status: 'unavailable' as const, writable: false, mode: 'host' as const }
+const writableSettingsScope = {
+  getSnapshot: () => writableSettingsSnapshot,
+  subscribe: () => () => {},
+  set: async () => {}, unset: async () => {}, setPath: async () => {}, unsetPath: async () => {},
+} satisfies ClientSettingsScope<Config>
+const readOnlySettingsScope = {
+  ...writableSettingsScope,
+  getSnapshot: () => readOnlySettingsSnapshot,
+} satisfies ClientSettingsScope<Config>
 
 function deferred<T>() {
   let resolve!: (value: T) => void
@@ -81,7 +93,7 @@ describe('conversation interaction surfaces', () => {
     })
     const connection = { rpc: { call: rpcCall } } as ClientConnectionHandle
 
-    render(<MnemonSaveAction messageId="message-1" sessionId="session-a" connection={connection} t={translate as never} />)
+    render(<MnemonSaveAction messageId="message-1" sessionId="session-a" connection={connection} settingsScope={writableSettingsScope} t={translate as never} />)
     const action = screen.getByRole('button', { name: 'saveAction.button' })
     expect(action.textContent).toBe('')
     expect(action.getAttribute('aria-haspopup')).toBe('dialog')
@@ -120,7 +132,7 @@ describe('conversation interaction surfaces', () => {
     expect(screen.queryByText('saveAction.result')).toBeNull()
   })
 
-  it('keeps supervised message writes read-only on a remote trusted-host connection', async () => {
+  it('keeps supervised message writes read-only when the Host management grant is unavailable', async () => {
     const rpcCall = vi.fn(async (_channel: string, endpoint: string) => {
       if (endpoint === 'status') return { ok: true as const, value: { writeEnabled: true } }
       if (endpoint === 'assistant-message') return { ok: true as const, value: { messageId: 'message-1', text: 'A durable project decision.' } }
@@ -128,7 +140,7 @@ describe('conversation interaction surfaces', () => {
     })
     const connection = { rpc: { call: rpcCall }, isLoopback: false } as ClientConnectionHandle
 
-    render(<MnemonSaveAction messageId="message-1" sessionId="session-a" connection={connection} t={translate as never} />)
+    render(<MnemonSaveAction messageId="message-1" sessionId="session-a" connection={connection} settingsScope={readOnlySettingsScope} t={translate as never} />)
     fireEvent.click(screen.getByRole('button', { name: 'saveAction.button' }))
 
     const submit = await screen.findByRole('button', { name: 'saveAction.submit' }) as HTMLButtonElement
@@ -136,5 +148,23 @@ describe('conversation interaction surfaces', () => {
     expect(submit.disabled).toBe(true)
     fireEvent.click(submit)
     expect(rpcCall.mock.calls.some(([, endpoint]) => endpoint === 'supervise')).toBe(false)
+  })
+
+  it('allows supervised message writes on an explicitly authorized remote Host', async () => {
+    const rpcCall = vi.fn(async (_channel: string, endpoint: string) => {
+      if (endpoint === 'status') return { ok: true as const, value: { writeEnabled: true } }
+      if (endpoint === 'assistant-message') return { ok: true as const, value: { messageId: 'message-1', text: 'A durable project decision.' } }
+      if (endpoint === 'supervise') return { ok: true as const, value: { summary: 'stored', action: 'remember' } }
+      throw new Error(`unexpected endpoint: ${endpoint}`)
+    })
+    const connection = { rpc: { call: rpcCall }, isLoopback: false } as ClientConnectionHandle
+
+    render(<MnemonSaveAction messageId="message-1" sessionId="session-a" connection={connection} settingsScope={writableSettingsScope} t={translate as never} />)
+    fireEvent.click(screen.getByRole('button', { name: 'saveAction.button' }))
+
+    const submit = await screen.findByRole('button', { name: 'saveAction.submit' }) as HTMLButtonElement
+    await waitFor(() => expect(submit.disabled).toBe(false))
+    fireEvent.click(submit)
+    await waitFor(() => expect(rpcCall.mock.calls.some(([, endpoint]) => endpoint === 'supervise')).toBe(true))
   })
 })

--- a/tests/client.spec.tsx
+++ b/tests/client.spec.tsx
@@ -19,6 +19,11 @@ describe('MnemonView', () => {
     setPath: async () => {},
     unsetPath: async () => {},
   } satisfies ClientSettingsScope<Config>
+  const readOnlySettingsSnapshot = { status: 'unavailable' as const, writable: false, mode: 'host' as const }
+  const readOnlySettingsScope = {
+    ...settingsScope,
+    getSnapshot: () => readOnlySettingsSnapshot,
+  } satisfies ClientSettingsScope<Config>
 
   function createConnection(options: { isLoopback?: boolean; withInactiveBody?: boolean; withSecondActiveBody?: boolean; metadataFailureBodyId?: string; withPlacement?: boolean; withProviderSources?: boolean; listCount?: number; searchCount?: number; entityCount?: number; entityInsightCount?: number; documentCount?: number; runtimeCount?: number; longContent?: boolean; workspaceMismatch?: boolean; nativeUnhealthy?: boolean; graphPending?: boolean; statusPending?: boolean; directoryPending?: boolean; reconnectPending?: boolean; relatedDeferred?: boolean } = {}) {
     const body = {
@@ -446,9 +451,9 @@ describe('MnemonView', () => {
     expect(screen.getByRole('button', { name: '实体: DSH' })).toBeTruthy()
   })
 
-  it('keeps only activation controls writable on a remote trusted-host connection', async () => {
+  it('keeps only activation controls writable when remote management is not authorized', async () => {
     const { connection, call } = createConnection({ isLoopback: false, withInactiveBody: true })
-    render(<MnemonView connection={connection} settingsScope={settingsScope} sessionId="session-1" surface="sidebar" />)
+    render(<MnemonView connection={connection} settingsScope={readOnlySettingsScope} sessionId="session-1" surface="sidebar" />)
 
     await waitFor(() => expect(screen.getByText('已连接')).toBeTruthy())
     fireEvent.click(screen.getByRole('button', { name: '检查版本' }))
@@ -475,6 +480,22 @@ describe('MnemonView', () => {
     await waitFor(() => expect(toggle.getAttribute('aria-checked')).toBe('true'))
     expect(call).toHaveBeenCalledWith('/dsh-mnemon-activation', 'body', { memoryBodyId: 'preferences', active: true, sessionId: 'session-1' })
     expect(call.mock.calls.some(([channel]) => channel === '/dsh-mnemon-write')).toBe(false)
+  })
+
+  it('enables memory management controls on an explicitly authorized remote Host', async () => {
+    const { connection } = createConnection({ isLoopback: false, withInactiveBody: true })
+    render(<MnemonView connection={connection} settingsScope={settingsScope} sessionId="session-1" surface="sidebar" />)
+
+    await waitFor(() => expect(screen.getByText('已连接')).toBeTruthy())
+    fireEvent.click(screen.getByRole('tab', { name: '记忆体' }))
+    await waitFor(() => expect(screen.getByRole('region', { name: '记忆体目录' })).toBeTruthy())
+
+    expect(screen.getByText('独立任务 Agent')).toBeTruthy()
+    expect((screen.getByRole('button', { name: '沉淀记忆' }) as HTMLButtonElement).disabled).toBe(false)
+    expect(screen.getByRole('button', { name: '创建记忆体' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'AI 维护元信息' })).toBeTruthy()
+    expect((screen.getByRole('button', { name: '编辑项目记忆体' }) as HTMLButtonElement).disabled).toBe(false)
+    expect((screen.getByRole('button', { name: '删除项目记忆体' }) as HTMLButtonElement).disabled).toBe(false)
   })
 
   it('keeps overview, recall, content, and entities aligned with each provider read contract', async () => {


### PR DESCRIPTION
## Summary

- derive Mnemon workspace write controls from the Host settings capability grant instead of `connection.isLoopback`
- pass the same settings capability into the assistant-message save action
- preserve activation-only behavior when remote management is unavailable and add positive coverage for explicitly authorized remote Hosts

## Why

`remoteAccess: trusted-host` promotes the write, settings, and pack RPC channels at Host startup, but the v0.2.6+ client still disabled memory writes whenever `isLoopback` was false. This caused the UI to reject authorized remote writes before transport even though the Host had granted them.

## Validation

- `vitest run`: 345 passed, 1 Windows-only test skipped
- `tsc -p tsconfig.json --noEmit`
- `tsdown`
- `tsc -p tsconfig.types.json`
- `git diff --check`