### PR TITLE
docs: document 'memory subagent stopped with error' fix in troubleshooting

### DIFF
--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -144,6 +144,7 @@ Report vulnerabilities privately through [SECURITY.md](../../SECURITY.md), not a
 | `memoryBodyId is required...` | Active count is not exactly one; select a target explicitly |
 | `memory body is not active for reading` | Activate it in Overview; inactive writes are allowed, reads are not |
 | Provider error | Semantic work needs full isolation capabilities; background review additionally needs `fork + inheritsParentContext` |
+| `memory subagent stopped with error` | Structured-output delegated runs (`mnemon_remember` / `mnemon_recall` / `mnemon_related` / `mnemon_forget`) fail on DSH 0.1.0-rc.6 when the plugin also passes a `toolFilter` that hides the result-capture tool. Fixed in dsh-mnemon ≥ 0.2.x, which registers a dynamic per-run result tool and includes it in the allowlist. Upgrade to the latest release (`dsh plugin --profile web add dsh-mnemon@latest`) and restart DSH. See https://github.com/omdsh-dev/dsh-mnemon/issues/14 |
 | Runtime replace exceeds capacity | Shorten it or organize first; automatic maintenance handles add overflow only |
 | Document source path rejected | Keep it inside the session workspace and outside managed Documents |
 | CLI timeout | Increase `timeoutMs`; large Stores may need more than 10 seconds for status or graph |

--- a/docs/zh-CN/operations.md
+++ b/docs/zh-CN/operations.md
@@ -144,6 +144,7 @@ Test-Path "$env:LOCALAPPDATA\Programs\mnemon\mnemon.exe"
 | `memoryBodyId is required...` | active 数量不是恰好 1；显式选择目标 |
 | `memory body is not active for reading` | 在概览激活目标；写入 inactive 可以，读取不行 |
 | Provider 错误 | 普通语义任务需要完整隔离能力；后台审查另需 `fork + inheritsParentContext` |
+| `memory subagent stopped with error` | DSH 0.1.0-rc.6 下结构化输出的委派子代理（`mnemon_remember` / `mnemon_recall` / `mnemon_related` / `mnemon_forget`）会在此插件同时传入 `toolFilter` 时失败——它把结果捕获工具也过滤掉了。已在 dsh-mnemon ≥ 0.2.x 修复：改为注册动态、按次唯一的运行结果工具并纳入白名单。升级到最新版（`dsh plugin --profile web add dsh-mnemon@latest`）后重启 DSH。见 https://github.com/omdsh-dev/dsh-mnemon/issues/14 |
 | Runtime replace 超容量 | 缩短 replacement 或先显式整理；自动维护只处理 add 溢出 |
 | Document source path 被拒绝 | 路径必须在会话工作区内，且不能引用受管 Documents 目录 |
 | CLI timeout | 增大 `timeoutMs`；大 Store 的状态与图谱可能超过 10 秒 |


### PR DESCRIPTION
## What

Adds a troubleshooting row (English + Chinese) to `docs/operations.md` / `docs/zh-CN/operations.md` documenting the `memory subagent stopped with error` failure on DSH 0.1.0-rc.6.

## Why

Users (per issue #14) hit this exact error when calling `mnemon_remember` / `mnemon_recall` / `mnemon_related` / `mnemon_forget` and often chase unrelated causes (credential/local CLI) before finding the real one. The fix is a version bump (≥ 0.2.x), which is easy to miss. A single troubleshooting row saves the round-trip.

## Root cause (recap)

The structured-output delegated run in `delegate()` passed a `toolFilter` that hid the result-capture tool from the structured subagent, so DSH forced `stopReason = "error"`. Resolved in dsh-mnemon ≥ 0.2.x by registering a dynamic, per-run result tool and including it in the allowlist.

## Verification

- Both en + zh tables updated.
- Changelog/da docs build not affected (docs-only change).