### PR TITLE
fix(version): run pnpm update inside the owning DSH profile

### DIFF
--- a/src/version-updates.ts
+++ b/src/version-updates.ts
@@ -235,8 +235,8 @@ function inspectDshInstall(packageManifestPath: string, dshHome: string): DshIns
   return profileFromAncestor(packageManifestPath) ?? linkedProfile(packageManifestPath, dshHome) ?? { mode: 'manual', locationDir: resolve(dirname(packageManifestPath)) }
 }
 
-async function resultOrThrow(runner: ProcessRunner, command: string, args: readonly string[], timeoutMs: number): Promise<ProcessResult> {
-  const result = await runner(command, args, { timeoutMs, maxOutputBytes: MAX_UPDATE_OUTPUT_BYTES })
+async function resultOrThrow(runner: ProcessRunner, command: string, args: readonly string[], timeoutMs: number, options: { cwd?: string } = {}): Promise<ProcessResult> {
+  const result = await runner(command, args, { timeoutMs, maxOutputBytes: MAX_UPDATE_OUTPUT_BYTES, ...options })
   if (result.exitCode !== 0) {
     const detail = result.stderr.trim() || result.stdout.trim() || `exit ${String(result.exitCode)}`
     throw new Error(detail)
@@ -387,7 +387,7 @@ export class VersionUpdateManager {
     const install = inspectDshInstall(this.packageManifestPath, this.dshHome)
     const pnpm = this.executable('pnpm')
     if (install.mode !== 'npm' || install.profileDir === undefined || pnpm === undefined) throw new Error('This dsh-mnemon installation cannot be updated automatically')
-    const output = await resultOrThrow(this.processRunner, pnpm, ['update', DSH_MNEMON_PACKAGE], UPDATE_TIMEOUT_MS)
+    const output = await resultOrThrow(this.processRunner, pnpm, ['update', DSH_MNEMON_PACKAGE], UPDATE_TIMEOUT_MS, { cwd: install.profileDir })
     const outputText = updateOutput(output)
     this.dshMnemonVersion = latest
     return {

--- a/tests/version-updates.spec.ts
+++ b/tests/version-updates.spec.ts
@@ -100,7 +100,7 @@ describe('VersionUpdateManager', () => {
     })
     await expect(manager.update('dsh-mnemon')).resolves.toMatchObject({ updated: true, currentVersion: '0.1.3', restartRequired: true })
     expect(manager.currentDshMnemonVersion).toBe('0.1.3')
-    expect(run).toHaveBeenCalledWith(expect.stringMatching(/pnpm$/), ['update', 'dsh-mnemon'], expect.objectContaining({ timeoutMs: 600_000, maxOutputBytes: 16 * 1024 }))
+    expect(run).toHaveBeenCalledWith(expect.stringMatching(/pnpm$/), ['update', 'dsh-mnemon'], expect.objectContaining({ timeoutMs: 600_000, maxOutputBytes: 16 * 1024, cwd: profile }))
   })
 
   it('uses the fixed Homebrew cask command for a recognized Mnemon install', async () => {


### PR DESCRIPTION
## Problem

The automatic **Update version** action for dsh-mnemon always fails for npm-managed (profile) installs:

```
[ERR_PNPM_NO_PKG_MANIFEST] No package.json found in /Users/ivan
```

The UI surfaces this as **版本操作失败** ("version operation failed").

### Root cause

`VersionUpdateManager.update('dsh-mnemon')` invokes:

```ts
resultOrThrow(this.processRunner, pnpm, ['update', DSH_MNEMON_PACKAGE], UPDATE_TIMEOUT_MS)
```

without a working directory. `runProcess` spawns pnpm with the *inherited* cwd, which for the DSH Desktop app is the process launch directory (typically the user's home, e.g. `/Users/ivan`) — a directory that has no `package.json`. pnpm therefore fails with `ERR_PNPM_NO_PKG_MANIFEST` before doing any work.

The bug affects every npm-managed install: `inspectDshInstall()` already resolves the owning profile directory (`install.profileDir`), but it is never passed to the pnpm invocation.

## Fix

Thread an optional `cwd` through `resultOrThrow` and pass `install.profileDir` for the `pnpm update dsh-mnemon` call, so the update runs inside the profile that actually owns the dependency:

```ts
const output = await resultOrThrow(this.processRunner, pnpm, ['update', DSH_MNEMON_PACKAGE], UPDATE_TIMEOUT_MS, { cwd: install.profileDir })
```

- `ProcessRunner` / `runProcess` already support `options.cwd` — no change needed there.
- For `link`/`manual` installs the code path already rejects before reaching this call, so behavior is unchanged for those modes.

## Verification

- `pnpm run typecheck` — passes
- `vitest run tests/version-updates.spec.ts` — 5/5 pass, including the updated assertion that the pnpm call now receives `cwd: profile`
- Manual reproduction: without cwd, `pnpm update dsh-mnemon` in `/Users/ivan` fails with `ERR_PNPM_NO_PKG_MANIFEST`; with cwd set to the profile directory it runs successfully.
