### PR TITLE
fix: allow persistence strategy settings updates

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -46,7 +46,7 @@ const MUTABLE_FIELDS = [
   'storageScope', 'cliPath', 'dataDir', 'customPackId', 'customPacks', 'store', 'timeoutMs', 'defaultRecallLimit',
   'recallQuality',
   'routingGuidance', 'lifecycleEnabled', 'recallMode', 'writebackMode', 'idleReviewMs',
-  'displayMode', 'tabEnabled', 'writeEnabled', 'taskAgentModel',
+  'displayMode', 'tabEnabled', 'writeEnabled', 'persistenceStrategy', 'taskAgentModel',
 ]
 // remoteAccess is intentionally absent: changing the transport authority
 // requires a local configuration edit and a Host restart.

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -64,6 +64,35 @@ describe('Mnemon settings bridge', () => {
     expect(settings.mutate).not.toHaveBeenCalled()
   })
 
+  it('accepts the whole persistence strategy through the Mnemon namespace', async () => {
+    const persistenceStrategy = {
+      mode: 'automatic',
+      providerId: 'mnemon-native',
+      prompt: 'Prefer shared project memory.',
+      rules: {
+        allowedProviderIds: ['mnemon-native', 'openviking'],
+        dataBoundary: 'allow-remote',
+        requiredCapabilities: ['graph'],
+        preference: 'shared-first',
+      },
+      providerConnections: { openviking: { targetUri: 'viking://resources/team' } },
+    }
+    const mutate = vi.fn(async () => {})
+    const settings = {
+      writable: true,
+      register: vi.fn(),
+      mutate,
+      describe: () => [{ ns: 'mnemon', value: { persistenceStrategy }, revision: 1, applies: 'restart' as const }],
+    } as unknown as HostSettingsService
+
+    await expect(createSettingsHandler(settings)('mutate', {
+      ops: [{ op: 'set', path: ['persistenceStrategy'], value: persistenceStrategy }],
+    })).resolves.toMatchObject({ ok: true })
+    expect(mutate).toHaveBeenCalledWith('mnemon', [
+      { op: 'set', path: ['persistenceStrategy'], value: persistenceStrategy },
+    ], undefined)
+  })
+
   it('does not let a remote settings client promote its own transport authority', async () => {
     const settings = {
       writable: true,


### PR DESCRIPTION
## Summary

- add `persistenceStrategy` to the Mnemon settings mutable-field allowlist so the Memory System dialog can save the complete strategy object
- add a focused settings-bridge regression test for the exact top-level mutation while preserving existing unsupported-field rejection coverage

## Testing

- `pnpm exec vitest run tests/settings.spec.ts` — 1 file passed, 6 tests passed
- `pnpm run typecheck` — passed

## Risks / manual review notes

- Low risk: the change permits only the existing top-level `persistenceStrategy` schema field; nested or unrelated unsupported settings paths remain rejected.
- No manual WebUI run was performed; the bridge test exercises the exact whole-object RPC mutation used by the dialog.

Closes #43
