### PR TITLE
fix(subagent): recover committed tool receipts

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -46,6 +46,8 @@ export interface ToolExecution {
   signal: AbortSignal
   agent?: HostAgent
   name?: string
+  /** Parsed tool arguments, available on the authoritative tools/result event. */
+  arguments?: unknown
   parent?: symbol
   token?: symbol
   /** End the current model turn after an authoritative terminal tool call. */

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -51,6 +51,25 @@ const RESULT_TOOL_OUTPUT_SCHEMA = {
   required: ['recorded'],
   additionalProperties: false,
 } as const
+const WRITE_ACTIONS = ['stored', 'updated', 'added', 'replaced', 'removed', 'skipped', 'forgotten', 'linked', 'created', 'merged', 'failed'] as const
+const WRITE_ACTION_SET = new Set<string>(WRITE_ACTIONS)
+const WRITE_OPERATION_RESULT_TOOL: Record<string, string> = {
+  remember: 'mnemon_remember',
+  'supervised-writeback': 'mnemon_remember',
+  link: 'mnemon_link',
+  forget: 'mnemon_forget',
+  'create-memory-body': 'mnemon_memory_body_create',
+  'update-memory-body': 'mnemon_memory_body_update',
+  'merge-memory-bodies': 'mnemon_memory_body_merge',
+}
+const WRITE_TOOL_FALLBACK_ACTION: Record<string, string> = {
+  mnemon_remember: 'stored',
+  mnemon_link: 'linked',
+  mnemon_forget: 'forgotten',
+  mnemon_memory_body_create: 'created',
+  mnemon_memory_body_update: 'updated',
+  mnemon_memory_body_merge: 'merged',
+}
 
 interface HostToolRegistry {
   register(definition: ToolDefinition): unknown
@@ -64,6 +83,21 @@ interface HostResultToolRuntime {
 interface CapturedSubagentResult {
   agentId: string
   value: unknown
+}
+
+interface CapturedToolReceipt extends CapturedSubagentResult {
+  name: string
+  arguments: unknown
+}
+
+interface HostToolResultObservation {
+  isError?: boolean
+  value?: unknown
+}
+
+interface ToolReceiptRecovery {
+  kind: 'recall' | 'write'
+  terminalTools: readonly string[]
 }
 
 const INSIGHT_SCHEMA = {
@@ -94,7 +128,7 @@ const WRITE_SCHEMA = {
   type: 'object',
   properties: {
     summary: { type: 'string' },
-    action: { type: 'string', enum: ['stored', 'updated', 'added', 'replaced', 'removed', 'skipped', 'forgotten', 'linked', 'created', 'merged', 'failed'] },
+    action: { type: 'string', enum: [...WRITE_ACTIONS] },
     memoryBodyIds: { type: 'array', items: { type: 'string' } },
     documentIds: { type: 'array', items: { type: 'string' } },
   },
@@ -501,6 +535,93 @@ function insight(value: unknown): Insight | undefined {
   return result
 }
 
+function optionalObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : undefined
+}
+
+function addString(target: Set<string>, value: unknown): void {
+  if (typeof value === 'string' && value.trim() !== '') target.add(value)
+}
+
+function addStrings(target: Set<string>, value: unknown): void {
+  if (Array.isArray(value)) for (const entry of value) addString(target, entry)
+}
+
+function receiptMemoryBodyIds(receipt: CapturedToolReceipt): string[] {
+  const ids = new Set<string>()
+  const args = optionalObject(receipt.arguments)
+  const value = optionalObject(receipt.value)
+  for (const record of [args, value]) {
+    addString(ids, record?.memoryBodyId)
+    addString(ids, record?.targetMemoryBodyId)
+    addStrings(ids, record?.memoryBodyIds)
+    addStrings(ids, record?.sourceMemoryBodyIds)
+  }
+  if (receipt.name === 'mnemon_memory_body_create' || receipt.name === 'mnemon_memory_body_update') addString(ids, value?.id)
+  return [...ids]
+}
+
+function recoverRecallResult(receipts: readonly CapturedToolReceipt[]): Record<string, unknown> | undefined {
+  if (receipts.length === 0) return undefined
+  const results: Insight[] = []
+  const seen = new Set<string>()
+  const selectedMemoryBodyIds = new Set<string>()
+  let summary = ''
+  for (const receipt of receipts) {
+    for (const id of receiptMemoryBodyIds(receipt)) selectedMemoryBodyIds.add(id)
+    const value = optionalObject(receipt.value)
+    if (typeof value?.hint === 'string' && value.hint.trim() !== '') summary = value.hint
+    else if (typeof value?.summary === 'string' && value.summary.trim() !== '') summary = value.summary
+    if (Array.isArray(value?.sources)) {
+      for (const source of value.sources) addString(selectedMemoryBodyIds, optionalObject(source)?.memoryBodyId)
+    }
+    if (!Array.isArray(value?.results)) continue
+    for (const candidate of value.results) {
+      if (results.length >= 12) break
+      const entry = insight(candidate)
+      if (entry === undefined || typeof entry.memoryBodyId !== 'string' || typeof entry.memoryBodyName !== 'string') continue
+      const key = `${entry.memoryBodyId}\u0000${entry.id}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      selectedMemoryBodyIds.add(entry.memoryBodyId)
+      results.push(entry)
+    }
+  }
+  return { summary, selectedMemoryBodyIds: [...selectedMemoryBodyIds], results }
+}
+
+function recoverWriteResult(receipts: readonly CapturedToolReceipt[]): Record<string, unknown> | undefined {
+  const receipt = receipts.at(-1)
+  if (receipt === undefined) return undefined
+  const value = optionalObject(receipt.value)
+  const candidateAction = typeof value?.action === 'string' && WRITE_ACTION_SET.has(value.action) ? value.action : undefined
+  const action = candidateAction ?? WRITE_TOOL_FALLBACK_ACTION[receipt.name]
+  if (action === undefined) return undefined
+  const memoryBodyIds = new Set<string>()
+  const documentIds = new Set<string>()
+  for (const entry of receipts) {
+    for (const id of receiptMemoryBodyIds(entry)) memoryBodyIds.add(id)
+    addStrings(documentIds, optionalObject(entry.value)?.documentIds)
+  }
+  const summary = typeof value?.summary === 'string'
+    ? value.summary
+    : typeof value?.message === 'string' ? value.message : ''
+  return {
+    summary,
+    action,
+    memoryBodyIds: [...memoryBodyIds],
+    ...(documentIds.size === 0 ? {} : { documentIds: [...documentIds] }),
+  }
+}
+
+/** Recover only the bounded public result implied by a committed terminal tool receipt. */
+function recoverStructuredResult(recovery: ToolReceiptRecovery | undefined, receipts: readonly CapturedToolReceipt[]): Record<string, unknown> | undefined {
+  if (recovery === undefined) return undefined
+  const terminalTools = new Set(recovery.terminalTools)
+  const matching = receipts.filter(receipt => terminalTools.has(receipt.name))
+  return recovery.kind === 'recall' ? recoverRecallResult(matching) : recoverWriteResult(matching)
+}
+
 export function isSubagent(agent: HostAgent | undefined): boolean {
   return agent?.session.header?.origin === 'subagent'
 }
@@ -536,7 +657,10 @@ export class MnemonSubagentCoordinator {
 
   async recall(parent: HostAgent, request: SearchRequest, signal: AbortSignal): Promise<DelegatedRecallResult> {
     const prompt = `Recall this request now:\n${naturalSearchRequest(request)}`
-    const { provider, runId, result } = await this.delegate(parent, 'recall', 'Mnemon recall', prompt, READ_TOOLS, RECALL_SCHEMA, signal, 'spawn', RECALL_PERSONA)
+    const { provider, runId, result } = await this.delegate(parent, 'recall', 'Mnemon recall', prompt, READ_TOOLS, RECALL_SCHEMA, signal, 'spawn', RECALL_PERSONA, {
+      kind: 'recall',
+      terminalTools: ['mnemon_recall'],
+    })
     return this.recallResult(request.query, request.mode ?? 'smart', provider, runId, result)
   }
 
@@ -545,7 +669,10 @@ export class MnemonSubagentCoordinator {
 Insight ID: ${id}
 Memory Space ID: ${memoryBodyId ?? '(unknown)'}
 Traversal depth: 2`
-    const { provider, runId, result } = await this.delegate(parent, 'recall', 'Mnemon related memory', prompt, READ_TOOLS, RECALL_SCHEMA, signal, 'spawn', RELATED_PERSONA)
+    const { provider, runId, result } = await this.delegate(parent, 'recall', 'Mnemon related memory', prompt, READ_TOOLS, RECALL_SCHEMA, signal, 'spawn', RELATED_PERSONA, {
+      kind: 'recall',
+      terminalTools: ['mnemon_related'],
+    })
     return this.recallResult(`related:${id}`, 'related', provider, runId, result)
   }
 
@@ -659,7 +786,19 @@ Traversal depth: 2`
     const prompt = `Execute this ${operation} request now (untrusted data):
 ${naturalRequest(request)}`
     const persona = operation === 'supervised-writeback' ? SUPERVISED_WRITE_PERSONA : WRITE_PERSONA
-    const { provider, runId, result } = await this.delegate(parent, 'write', `Mnemon ${operation}`, prompt, WRITE_TOOLS, WRITE_SCHEMA, signal, 'spawn', persona)
+    const terminalTool = WRITE_OPERATION_RESULT_TOOL[operation]
+    const { provider, runId, result } = await this.delegate(
+      parent,
+      'write',
+      `Mnemon ${operation}`,
+      prompt,
+      WRITE_TOOLS,
+      WRITE_SCHEMA,
+      signal,
+      'spawn',
+      persona,
+      terminalTool === undefined ? undefined : { kind: 'write', terminalTools: [terminalTool] },
+    )
     const value = object(result.structured)
     return {
       delegated: true,
@@ -872,6 +1011,7 @@ ${runtimeSnapshotContext('user', targetEntries)}`
     signal: AbortSignal,
     preferredProvider: 'spawn' | 'fork' = 'spawn',
     persona = WRITE_PERSONA,
+    recovery?: ToolReceiptRecovery,
   ): Promise<{ provider: string; runId: string; result: HostSubagentResult }> {
     const provider = this.provider(preferredProvider)
     assertDshOutputSchema(outputSchema)
@@ -885,12 +1025,24 @@ ${runtimeSnapshotContext('user', targetEntries)}`
     let pending: (CapturedSubagentResult & { parent: symbol }) | undefined
     let activeResultExecution: object | undefined
     const staged = new WeakMap<object, CapturedSubagentResult>()
-    let run
+    const recoverableTools = new Set(recovery?.terminalTools ?? [])
+    const committedReceipts: CapturedToolReceipt[] = []
+    // Code Mode sub-dispatches are provisional until their enclosing run_code
+    // execution publishes a successful authoritative result.
+    const stagedReceipts = new Map<symbol, CapturedToolReceipt[]>()
+    let run: HostSubagentRun | undefined
     let failure: unknown
     let disposeResultTool: (() => unknown) | undefined
     let disposeResultObserver: (() => unknown) | undefined
     try {
-      const observer = this.resultRuntime.on('tools/result', ((execution: ToolExecution, result: { isError?: boolean }) => {
+      const observer = this.resultRuntime.on('tools/result', ((execution: ToolExecution, result: HostToolResultObservation) => {
+        if (execution.token !== undefined) {
+          const entries = stagedReceipts.get(execution.token)
+          if (entries !== undefined) {
+            stagedReceipts.delete(execution.token)
+            if (result.isError !== true) committedReceipts.push(...entries)
+          }
+        }
         if (execution.name === resultToolName) {
           const entry = staged.get(execution)
           if (entry === undefined) return
@@ -904,10 +1056,17 @@ ${runtimeSnapshotContext('user', targetEntries)}`
           }
           return
         }
-        if (pending === undefined || pending.parent !== execution.token) return
-        const entry = pending
-        pending = undefined
-        if (result.isError !== true && captured === undefined) captured = { agentId: entry.agentId, value: entry.value }
+        if (pending !== undefined && pending.parent === execution.token) {
+          const entry = pending
+          pending = undefined
+          if (result.isError !== true && captured === undefined) captured = { agentId: entry.agentId, value: entry.value }
+        }
+        if (execution.name === undefined || !recoverableTools.has(execution.name) || result.isError === true || !Object.hasOwn(result, 'value')) return
+        const agent = execution.agent
+        if (agent === undefined || !isSubagent(agent)) return
+        const receipt: CapturedToolReceipt = { agentId: agent.id, name: execution.name, arguments: execution.arguments, value: result.value }
+        if (execution.parent === undefined) committedReceipts.push(receipt)
+        else stagedReceipts.set(execution.parent, [...(stagedReceipts.get(execution.parent) ?? []), receipt])
       }) as never)
       if (typeof observer !== 'function') throw new Error('dsh-mnemon subagent result observer registration did not return a disposer')
       disposeResultObserver = observer as () => unknown
@@ -946,20 +1105,26 @@ Completion protocol: call \`${resultToolName}\` exactly once with the final resu
         toolFilter: { allow: [...tools, resultToolName] },
         persona: completionPersona,
       })
-      const result = await run.result
-      if (captured !== undefined && captured.agentId !== run.id) throw new Error('Mnemon subagent result was recorded by a different child')
-      const structured = captured?.value ?? result.structured
+      const activeRun = run
+      const result = await activeRun.result
+      if (captured !== undefined && captured.agentId !== activeRun.id) throw new Error('Mnemon subagent result was recorded by a different child')
+      let structured = captured?.value ?? result.structured
+      if (structured === undefined && result.stopReason === 'completed') {
+        // Do not rerun a mutation after a missed handoff. A matching successful
+        // tool receipt is already the host's authoritative commit evidence.
+        structured = recoverStructuredResult(recovery, committedReceipts.filter(receipt => receipt.agentId === activeRun.id))
+      }
       if (structured !== undefined) assertDshOutputValue(outputSchema, structured)
       if (result.stopReason !== 'completed') {
-        const detail = subagentFailureDetail(run)
+        const detail = subagentFailureDetail(activeRun)
         throw new Error(`memory subagent stopped with ${result.stopReason}${detail === undefined ? '' : `: ${detail}`}`)
       }
       if (structured === undefined) throw new Error('memory subagent completed without recording its result')
       this.counters[operation === 'recall' ? 'recalls' : operation === 'write' ? 'writes' : operation === 'review' ? 'reviews' : operation === 'placement' ? 'placements' : operation === 'migration' ? 'migrations' : operation === 'compaction' ? 'compactions' : operation === 'document-archive' ? 'documentArchives' : operation === 'metadata-maintenance' ? 'metadataMaintenances' : 'answers'] += 1
-      this.counters.lastRunId = run.id
+      this.counters.lastRunId = activeRun.id
       if (operation !== 'answer') this.counters.lastOperation = operation
       this.counters.lastAt = new Date().toISOString()
-      return { provider, runId: run.id, result: { ...result, structured } }
+      return { provider, runId: activeRun.id, result: { ...result, structured } }
     } catch (error) {
       this.counters.failures += 1
       failure = error

--- a/tests/subagent.spec.ts
+++ b/tests/subagent.spec.ts
@@ -95,6 +95,46 @@ function createCoordinator(host: HostSubagentsService, runtime?: RuntimeMemoryCo
   return new MnemonSubagentCoordinator(host, runtime, documents, toolRegistry().value)
 }
 
+function observedSubagents(
+  resultTools: ReturnType<typeof toolRegistry>,
+  publish: (child: HostAgent) => void,
+  stopReason = 'completed',
+) {
+  const dispose = vi.fn(async () => {})
+  const child = parent('subagent')
+  child.id = 'child-run-1'
+  const start = vi.fn(async () => {
+    publish(child)
+    return { id: child.id, result: Promise.resolve({ output: [], stopReason }), dispose, localAgent: child }
+  })
+  const value = {
+    list: vi.fn(() => ['spawn']),
+    getProvider: vi.fn(() => ({ capabilities })),
+    start,
+  } as unknown as HostSubagentsService
+  return { value, start, dispose, child }
+}
+
+function emitSuccessfulToolResult(
+  resultTools: ReturnType<typeof toolRegistry>,
+  child: HostAgent,
+  name: string,
+  argumentsValue: unknown,
+  value: unknown,
+  parentToken?: symbol,
+) {
+  const execution = {
+    name,
+    arguments: argumentsValue,
+    token: Symbol(name),
+    ...(parentToken === undefined ? {} : { parent: parentToken }),
+    agent: child,
+    signal: new AbortController().signal,
+  }
+  resultTools.emit('tools/result', execution, { isError: false, value })
+  return execution
+}
+
 describe('Mnemon memory subagent coordinator', () => {
   it('rejects structured-output keywords outside the DSH schema subset', () => {
     expect(() => assertDshOutputSchema({
@@ -224,7 +264,105 @@ describe('Mnemon memory subagent coordinator', () => {
     for (const disposer of resultTools.disposers) expect(disposer).toHaveBeenCalledOnce()
   })
 
-  it('fails closed when a child completes without calling its result tool', async () => {
+  it('recovers recall evidence from an authoritative native tool receipt when the child omits its terminal result', async () => {
+    const resultTools = toolRegistry()
+    const host = observedSubagents(resultTools, child => {
+      emitSuccessfulToolResult(resultTools, child, 'mnemon_recall', { query: 'database', memoryBodyIds: ['project'] }, {
+        query: 'database',
+        mode: 'smart',
+        hint: 'Project memory matched.',
+        results: [{ id: 'm1', content: 'Use SQLite.', memoryBodyId: 'project', memoryBodyName: 'Project' }],
+        sources: [{ memoryBodyId: 'project' }],
+      })
+    })
+    const coordinator = new MnemonSubagentCoordinator(host.value, undefined, undefined, resultTools.value)
+
+    await expect(coordinator.recall(parent(), { query: 'database' }, new AbortController().signal)).resolves.toMatchObject({
+      results: [{ id: 'm1', content: 'Use SQLite.', memoryBodyId: 'project' }],
+      hint: 'Project memory matched.',
+      delegation: { runId: 'child-run-1', selectedMemoryBodyIds: ['project'] },
+    })
+    expect(host.start).toHaveBeenCalledOnce()
+    expect(coordinator.snapshot()).toMatchObject({ recalls: 1, failures: 0 })
+  })
+
+  it('recovers a committed write receipt without retrying the mutation', async () => {
+    const resultTools = toolRegistry()
+    const host = observedSubagents(resultTools, child => {
+      emitSuccessfulToolResult(resultTools, child, 'mnemon_remember', { content: 'Use SQLite.', memoryBodyId: 'project' }, {
+        action: 'added',
+        message: 'Stored durable project memory.',
+        memoryBodyId: 'project',
+        memoryBodyName: 'Project',
+      })
+    })
+    const coordinator = new MnemonSubagentCoordinator(host.value, undefined, undefined, resultTools.value)
+
+    await expect(coordinator.remember(parent(), { content: 'Use SQLite.', memoryBodyId: 'project' }, new AbortController().signal)).resolves.toMatchObject({
+      delegated: true,
+      action: 'added',
+      summary: 'Stored durable project memory.',
+      memoryBodyIds: ['project'],
+    })
+    expect(host.start).toHaveBeenCalledOnce()
+    expect(coordinator.snapshot()).toMatchObject({ writes: 1, failures: 0 })
+  })
+
+  it('commits a nested Code Mode receipt only after the enclosing run_code succeeds', async () => {
+    const resultTools = toolRegistry()
+    const host = observedSubagents(resultTools, child => {
+      const outerToken = Symbol('run-code')
+      emitSuccessfulToolResult(resultTools, child, 'mnemon_remember', { content: 'Use SQLite.' }, {
+        action: 'added', memoryBodyId: 'project', memoryBodyName: 'Project',
+      }, outerToken)
+      resultTools.emit('tools/result', {
+        name: 'run_code', arguments: {}, token: outerToken, agent: child, signal: new AbortController().signal,
+      }, { isError: false, value: null })
+    })
+    const coordinator = new MnemonSubagentCoordinator(host.value, undefined, undefined, resultTools.value)
+
+    await expect(coordinator.remember(parent(), { content: 'Use SQLite.' }, new AbortController().signal)).resolves.toMatchObject({
+      action: 'added', memoryBodyIds: ['project'],
+    })
+  })
+
+  it('discards a nested receipt when the enclosing Code Mode call fails', async () => {
+    const resultTools = toolRegistry()
+    const host = observedSubagents(resultTools, child => {
+      const outerToken = Symbol('run-code')
+      emitSuccessfulToolResult(resultTools, child, 'mnemon_remember', { content: 'Use SQLite.' }, {
+        action: 'added', memoryBodyId: 'project', memoryBodyName: 'Project',
+      }, outerToken)
+      resultTools.emit('tools/result', {
+        name: 'run_code', arguments: {}, token: outerToken, agent: child, signal: new AbortController().signal,
+      }, { isError: true })
+    })
+    const coordinator = new MnemonSubagentCoordinator(host.value, undefined, undefined, resultTools.value)
+
+    await expect(coordinator.remember(parent(), { content: 'Use SQLite.' }, new AbortController().signal)).rejects.toThrow('completed without recording its result')
+  })
+
+  it('does not recover partial or failed child runs from unrelated successful tools', async () => {
+    const resultTools = toolRegistry()
+    const partial = observedSubagents(resultTools, child => {
+      emitSuccessfulToolResult(resultTools, child, 'mnemon_memory_body_create', { name: 'Project', description: 'Project decisions.' }, {
+        id: 'project', name: 'Project', description: 'Project decisions.',
+      })
+    })
+    const partialCoordinator = new MnemonSubagentCoordinator(partial.value, undefined, undefined, resultTools.value)
+    await expect(partialCoordinator.remember(parent(), { content: 'Use SQLite.' }, new AbortController().signal)).rejects.toThrow('completed without recording its result')
+
+    const failedTools = toolRegistry()
+    const failed = observedSubagents(failedTools, child => {
+      emitSuccessfulToolResult(failedTools, child, 'mnemon_remember', { content: 'Use SQLite.' }, {
+        action: 'added', memoryBodyId: 'project', memoryBodyName: 'Project',
+      })
+    }, 'error')
+    const failedCoordinator = new MnemonSubagentCoordinator(failed.value, undefined, undefined, failedTools.value)
+    await expect(failedCoordinator.remember(parent(), { content: 'Use SQLite.' }, new AbortController().signal)).rejects.toThrow('stopped with error')
+  })
+
+  it('fails closed when a child completes without a terminal result or matching successful tool receipt', async () => {
     const host = subagents(undefined)
     const coordinator = createCoordinator(host.value)
     await expect(coordinator.recall(parent(), { query: 'x' }, new AbortController().signal)).rejects.toThrow('completed without recording its result')


### PR DESCRIPTION
## 摘要 / Summary

修复子 Agent 已成功执行 Mnemon 终态工具、但未调用 UUID 结果工具时被误报为失败的问题。Host 现在可从同一子 Agent 的权威 `tools/result` 回执恢复受约束的结构化结果，同时保持严格工具白名单、失败关闭语义，并避免重试已经提交的写操作。

Fix the false failure reported when a memory subagent successfully executes its terminal Mnemon tool but omits the UUID result-tool handoff. The Host can now recover a bounded structured result from authoritative `tools/result` receipts from the same child while preserving the strict allowlist, fail-closed semantics, and no-retry behavior for committed mutations.

## 关联 Issue 或背景 / Related Issue or Context

Fixes #45

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [x] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [x] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [ ] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [x] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [x] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [x] 兼容性适配 / Compatibility change
- [ ] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin main --tags --prune
```

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

GPT-5.6

使用的编码 Agent 工具 / Coding Agent tool used:

Codex

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

兼容 DSH rc.6 已发布的 `tools/result` 契约；UUID 结果工具仍是首选交接通道，只有同一子 Agent 在正常完成后缺少结构化结果时，才使用与当前操作严格匹配的成功终态工具回执。Code Mode 内部回执只有在外层 `run_code` 成功后才会提交。工具白名单、Provider、配置、存储格式、RPC、公开工具 schema 和现有数据均不变，也不会重试已提交的写操作。回滚仅恢复旧行为，可能重新出现成功操作被误报失败的问题。

Compatible with the published DSH rc.6 `tools/result` contract. The UUID result tool remains the primary handoff channel; a successful terminal-tool receipt strictly matching the current operation is used only when the same child completes normally without a structured result. Nested Code Mode receipts are committed only after the enclosing `run_code` succeeds. Tool allowlists, Providers, configuration, storage formats, RPC, public tool schemas, and existing data remain unchanged, and committed writes are never retried. Rolling back only restores the previous false-negative behavior.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm exec vitest run tests/subagent.spec.ts
pnpm run typecheck
pnpm run verify
```

结果摘要 / Result summary:

- 子 Agent 定向测试：22/22 通过，包括 Native、Code Mode 成功提交、Code Mode 外层失败丢弃、非终态工具与异常停止保持失败关闭，以及写操作不重试。
- TypeScript 类型检查通过。
- 完整验证通过：351 项测试通过，1 项仅适用于 Windows 的测试在本机跳过；确定性构建、Headless 激活（35 个工具，其中 5 个 Mnemon 工具）、包内容检查、publint strict 与 attw 均通过。
- Subagent suite: 22/22 passed, covering Native recovery, successful Code Mode commit, discard after outer Code Mode failure, fail-closed behavior for unrelated tools and abnormal stops, and no mutation retry.
- TypeScript type checking passed.
- Full verification passed: 351 tests passed and one Windows-only test was skipped locally; deterministic build, Headless activation (35 tools including 5 Mnemon tools), package checks, publint strict, and attw all passed.

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence:

这是 Host 内部结果交接修复，没有适合截图的 UI。自动化回归使用合成数据模拟了 Native 与 Code Mode 的权威 `tools/result` 回执，确认成功操作返回结构化结果且写操作只执行一次；完整验证结果见上方。

This is an internal Host handoff fix with no UI suitable for screenshots. Automated regressions use synthetic data to simulate authoritative Native and Code Mode `tools/result` receipts, confirming that successful operations return structured results and writes execute exactly once; full verification results are listed above.
