### PR TITLE
chore: prepare v0.2.10 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center"><strong>English</strong> · <a href="./README.zh-CN.md">简体中文</a></p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.9-5b5bd6" alt="release v0.2.9">
+  <img src="https://img.shields.io/badge/release-v0.2.10-5b5bd6" alt="release v0.2.10">
   <img src="https://img.shields.io/badge/memory-3%20tiers-087c5b" alt="three memory tiers">
   <img src="https://img.shields.io/badge/providers-9-c66a09" alt="nine providers">
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A520-43853d" alt="Node.js 20 or newer">
@@ -22,7 +22,7 @@
 <p align="center">
   <a href="./docs/en/capabilities.md"><strong>Explore the capability map</strong></a> ·
   <a href="./docs/en/getting-started.md">Start in five minutes</a> ·
-  <a href="./docs/en/releases/v0.2.9.md">Read the v0.2.9 notes</a> ·
+  <a href="./docs/en/releases/v0.2.10.md">Read the v0.2.10 notes</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">Watch the widescreen demo</a>
 </p>
 
@@ -190,7 +190,7 @@ See [Operations, security, and troubleshooting](./docs/en/operations.md) for bac
 | Configure scope, routing, and model selection | [Configuration](./docs/en/configuration.md) |
 | Back up, update, or troubleshoot | [Operations](./docs/en/operations.md) |
 | Integrate tools, commands, or RPC | [Interface reference](./docs/en/interfaces.md) |
-| Review the release | [v0.2.9 release notes](./docs/en/releases/v0.2.9.md) |
+| Review the release | [v0.2.10 release notes](./docs/en/releases/v0.2.10.md) |
 
 See the [documentation hub](./docs/en/README.md) for the full map.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 <p align="center"><a href="./README.md">English</a> · <strong>简体中文</strong></p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.9-5b5bd6" alt="发布版本 v0.2.9">
+  <img src="https://img.shields.io/badge/release-v0.2.10-5b5bd6" alt="发布版本 v0.2.10">
   <img src="https://img.shields.io/badge/%E8%AE%B0%E5%BF%86-3%20%E5%B1%82-087c5b" alt="三层记忆">
   <img src="https://img.shields.io/badge/Provider-9-c66a09" alt="九种 Provider">
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A520-43853d" alt="Node.js 20 或更新版本">
@@ -22,7 +22,7 @@
 <p align="center">
   <a href="./docs/zh-CN/capabilities.md"><strong>先看能力地图</strong></a> ·
   <a href="./docs/zh-CN/getting-started.md">5 分钟开始</a> ·
-  <a href="./docs/zh-CN/releases/v0.2.9.md">v0.2.9 升级说明</a> ·
+  <a href="./docs/zh-CN/releases/v0.2.10.md">v0.2.10 升级说明</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">观看宽屏实机演示</a>
 </p>
 
@@ -190,7 +190,7 @@ dsh plugin --profile headless add "link:/absolute/path/to/dsh-mnemon"
 | 配置范围、路由与模型 | [配置参考](./docs/zh-CN/configuration.md) |
 | 备份、更新或排障 | [运维指南](./docs/zh-CN/operations.md) |
 | 接入工具、命令或 RPC | [接口参考](./docs/zh-CN/interfaces.md) |
-| 查看本次升级 | [v0.2.9 发布说明](./docs/zh-CN/releases/v0.2.9.md) |
+| 查看本次升级 | [v0.2.10 发布说明](./docs/zh-CN/releases/v0.2.10.md) |
 
 完整目录见[文档中心](./docs/zh-CN/README.md)。
 

--- a/docs/en/releases/v0.2.10.md
+++ b/docs/en/releases/v0.2.10.md
@@ -1,0 +1,31 @@
+# v0.2.10: Reliable Updates and Subagent Handoffs
+
+[简体中文](../../zh-CN/releases/v0.2.10.md) | **English** | [Capability map](../capabilities.md)
+
+v0.2.10 is a focused reliability patch for authorized remote management, in-app package updates, Memory System settings, and delegated memory operations.
+
+## Fixed
+
+- Trusted remote WebUI sessions now derive memory-write controls and assistant-message save actions from the Host settings capability grant instead of the transport location. Explicitly authorized remote management works while read-only sessions remain restricted.
+- The in-app dsh-mnemon updater now runs `pnpm update` inside the DSH profile that owns the installation, preventing `ERR_PNPM_NO_PKG_MANIFEST` failures caused by an unrelated process working directory.
+- The Memory System dialog can save the complete existing `persistenceStrategy` object through the settings bridge. Unsupported top-level fields remain rejected.
+- Memory subagents can recover a bounded result from an authoritative successful terminal-tool receipt when the child omits its UUID result-tool handoff. Successful recall and write operations no longer surface the false `memory subagent completed without recording its result` error.
+
+## Safety and compatibility
+
+- The UUID result tool remains the primary completion channel. Strict tool allowlists are unchanged, and unrelated tools, failed receipts, abnormal child stops, and failed enclosing Code Mode calls still fail closed.
+- Already committed writes are never retried, avoiding duplicate side effects. Nested Code Mode receipts are accepted only after the enclosing `run_code` succeeds.
+- Storage formats, Provider connection formats, RPC permissions, public tool schemas, and configuration keys are unchanged. Existing data requires no migration.
+- Updating dsh-mnemon and restarting the affected DSH profile is sufficient.
+
+## Repository maintenance
+
+- Bilingual Issue Forms, PR templates, contribution guides, and automated contribution checks now define the repository's maintenance workflow. This does not change the installed runtime.
+
+## Verification
+
+- The complete local suite passes with 351 tests; one Windows-only smoke test is skipped only on non-Windows local runs.
+- Focused coverage exercises authorized remote controls, profile-owned version updates, persistence-strategy settings, Native tool receipts, successful and failed Code Mode handoffs, fail-closed paths, and no-retry write behavior.
+- Type checking, deterministic builds, Headless activation, package validation, publint, attw, and CI on Ubuntu and Windows pass.
+
+See the [v0.2.9 release notes](./v0.2.9.md) for the previous patch release.

--- a/docs/zh-CN/releases/v0.2.10.md
+++ b/docs/zh-CN/releases/v0.2.10.md
@@ -1,0 +1,31 @@
+# v0.2.10：可靠更新与子 Agent 结果交接
+
+**简体中文** | [English](../../en/releases/v0.2.10.md) | [能力地图](../capabilities.md)
+
+v0.2.10 是一次聚焦可靠性的补丁发布，覆盖可信远程管理、应用内包更新、记忆系统设置与委派记忆操作。
+
+## 修复
+
+- 可信远程 WebUI 现在根据 Host 授予的设置能力控制记忆写入与助手消息保存，不再根据传输位置判断。明确授权的远程管理可以正常使用，只读会话仍保持受限。
+- 应用内 dsh-mnemon 更新器现在会在实际拥有该安装的 DSH profile 内执行 `pnpm update`，避免无关进程工作目录导致 `ERR_PNPM_NO_PKG_MANIFEST`。
+- 记忆系统对话框现在可以通过设置桥保存完整的已有 `persistenceStrategy` 对象；不受支持的顶层字段仍会被拒绝。
+- 当子 Agent 遗漏 UUID 结果工具交接时，Mnemon 可以从权威的成功终态工具回执恢复受约束的结果。已经成功的召回与写入不再误报 `memory subagent completed without recording its result`。
+
+## 安全与兼容性
+
+- UUID 结果工具仍是首选完成通道，严格工具白名单保持不变；无关工具、失败回执、子 Agent 异常停止和外层 Code Mode 失败仍然保持失败关闭。
+- 已提交的写操作不会被重试，从而避免重复副作用。Code Mode 内部回执只有在外层 `run_code` 成功后才会被接受。
+- 存储格式、Provider 连接格式、RPC 权限、公开工具 schema 和配置键均未改变，已有数据无需迁移。
+- 更新 dsh-mnemon 并重启受影响的 DSH profile 即可。
+
+## 仓库维护
+
+- 双语 Issue Forms、PR 模板、贡献指南和自动贡献检查现在共同定义仓库维护流程，不改变已安装的运行时。
+
+## 验证
+
+- 本地完整测试套件 351 项通过；Windows 专用 smoke test 只会在非 Windows 本地环境跳过。
+- 定向覆盖可信远程控制、profile 内版本更新、持久化策略设置、Native 工具回执、Code Mode 成功与失败交接、失败关闭路径以及写操作不重试。
+- 类型检查、确定性构建、Headless 激活、发布包校验、publint、attw，以及 Ubuntu 与 Windows CI 均通过。
+
+上一个补丁版本见 [v0.2.9 发布说明](./v0.2.9.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mnemon",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Three-tier memory control plane for DeepSeek Harness: persistent runtime context, searchable project documents, pluggable long-term memory, smart routing, supervised agent workflows, WebUI, and headless tools.",
   "keywords": [
     "deepseek-harness",


### PR DESCRIPTION
## 摘要 / Summary

准备 dsh-mnemon v0.2.10 补丁发布：递增包版本，新增中英文发布说明，并将 README 的发布徽章与入口更新到 v0.2.10。本版本汇总 v0.2.9 之后已经合入的可信远程管理、应用内更新、持久化策略保存和子 Agent 结果交接修复。

Prepare the dsh-mnemon v0.2.10 patch release by bumping the package version, adding bilingual release notes, and updating README release badges and entry points. This release packages the trusted remote management, in-app update, persistence-strategy settings, and subagent result-handoff fixes merged after v0.2.9.

## 关联 Issue 或背景 / Related Issue or Context

N/A — 这是维护者明确要求的补丁发布，打包已经通过 #36、#42、#44 和 #48 合入的修复；相关运行时 Issue 已分别处理。 / This is a maintainer-requested patch release packaging fixes already merged through #36, #42, #44, and #48; their runtime issues have already been handled.

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [x] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [x] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [ ] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [x] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin main --tags --prune
git switch -c agent/release-v0.2.10 origin/main
```

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

GPT-5.6

使用的编码 Agent 工具 / Coding Agent tool used:

Codex

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

本 PR 不增加新的运行时代码变更，只把 `main` 上已验证的修复发布为 0.2.10。存储格式、Provider 连接格式、RPC 权限、公开工具 schema 和配置键不变，已有数据无需迁移。回滚到 0.2.9 会重新暴露本次发布说明中列出的旧问题；升级后重启受影响的 DSH profile 即可。

This PR adds no new runtime code changes; it releases the already-verified fixes on `main` as 0.2.10. Storage formats, Provider connection formats, RPC permissions, public tool schemas, and configuration keys are unchanged, and existing data requires no migration. Rolling back to 0.2.9 re-exposes the previously fixed behavior listed in the notes; restart the affected DSH profile after updating.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm run verify
git diff --cached --check
```

结果摘要 / Result summary:

- 351 项测试通过，1 项 Windows-only smoke test 在 macOS 本地按预期跳过。
- 类型检查、64 个文件的确定性构建、Headless 激活（35 个工具，其中 5 个 Mnemon 工具）、71 个发布包文件校验、publint strict 和 attw 全部通过。
- Package metadata 的 repository、homepage、bugs 均指向 `omdsh-dev/dsh-mnemon`，版本为 0.2.10。
- 351 tests passed; one Windows-only smoke test was skipped as expected on macOS.
- Type checking, deterministic output for 64 files, Headless activation (35 tools including 5 Mnemon tools), 71-file package validation, publint strict, and attw all passed.
- Package repository, homepage, and bugs metadata point to `omdsh-dev/dsh-mnemon`, with version 0.2.10.

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence:

发布元数据已在本地验证：`package.json` 返回 0.2.10，中英文 README 均链接对应的 v0.2.10 发布说明，完整发布包校验通过。本 PR 本身不新增 UI 运行时行为，因此没有额外截图。

Release metadata was verified locally: `package.json` reports 0.2.10, both READMEs link to their matching v0.2.10 release notes, and full package validation passed. This PR introduces no additional UI runtime behavior, so no screenshot is applicable.
