### PR TITLE
fix(client): stabilize mobile dialog layering and gestures

### DIFF
--- a/src/client/MnemonDialog.tsx
+++ b/src/client/MnemonDialog.tsx
@@ -1,0 +1,347 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  type JSX,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { appearanceClass, useMnemonViewAppearance } from './MnemonViewAppearance.tsx'
+import css from './MnemonView.module.css'
+
+const SHEET_MEDIA = '(max-width: 760px)'
+const REDUCED_MOTION_MEDIA = '(prefers-reduced-motion: reduce)'
+const CLOSE_DURATION_MS = 240
+const SNAP_DURATION_MS = 280
+
+interface DragSession {
+  pointerId: number
+  captureTarget: HTMLDivElement
+  startY: number
+  initialOffset: number
+  lastY: number
+  lastTime: number
+  velocity: number
+  offset: number
+  height: number
+}
+
+export interface MnemonDialogProps {
+  title: string
+  closeLabel: string
+  description?: string
+  busy?: boolean
+  contentReady?: boolean
+  wide?: boolean
+  footer?: ReactNode
+  onClose: () => void
+  children: ReactNode
+}
+
+function matches(query: string): boolean {
+  return typeof window.matchMedia === 'function' && window.matchMedia(query).matches
+}
+
+function currentTransform(element: HTMLElement): string {
+  const value = window.getComputedStyle(element).transform
+  return value === '' || value === 'none' ? 'translate3d(0, 0, 0)' : value
+}
+
+function currentTranslateY(element: HTMLElement): number {
+  const transform = currentTransform(element)
+  if (transform === 'translate3d(0, 0, 0)') return 0
+  try {
+    return Math.max(new DOMMatrixReadOnly(transform).m42, 0)
+  } catch {
+    const matrix3d = transform.match(/^matrix3d\((.+)\)$/)
+    if (matrix3d !== null) return Math.max(Number(matrix3d[1]?.split(',')[13]) || 0, 0)
+    const matrix = transform.match(/^matrix\((.+)\)$/)
+    return matrix === null ? 0 : Math.max(Number(matrix[1]?.split(',')[5]) || 0, 0)
+  }
+}
+
+function cancelAnimations(element: HTMLElement | null): void {
+  if (element === null || typeof element.getAnimations !== 'function') return
+  element.getAnimations().forEach(animation => animation.cancel())
+}
+
+function releaseDragCapture(drag: DragSession): void {
+  try {
+    if (typeof drag.captureTarget.hasPointerCapture !== 'function' || drag.captureTarget.hasPointerCapture(drag.pointerId)) {
+      drag.captureTarget.releasePointerCapture?.(drag.pointerId)
+    }
+  } catch {
+    // Pointer capture can already be gone after a native cancellation or app switch.
+  }
+}
+
+function waitForAnimations(animations: Animation[], duration: number): Promise<void> {
+  return new Promise(resolve => {
+    let settled = false
+    const finish = (): void => {
+      if (settled) return
+      settled = true
+      window.clearTimeout(timeout)
+      resolve()
+    }
+    const timeout = window.setTimeout(finish, duration + 100)
+    void Promise.allSettled(animations.map(animation => animation.finished)).then(finish)
+  })
+}
+
+/** Shared top-layer dialog behavior for every Mnemon workspace action surface. */
+export function MnemonDialog(props: MnemonDialogProps): JSX.Element | null {
+  const appearance = useMnemonViewAppearance()
+  const titleId = useId()
+  const descriptionId = useId()
+  const backdropRef = useRef<HTMLDivElement | null>(null)
+  const dialogRef = useRef<HTMLElement | null>(null)
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null)
+  const returnFocusRef = useRef<HTMLElement | null>(null)
+  const dragRef = useRef<DragSession | null>(null)
+  const snapGenerationRef = useRef(0)
+  const closingRef = useRef(false)
+  const mountedRef = useRef(true)
+  const busyRef = useRef(props.busy === true)
+  const onCloseRef = useRef(props.onClose)
+  busyRef.current = props.busy === true
+  onCloseRef.current = props.onClose
+
+  const focusPreferredControl = useCallback(() => {
+    const control = dialogRef.current?.querySelector<HTMLElement>('[data-autofocus]:not(:disabled)')
+      ?? dialogRef.current?.querySelector<HTMLElement>('input:not(:disabled), textarea:not(:disabled), select:not(:disabled)')
+    control?.focus({ preventScroll: true })
+  }, [])
+
+  const finishClose = useCallback(() => {
+    if (mountedRef.current) onCloseRef.current()
+  }, [])
+
+  const requestClose = useCallback(() => {
+    if (busyRef.current || closingRef.current) return
+    const dialog = dialogRef.current
+    const backdrop = backdropRef.current
+    if (dialog === null || backdrop === null || matches(REDUCED_MOTION_MEDIA) || typeof dialog.animate !== 'function' || typeof backdrop.animate !== 'function') {
+      finishClose()
+      return
+    }
+
+    closingRef.current = true
+    snapGenerationRef.current += 1
+    dialog.dataset.closing = 'true'
+    backdrop.dataset.closing = 'true'
+    const sheet = matches(SHEET_MEDIA)
+    const fromTransform = currentTransform(dialog)
+    const fromBackdropOpacity = window.getComputedStyle(backdrop).opacity
+    cancelAnimations(dialog)
+    cancelAnimations(backdrop)
+    const easing = sheet ? 'cubic-bezier(.4, 0, 1, 1)' : 'cubic-bezier(.4, 0, .2, 1)'
+    const dialogAnimation = dialog.animate(sheet
+      ? [
+          { opacity: 1, transform: fromTransform },
+          { opacity: 1, transform: 'translate3d(0, calc(100% + 32px), 0)' },
+        ]
+      : [
+          { opacity: 1, transform: fromTransform },
+          { opacity: 0, transform: 'translate3d(0, 8px, 0) scale(.985)' },
+        ], { duration: CLOSE_DURATION_MS, easing, fill: 'forwards' })
+    const backdropAnimation = backdrop.animate([{ opacity: fromBackdropOpacity }, { opacity: 0 }], { duration: CLOSE_DURATION_MS, easing: 'ease-out', fill: 'forwards' })
+    void waitForAnimations([dialogAnimation, backdropAnimation], CLOSE_DURATION_MS).then(finishClose)
+  }, [finishClose])
+
+  const resetDrag = useCallback(() => {
+    const dialog = dialogRef.current
+    const backdrop = backdropRef.current
+    if (dialog === null || backdrop === null) return
+    const drag = dragRef.current
+    const offset = drag?.offset ?? 0
+    const snapGeneration = ++snapGenerationRef.current
+    dragRef.current = null
+    if (drag !== null) releaseDragCapture(drag)
+    delete dialog.dataset.dragging
+    if (offset <= 0 || matches(REDUCED_MOTION_MEDIA) || typeof dialog.animate !== 'function' || typeof backdrop.animate !== 'function') {
+      dialog.style.removeProperty('--mn-modal-drag-y')
+      backdrop.style.removeProperty('opacity')
+      return
+    }
+    const dialogAnimation = dialog.animate([
+      { transform: currentTransform(dialog) },
+      { transform: 'translate3d(0, 0, 0)' },
+    ], { duration: SNAP_DURATION_MS, easing: 'cubic-bezier(.2, .8, .2, 1)', fill: 'forwards' })
+    const backdropAnimation = backdrop.animate([
+      { opacity: window.getComputedStyle(backdrop).opacity },
+      { opacity: 1 },
+    ], { duration: SNAP_DURATION_MS, easing: 'ease-out', fill: 'forwards' })
+    void waitForAnimations([dialogAnimation, backdropAnimation], SNAP_DURATION_MS).then(() => {
+      if (!mountedRef.current || snapGenerationRef.current !== snapGeneration) return
+      dialog.style.removeProperty('--mn-modal-drag-y')
+      backdrop.style.removeProperty('opacity')
+      dialogAnimation.cancel()
+      backdropAnimation.cancel()
+    })
+  }, [])
+
+  const beginDrag = (event: ReactPointerEvent<HTMLDivElement>): void => {
+    if (busyRef.current || closingRef.current || !event.isPrimary || !matches(SHEET_MEDIA)) return
+    if (event.pointerType === 'mouse' && event.button !== 0) return
+    const dialog = dialogRef.current
+    if (dialog === null) return
+    snapGenerationRef.current += 1
+    const initialOffset = currentTranslateY(dialog)
+    const backdrop = backdropRef.current
+    const initialBackdropOpacity = backdrop === null ? '' : window.getComputedStyle(backdrop).opacity
+    cancelAnimations(dialog)
+    cancelAnimations(backdrop)
+    const time = event.timeStamp
+    dragRef.current = {
+      pointerId: event.pointerId,
+      captureTarget: event.currentTarget,
+      startY: event.clientY,
+      initialOffset,
+      lastY: event.clientY,
+      lastTime: time,
+      velocity: 0,
+      offset: initialOffset,
+      height: Math.max(dialog.getBoundingClientRect().height, 1),
+    }
+    dialog.dataset.dragging = 'true'
+    dialog.style.setProperty('--mn-modal-drag-y', `${initialOffset}px`)
+    if (backdrop !== null) backdrop.style.opacity = initialBackdropOpacity
+    try { event.currentTarget.setPointerCapture?.(event.pointerId) } catch { /* Global pointer listeners keep the gesture alive. */ }
+  }
+
+  const moveDrag = useCallback((event: PointerEvent): void => {
+    const drag = dragRef.current
+    const dialog = dialogRef.current
+    const backdrop = backdropRef.current
+    if (drag === null || dialog === null || backdrop === null || drag.pointerId !== event.pointerId) return
+    event.preventDefault()
+    const rawOffset = Math.max(0, drag.initialOffset + event.clientY - drag.startY)
+    const offset = rawOffset <= drag.height ? rawOffset : drag.height + (rawOffset - drag.height) * .16
+    const elapsed = Math.max(event.timeStamp - drag.lastTime, 1)
+    const sampleVelocity = (event.clientY - drag.lastY) / elapsed
+    drag.velocity = drag.velocity * .35 + sampleVelocity * .65
+    drag.lastY = event.clientY
+    drag.lastTime = event.timeStamp
+    drag.offset = offset
+    dialog.style.setProperty('--mn-modal-drag-y', `${offset}px`)
+    backdrop.style.opacity = String(1 - Math.min((offset / drag.height) * .58, .52))
+  }, [])
+
+  const endDrag = useCallback((event: PointerEvent): void => {
+    const drag = dragRef.current
+    if (drag === null || drag.pointerId !== event.pointerId) return
+    const threshold = Math.min(Math.max(drag.height * .22, 96), 180)
+    const shouldClose = drag.offset >= threshold || (drag.offset >= 28 && drag.velocity >= .55)
+    if (shouldClose) {
+      dragRef.current = null
+      releaseDragCapture(drag)
+      if (dialogRef.current !== null) delete dialogRef.current.dataset.dragging
+      requestClose()
+    } else {
+      resetDrag()
+    }
+  }, [requestClose, resetDrag])
+
+  const cancelDrag = useCallback((event: PointerEvent): void => {
+    if (dragRef.current?.pointerId === event.pointerId) resetDrag()
+  }, [resetDrag])
+
+  useLayoutEffect(() => {
+    returnFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const firstControl = dialogRef.current?.querySelector<HTMLElement>('[data-autofocus]:not(:disabled)')
+      ?? dialogRef.current?.querySelector<HTMLElement>('input:not(:disabled), textarea:not(:disabled), select:not(:disabled)')
+      ?? dialogRef.current?.querySelector<HTMLElement>('button:not(:disabled)')
+    firstControl?.focus({ preventScroll: true })
+    return () => { if (returnFocusRef.current?.isConnected === true) returnFocusRef.current.focus({ preventScroll: true }) }
+  }, [])
+
+  useLayoutEffect(() => {
+    if (props.contentReady !== true) return
+    const active = document.activeElement
+    if (active !== closeButtonRef.current && active !== dialogRef.current) return
+    focusPreferredControl()
+  }, [focusPreferredControl, props.contentReady])
+
+  useEffect(() => {
+    mountedRef.current = true
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      mountedRef.current = false
+      document.body.style.overflow = previousOverflow
+    }
+  }, [])
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        requestClose()
+        return
+      }
+      if (event.key !== 'Tab' || closingRef.current) return
+      const controls = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>('button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), a[href], [tabindex]:not([tabindex="-1"])') ?? []).filter(control => control.getAttribute('aria-hidden') !== 'true')
+      const first = controls[0]
+      const last = controls.at(-1)
+      if (first === undefined || last === undefined) {
+        event.preventDefault()
+        return
+      }
+      const active = document.activeElement
+      if (event.shiftKey && (active === first || !dialogRef.current?.contains(active))) {
+        event.preventDefault(); last.focus()
+      } else if (!event.shiftKey && (active === last || !dialogRef.current?.contains(active))) {
+        event.preventDefault(); first.focus()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [requestClose])
+
+  useEffect(() => {
+    const cancelOnBlur = (): void => { if (dragRef.current !== null) resetDrag() }
+    const cancelWhenHidden = (): void => { if (document.visibilityState === 'hidden') cancelOnBlur() }
+    window.addEventListener('pointermove', moveDrag, { passive: false })
+    window.addEventListener('pointerup', endDrag)
+    window.addEventListener('pointercancel', cancelDrag)
+    window.addEventListener('blur', cancelOnBlur)
+    document.addEventListener('visibilitychange', cancelWhenHidden)
+    return () => {
+      window.removeEventListener('pointermove', moveDrag)
+      window.removeEventListener('pointerup', endDrag)
+      window.removeEventListener('pointercancel', cancelDrag)
+      window.removeEventListener('blur', cancelOnBlur)
+      document.removeEventListener('visibilitychange', cancelWhenHidden)
+    }
+  }, [cancelDrag, endDrag, moveDrag, resetDrag])
+
+  const interceptCloseControl = (event: ReactMouseEvent<HTMLElement>): void => {
+    const target = event.target instanceof Element ? event.target.closest<HTMLElement>('[data-dialog-close]') : null
+    if (target === null || !dialogRef.current?.contains(target)) return
+    event.preventDefault()
+    event.stopPropagation()
+    requestClose()
+  }
+
+  if (typeof document === 'undefined') return null
+  return createPortal(
+    <div className={css.modalPortal} data-mnemon-dialog-portal="">
+      <div className={appearanceClass(appearanceClass(css.modalTheme, css.shell), appearance.classes.shell)}>
+        <div ref={backdropRef} className={appearanceClass(css.modalBackdrop, appearance.classes.modalBackdrop)} onPointerDown={event => { if (event.target === event.currentTarget) requestClose() }}>
+          <section ref={dialogRef} className={appearanceClass(appearanceClass(css.modal, appearance.classes.modal), props.wide === true ? css.modalWide : undefined)} role="dialog" aria-modal="true" aria-busy={props.contentReady === false || props.busy === true ? true : undefined} aria-labelledby={titleId} aria-describedby={props.description === undefined ? undefined : descriptionId} onClickCapture={interceptCloseControl}>
+            <div className={css.modalDragHandle} data-dialog-drag-handle="" aria-hidden="true" onPointerDown={beginDrag} onLostPointerCapture={event => { if (dragRef.current?.pointerId === event.pointerId) resetDrag() }}><span /></div>
+            <header><div><h2 id={titleId}>{props.title}</h2>{props.description !== undefined && <p id={descriptionId}>{props.description}</p>}</div><button ref={closeButtonRef} type="button" className={css.iconButton} disabled={props.busy} onClick={requestClose} aria-label={props.closeLabel}>×</button></header>
+            <div className={css.modalBody}>{props.children}</div>
+            {props.footer !== undefined && <footer className={css.modalFooter}>{props.footer}</footer>}
+          </section>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/client/MnemonSidebarView.module.css
+++ b/src/client/MnemonSidebarView.module.css
@@ -748,7 +748,7 @@
   .shell .canvas[data-lock-page-header] [class*='pageHeader'] { margin-inline: -12px; padding-inline: 12px; }
   .shell .modalBackdrop { align-items: flex-end; padding: max(10px, env(safe-area-inset-top, 0px)) 0 0; }
   .shell .modal, .shell .modal.modalWide { width: 100vw; max-height: calc(100vh - max(10px, env(safe-area-inset-top, 0px))); border-radius: 18px 18px 0 0; border-bottom: 0; }
-  .shell .modal::before { background: var(--dsw-alias-border-l2); }
+  .shell .modalDragHandle span { background: var(--dsw-alias-border-l2); }
   .shell .modal > header { gap: 12px; padding: 10px max(14px, env(safe-area-inset-right, 0px)) 12px max(14px, env(safe-area-inset-left, 0px)); }
   .shell .modal > header p { display: -webkit-box; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
   .shell .modal > header [class*='iconButton'] { width: 44px; min-width: 44px; height: 44px; min-height: 44px; }

--- a/src/client/MnemonView.module.css
+++ b/src/client/MnemonView.module.css
@@ -676,8 +676,12 @@ button.readSourceCard:hover { border-color: color-mix(in srgb, var(--mn-provider
 .compactListProgress { display: grid; justify-items: stretch; gap: 7px; margin-top: 8px; padding: 10px 2px 2px; border-top: 1px solid var(--mn-line); color: var(--mn-faint); font-size: 10px; text-align: center; }
 .compactListProgress button { width: 100%; }
 
-.modalBackdrop { position: fixed; z-index: 1300; inset: 0; display: flex; align-items: center; justify-content: center; overflow: hidden; overscroll-behavior: contain; padding: 24px; background: color-mix(in srgb, #020617 54%, transparent); touch-action: none; }
-.modal { display: flex; box-sizing: border-box; width: min(680px, calc(100vw - 48px)); min-height: 0; max-height: calc(100vh - 48px); flex-direction: column; overflow: hidden; border: 1px solid var(--mn-line); border-radius: 14px; background: var(--mn-layer-1); box-shadow: 0 22px 60px rgb(2 6 23 / 22%); touch-action: auto; }
+.modalPortal { position: fixed; z-index: 2147483647; inset: 0; isolation: isolate; pointer-events: none; }
+.modalTheme.modalTheme.modalTheme { position: absolute; inset: 0; display: block; width: auto; height: auto; min-width: 0; min-height: 0; overflow: visible; color: var(--mn-text); background: transparent; pointer-events: none; }
+.modalBackdrop { position: fixed; z-index: 0; inset: 0; display: flex; align-items: center; justify-content: center; overflow: hidden; overscroll-behavior: contain; padding: 24px; background: color-mix(in srgb, #020617 54%, transparent); touch-action: none; pointer-events: auto; animation: mnemon-dialog-backdrop-enter 180ms ease-out both; }
+.modal { display: flex; box-sizing: border-box; width: min(680px, calc(100vw - 48px)); min-height: 0; max-height: calc(100vh - 48px); flex-direction: column; overflow: hidden; border: 1px solid var(--mn-line); border-radius: 14px; background: var(--mn-layer-1); box-shadow: 0 22px 60px rgb(2 6 23 / 22%); touch-action: auto; transform-origin: 50% 100%; backface-visibility: hidden; will-change: transform, opacity; animation: mnemon-dialog-enter 220ms cubic-bezier(.2, .75, .2, 1) both; }
+.modalBackdrop[data-closing], .modal[data-closing] { pointer-events: none; }
+.modalDragHandle { display: none; }
 .modalWide { width: min(780px, calc(100vw - 48px)); }
 .modal > header { display: flex; flex: none; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 15px 18px; border-bottom: 1px solid var(--mn-line); }
 .modal > header > div { min-width: 0; }
@@ -691,6 +695,9 @@ button.readSourceCard:hover { border-color: color-mix(in srgb, var(--mn-provider
 .modalFooterActions { display: flex; min-width: 0; align-items: center; justify-content: flex-end; gap: 8px; margin-left: auto; }
 .modalInlineStatus { margin: 12px 0 0; color: var(--mn-muted); font-size: 11px; line-height: 1.5; overflow-wrap: anywhere; }
 @supports (height: 100dvh) { .modal { max-height: calc(100dvh - 48px); } }
+@keyframes mnemon-dialog-backdrop-enter { from { opacity: 0; } }
+@keyframes mnemon-dialog-enter { from { opacity: 0; transform: translate3d(0, 10px, 0) scale(.985); } }
+@keyframes mnemon-sheet-enter { from { transform: translate3d(0, calc(100% + 32px), 0); } to { transform: translate3d(0, var(--mn-modal-drag-y, 0px), 0); } }
 .metadataDialog { display: grid; gap: 12px; }
 .metadataToolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; color: var(--mn-muted); font-size: 10px; }
 .metadataToolbar > span { display: flex; min-width: 0; align-items: center; gap: 7px; }
@@ -846,8 +853,11 @@ button.readSourceCard:hover { border-color: color-mix(in srgb, var(--mn-provider
   .workspacePicker select { width: min(170px, 32vw); }
   .statusCluster > span:not(.statusDot) { display: none; }
   .modalBackdrop { align-items: flex-end; padding: max(10px, env(safe-area-inset-top, 0px)) 0 0; }
-  .modal, .modalWide { width: 100vw; max-height: calc(100vh - max(10px, env(safe-area-inset-top, 0px))); border-radius: 18px 18px 0 0; border-bottom: 0; }
-  .modal::before { display: block; width: 36px; height: 4px; flex: none; margin: 8px auto 0; border-radius: 999px; background: var(--mn-line-strong); content: ''; }
+  .modal, .modalWide { width: 100vw; max-height: calc(100vh - max(10px, env(safe-area-inset-top, 0px))); border-radius: 18px 18px 0 0; border-bottom: 0; transform: translate3d(0, var(--mn-modal-drag-y, 0px), 0); animation-name: mnemon-sheet-enter; animation-duration: 340ms; animation-timing-function: cubic-bezier(.2, .82, .2, 1); }
+  .modalDragHandle { display: grid; width: 100%; height: 28px; flex: none; place-items: center; cursor: grab; touch-action: none; user-select: none; }
+  .modalDragHandle span { width: 36px; height: 4px; border-radius: 999px; background: var(--mn-line-strong); transition: width 140ms ease, background-color 140ms ease; }
+  .modal[data-dragging] .modalDragHandle { cursor: grabbing; }
+  .modal[data-dragging] .modalDragHandle span { width: 44px; background: color-mix(in srgb, var(--mn-accent) 52%, var(--mn-line-strong)); }
   .modal > header { gap: 12px; padding: 10px max(14px, env(safe-area-inset-right, 0px)) 12px max(14px, env(safe-area-inset-left, 0px)); }
   .modal > header p { display: -webkit-box; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
   .modal > header .iconButton { width: 44px; height: 44px; margin: -4px -5px -4px 0; }
@@ -995,6 +1005,7 @@ button.readSourceCard:hover { border-color: color-mix(in srgb, var(--mn-provider
 
 @media (prefers-reduced-motion: reduce) {
   .shell *, .shell *::before, .shell *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
+  .modalBackdrop, .modal { animation: none !important; }
   .insightCard:hover { transform: none; }
   .flowConnector[data-active] i::before { display: none; }
 }

--- a/src/client/MnemonView.tsx
+++ b/src/client/MnemonView.tsx
@@ -1,4 +1,4 @@
-import { createContext, Fragment, useCallback, useContext, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type FormEvent, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
+import { createContext, Fragment, useCallback, useContext, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type FormEvent, type PointerEvent as ReactPointerEvent } from 'react'
 import { IconChevronLeftOutline14 } from '@deepseek-ai/dsh-client-ui-primitives'
 import { consumeMnemonAnchor, subscribeMnemonAnchor, type MnemonAnchor } from './anchor.ts'
 import Markdown from 'markdown-to-jsx'
@@ -43,6 +43,7 @@ import {
 } from '../shared/contracts.ts'
 import { MnemonClient } from './api.ts'
 import { translateZh, type MnemonKey, type MnemonTranslate } from './locales.ts'
+import { MnemonDialog, type MnemonDialogProps } from './MnemonDialog.tsx'
 import { MnemonLogo } from './MnemonLogo.tsx'
 import { ProviderIcon } from './ProviderIcon.tsx'
 import { useRequestVersion } from './use-request-version.ts'
@@ -315,68 +316,9 @@ function ProgressiveFooter(props: { visible: number; total: number; pageSize: nu
 }
 
 /** DSH-style action dialog shared by Sidebar add/write flows. */
-function SidebarModal(props: { title: string; description?: string; busy?: boolean; contentReady?: boolean; wide?: boolean; footer?: ReactNode; onClose: () => void; children: ReactNode }): JSX.Element {
+function SidebarModal(props: Omit<MnemonDialogProps, 'closeLabel'>): JSX.Element {
   const t = useT()
-  const appearance = useMnemonViewAppearance()
-  const titleId = useId()
-  const descriptionId = useId()
-  const dialogRef = useRef<HTMLElement | null>(null)
-  const closeButtonRef = useRef<HTMLButtonElement | null>(null)
-  const returnFocusRef = useRef<HTMLElement | null>(null)
-  const close = useCallback(() => { if (props.busy !== true) props.onClose() }, [props.busy, props.onClose])
-  const focusPreferredControl = useCallback(() => {
-    const control = dialogRef.current?.querySelector<HTMLElement>('[data-autofocus]:not(:disabled)')
-      ?? dialogRef.current?.querySelector<HTMLElement>('input:not(:disabled), textarea:not(:disabled), select:not(:disabled)')
-    control?.focus({ preventScroll: true })
-  }, [])
-  useLayoutEffect(() => {
-    returnFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
-    const firstControl = dialogRef.current?.querySelector<HTMLElement>('[data-autofocus]:not(:disabled)')
-      ?? dialogRef.current?.querySelector<HTMLElement>('input:not(:disabled), textarea:not(:disabled), select:not(:disabled)')
-      ?? dialogRef.current?.querySelector<HTMLElement>('button:not(:disabled)')
-    firstControl?.focus({ preventScroll: true })
-    return () => { if (returnFocusRef.current?.isConnected === true) returnFocusRef.current.focus({ preventScroll: true }) }
-  }, [])
-  useLayoutEffect(() => {
-    if (props.contentReady !== true) return
-    const active = document.activeElement
-    if (active !== closeButtonRef.current && active !== dialogRef.current) return
-    focusPreferredControl()
-  }, [focusPreferredControl, props.contentReady])
-  useEffect(() => {
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault()
-        close()
-        return
-      }
-      if (event.key !== 'Tab') return
-      const controls = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>('button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), a[href], [tabindex]:not([tabindex="-1"])') ?? []).filter(control => control.getAttribute('aria-hidden') !== 'true')
-      const first = controls[0]
-      const last = controls.at(-1)
-      if (first === undefined || last === undefined) {
-        event.preventDefault()
-        return
-      }
-      const active = document.activeElement
-      if (event.shiftKey && (active === first || !dialogRef.current?.contains(active))) {
-        event.preventDefault(); last.focus()
-      } else if (!event.shiftKey && (active === last || !dialogRef.current?.contains(active))) {
-        event.preventDefault(); first.focus()
-      }
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [close])
-  return (
-    <div className={appearanceClass(css.modalBackdrop, appearance.classes.modalBackdrop)} onPointerDown={event => { if (event.target === event.currentTarget) close() }}>
-      <section ref={dialogRef} className={appearanceClass(appearanceClass(css.modal, appearance.classes.modal), props.wide === true ? css.modalWide : undefined)} role="dialog" aria-modal="true" aria-busy={props.contentReady === false || props.busy === true ? true : undefined} aria-labelledby={titleId} aria-describedby={props.description === undefined ? undefined : descriptionId}>
-        <header><div><h2 id={titleId}>{props.title}</h2>{props.description !== undefined && <p id={descriptionId}>{props.description}</p>}</div><button ref={closeButtonRef} type="button" className={css.iconButton} disabled={props.busy} onClick={close} aria-label={t('common.cancel')}>×</button></header>
-        <div className={css.modalBody}>{props.children}</div>
-        {props.footer !== undefined && <footer className={css.modalFooter}>{props.footer}</footer>}
-      </section>
-    </div>
-  )
+  return <MnemonDialog {...props} closeLabel={t('common.cancel')} />
 }
 
 function EmptyState(props: { glyph: string; title: string; children: string }): JSX.Element {
@@ -566,7 +508,7 @@ function InsightCard(props: {
         )}
       </div>
     </article>
-    {appearance.surface === 'sidebar' && confirming && <SidebarModal title={t('card.confirmText')} description={`${insight.memoryBodyName ?? insight.memoryBodyId ?? ''}${insight.memoryBodyName === undefined && insight.memoryBodyId === undefined ? '' : ' · '}${insight.id}`} busy={forgetting} onClose={() => setConfirming(false)} footer={<div className={css.modalFooterActions}><button type="button" data-autofocus className={css.ghostButton} disabled={forgetting} onClick={() => setConfirming(false)}>{t('common.cancel')}</button><button type="button" className={css.dangerSolidButton} disabled={forgetting} onClick={() => void forget()}>{forgetting ? t('card.processing') : t('card.confirmForget')}</button></div>}><div className={css.bodyDeleteConfirm}><div className={css.bodyDeleteSummary}><p className={css.bodyDeleteContent}>{insight.content}</p><span>{meta.join(' · ')}</span></div></div></SidebarModal>}
+    {appearance.surface === 'sidebar' && confirming && <SidebarModal title={t('card.confirmText')} description={`${insight.memoryBodyName ?? insight.memoryBodyId ?? ''}${insight.memoryBodyName === undefined && insight.memoryBodyId === undefined ? '' : ' · '}${insight.id}`} busy={forgetting} onClose={() => setConfirming(false)} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close data-autofocus className={css.ghostButton} disabled={forgetting} onClick={() => setConfirming(false)}>{t('common.cancel')}</button><button type="button" className={css.dangerSolidButton} disabled={forgetting} onClick={() => void forget()}>{forgetting ? t('card.processing') : t('card.confirmForget')}</button></div>}><div className={css.bodyDeleteConfirm}><div className={css.bodyDeleteSummary}><p className={css.bodyDeleteContent}>{insight.content}</p><span>{meta.join(' · ')}</span></div></div></SidebarModal>}
     </>
   )
 }
@@ -1345,8 +1287,8 @@ function OverviewPage(props: { client: MnemonClient; metadataClient: MnemonClien
         {appearance.surface === 'buildin' && props.writeEnabled && !catalogUnavailable && <details className={css.bodyCreate} open={catalog?.total === 0 ? true : undefined}><summary>{t('overview.create')}</summary>{bodyCreateForm}</details>}
       </section>
       <div className={css.asyncRegion}><ReadSourcePanel title={t('overview.snapshotSources')} hint={t('overview.snapshotSourcesHint')} sources={graphSources} /></div>
-      {appearance.surface === 'sidebar' && creatingBodyOpen && <SidebarModal title={t('overview.createTitle')} description={t('overview.createDialogHint')} busy={creating} wide onClose={() => setCreatingBodyOpen(false)} footer={<div className={css.modalFooterActions}><button type="button" className={css.ghostButton} disabled={creating} onClick={() => setCreatingBodyOpen(false)}>{t('common.cancel')}</button><button type="submit" form={bodyCreateFormId} className={css.primaryButton} disabled={creating || bodyName.trim() === '' || bodyDescription.trim() === '' || !providerDraftComplete(selectedProvider, providerDrafts[bodyProviderId])}>{creating ? t('overview.creating') : t('overview.createAction')}</button></div>}>{bodyCreateForm}</SidebarModal>}
-      {metadataOpen && <SidebarModal title={t('overview.metadataTitle')} description={t('overview.metadataDescription')} busy={metadataBusy} wide onClose={() => setMetadataOpen(false)} footer={<><p className={css.modalFooterNote}>{t('overview.metadataSafety')}</p><div className={css.modalFooterActions}><button type="button" className={css.ghostButton} disabled={metadataBusy} onClick={() => setMetadataOpen(false)}>{t('common.cancel')}</button><button type="button" className={css.primaryButton} disabled={!props.agentAvailable || metadataSelection.length === 0} title={!props.agentAvailable ? t('overview.metadataUnavailable') : undefined} onClick={maintainMetadata}>{t('overview.metadataGenerate', { count: metadataSelection.length })}</button></div></>}><div className={css.metadataDialog}>
+      {appearance.surface === 'sidebar' && creatingBodyOpen && <SidebarModal title={t('overview.createTitle')} description={t('overview.createDialogHint')} busy={creating} wide onClose={() => setCreatingBodyOpen(false)} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close className={css.ghostButton} disabled={creating} onClick={() => setCreatingBodyOpen(false)}>{t('common.cancel')}</button><button type="submit" form={bodyCreateFormId} className={css.primaryButton} disabled={creating || bodyName.trim() === '' || bodyDescription.trim() === '' || !providerDraftComplete(selectedProvider, providerDrafts[bodyProviderId])}>{creating ? t('overview.creating') : t('overview.createAction')}</button></div>}>{bodyCreateForm}</SidebarModal>}
+      {metadataOpen && <SidebarModal title={t('overview.metadataTitle')} description={t('overview.metadataDescription')} busy={metadataBusy} wide onClose={() => setMetadataOpen(false)} footer={<><p className={css.modalFooterNote}>{t('overview.metadataSafety')}</p><div className={css.modalFooterActions}><button type="button" data-dialog-close className={css.ghostButton} disabled={metadataBusy} onClick={() => setMetadataOpen(false)}>{t('common.cancel')}</button><button type="button" className={css.primaryButton} disabled={!props.agentAvailable || metadataSelection.length === 0} title={!props.agentAvailable ? t('overview.metadataUnavailable') : undefined} onClick={maintainMetadata}>{t('overview.metadataGenerate', { count: metadataSelection.length })}</button></div></>}><div className={css.metadataDialog}>
         {!props.agentAvailable && <div className={css.inlineError} role="status">{t('overview.metadataUnavailable')}</div>}
         <div className={css.metadataToolbar}><span>{t('overview.metadataSelected', { count: metadataSelection.length })}{metadataRunningCount > 0 && <em>{t('overview.metadataRunningCount', { count: metadataRunningCount })}</em>}</span><button type="button" className={css.ghostButton} disabled={metadataSelectable.length === 0} onClick={() => setMetadataSelection(metadataAllSelected ? [] : metadataSelectable.map(body => body.id))}>{metadataAllSelected ? t('overview.metadataClear') : t('overview.metadataSelectAll')}</button></div>
         <div className={css.metadataList} aria-live="polite">{metadataCandidates.length === 0 && <div className={css.metadataEmpty}>{catalogLoading ? t('overview.metadataLoading') : t('overview.metadataEmpty')}</div>}{metadataCandidates.map(body => {
@@ -1355,8 +1297,8 @@ function OverviewPage(props: { client: MnemonClient; metadataClient: MnemonClien
           return <label key={body.id} data-provider={body.provider.id} data-selected={selected || undefined} data-refreshing={task?.status === 'running' || undefined} data-refreshed={task?.status === 'success' || undefined} data-failed={task?.status === 'error' || undefined}><input type="checkbox" checked={selected} disabled={task?.status === 'running'} onChange={event => setMetadataSelection(current => event.target.checked ? [...new Set([...current, body.id])] : current.filter(id => id !== body.id))} /><i className={css.choiceControl} data-kind="check" aria-hidden="true" /><span><strong>{body.name}</strong><small>{body.description || t('overview.noDescription')}</small><span><MemoryProviderBadge providerId={body.provider.id} label={body.provider.label} />{task === undefined ? <code>{body.id}</code> : <small className={css.metadataTaskStatus} data-status={task.status} title={task.error}>{task.status === 'running' ? t('overview.metadataTaskRunning') : task.status === 'success' ? t('overview.metadataTaskSuccess') : t('overview.metadataTaskError', { error: task.error ?? t('overview.metadataTaskUnknown') })}</small>}</span></span></label>
         })}</div>
       </div></SidebarModal>}
-      {appearance.surface === 'sidebar' && editingBodyView !== undefined && <SidebarModal title={t('overview.editBodyAria', { name: editingBodyView.name })} description={editingBodyView.id} busy={savingBody === editingBodyView.id} onClose={() => setEditingBody(null)} footer={<div className={css.modalFooterActions}><button type="button" className={css.ghostButton} disabled={savingBody === editingBodyView.id} onClick={() => setEditingBody(null)}>{t('common.cancel')}</button><button type="submit" form={bodyEditFormId} className={css.primaryButton} disabled={savingBody === editingBodyView.id || editName.trim() === ''}>{savingBody === editingBodyView.id ? t('overview.savingBody') : t('overview.saveBody')}</button></div>}>{bodyEditForm(editingBodyView)}</SidebarModal>}
-      {appearance.surface === 'sidebar' && deletingBodyView !== undefined && <SidebarModal title={t(deletingBodyView.provider.id !== 'mnemon-native' ? 'overview.disconnectTitle' : 'overview.deleteTitle', { name: deletingBodyView.name })} description={deletingBodyView.id} busy={deletingBody === deletingBodyView.id} onClose={() => setConfirmingDeleteBody(null)} footer={<div className={css.modalFooterActions}><button type="button" data-autofocus className={css.ghostButton} disabled={deletingBody === deletingBodyView.id} onClick={() => setConfirmingDeleteBody(null)}>{t('common.cancel')}</button><button type="button" className={css.dangerSolidButton} title={canDeleteBody(deletingBodyView) ? undefined : t('overview.lastStoreDeleteHint')} disabled={deletingBody === deletingBodyView.id || !canDeleteBody(deletingBodyView)} onClick={() => void deleteBody(deletingBodyView)}>{deletingBody === deletingBodyView.id ? t('overview.deletingBody') : t(deletingBodyView.provider.id !== 'mnemon-native' ? 'overview.disconnectAction' : 'overview.deleteAction')}</button></div>}><div className={css.bodyDeleteConfirm}><p>{t(deletingBodyView.provider.id !== 'mnemon-native' ? 'overview.disconnectWarning' : 'overview.deleteWarning', { provider: deletingBodyView.provider.label })}</p><div className={css.bodyDeleteSummary}><strong>{deletingBodyView.name}</strong><span>{deletingBodyView.provider.label} · {deletingBodyView.provider.location || t('common.memories', { count: deletingBodyView.stats?.totalInsights ?? 0 })}</span></div></div></SidebarModal>}
+      {appearance.surface === 'sidebar' && editingBodyView !== undefined && <SidebarModal title={t('overview.editBodyAria', { name: editingBodyView.name })} description={editingBodyView.id} busy={savingBody === editingBodyView.id} onClose={() => setEditingBody(null)} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close className={css.ghostButton} disabled={savingBody === editingBodyView.id} onClick={() => setEditingBody(null)}>{t('common.cancel')}</button><button type="submit" form={bodyEditFormId} className={css.primaryButton} disabled={savingBody === editingBodyView.id || editName.trim() === ''}>{savingBody === editingBodyView.id ? t('overview.savingBody') : t('overview.saveBody')}</button></div>}>{bodyEditForm(editingBodyView)}</SidebarModal>}
+      {appearance.surface === 'sidebar' && deletingBodyView !== undefined && <SidebarModal title={t(deletingBodyView.provider.id !== 'mnemon-native' ? 'overview.disconnectTitle' : 'overview.deleteTitle', { name: deletingBodyView.name })} description={deletingBodyView.id} busy={deletingBody === deletingBodyView.id} onClose={() => setConfirmingDeleteBody(null)} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close data-autofocus className={css.ghostButton} disabled={deletingBody === deletingBodyView.id} onClick={() => setConfirmingDeleteBody(null)}>{t('common.cancel')}</button><button type="button" className={css.dangerSolidButton} title={canDeleteBody(deletingBodyView) ? undefined : t('overview.lastStoreDeleteHint')} disabled={deletingBody === deletingBodyView.id || !canDeleteBody(deletingBodyView)} onClick={() => void deleteBody(deletingBodyView)}>{deletingBody === deletingBodyView.id ? t('overview.deletingBody') : t(deletingBodyView.provider.id !== 'mnemon-native' ? 'overview.disconnectAction' : 'overview.deleteAction')}</button></div>}><div className={css.bodyDeleteConfirm}><p>{t(deletingBodyView.provider.id !== 'mnemon-native' ? 'overview.disconnectWarning' : 'overview.deleteWarning', { provider: deletingBodyView.provider.label })}</p><div className={css.bodyDeleteSummary}><strong>{deletingBodyView.name}</strong><span>{deletingBodyView.provider.label} · {deletingBodyView.provider.location || t('common.memories', { count: deletingBodyView.stats?.totalInsights ?? 0 })}</span></div></div></SidebarModal>}
       {!catalogUnavailable && graph !== null && graph.nodes.length > 0 ? (
         <div className={css.graphLayout}>
           <section className={css.graphPanel}>
@@ -1719,9 +1661,9 @@ function RuntimePage(props: { client: MnemonClient; revision: number; writeEnabl
         </section>
       </>}
       <p className={css.runtimeFootnote}>{t('runtime.footnote')}</p>
-      {appearance.surface === 'sidebar' && adding && <SidebarModal title={t('runtime.addTitle')} description={t('runtime.addDescription')} busy={saving} onClose={closeComposer} footer={<div className={css.modalFooterActions}><button type="button" className={css.ghostButton} disabled={saving} onClick={closeComposer}>{t('common.cancel')}</button><button type="submit" form={runtimeAddFormId} className={css.primaryButton} disabled={saving || content.trim() === ''}>{saving ? t('runtime.saving') : t('runtime.addAction')}</button></div>}>{composer}</SidebarModal>}
-      {appearance.surface === 'sidebar' && editingEntry !== undefined && <SidebarModal title={t('runtime.editContent')} description={t(`runtime.target.${editingEntry.target}` as MnemonKey)} busy={saving} onClose={() => setEditing(null)} footer={<div className={css.modalFooterActions}><button type="button" className={css.ghostButton} disabled={saving} onClick={() => setEditing(null)}>{t('common.cancel')}</button><button type="submit" form={runtimeEditFormId} className={css.primaryButton} disabled={saving || editContent.trim() === ''}>{t('runtime.saveEdit')}</button></div>}>{editForm}</SidebarModal>}
-      {appearance.surface === 'sidebar' && removingEntry !== undefined && <SidebarModal title={t('runtime.removeTitle')} description={t(`runtime.target.${removingEntry.target}` as MnemonKey)} busy={saving} onClose={() => setRemoving(null)} footer={<div className={css.modalFooterActions}><button type="button" data-autofocus className={css.ghostButton} disabled={saving} onClick={() => setRemoving(null)}>{t('common.cancel')}</button><button type="button" className={css.dangerSolidButton} disabled={saving} onClick={() => void remove(removingEntry)}>{t('runtime.removeAction')}</button></div>}><div className={css.bodyDeleteConfirm}><p>{t('runtime.removeWarning')}</p><div className={css.bodyDeleteSummary}><p className={css.bodyDeleteContent}>{removingEntry.content}</p><span>{t(`runtime.importance.${removingEntry.importance}` as MnemonKey)}</span></div></div></SidebarModal>}
+      {appearance.surface === 'sidebar' && adding && <SidebarModal title={t('runtime.addTitle')} description={t('runtime.addDescription')} busy={saving} onClose={closeComposer} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close className={css.ghostButton} disabled={saving} onClick={closeComposer}>{t('common.cancel')}</button><button type="submit" form={runtimeAddFormId} className={css.primaryButton} disabled={saving || content.trim() === ''}>{saving ? t('runtime.saving') : t('runtime.addAction')}</button></div>}>{composer}</SidebarModal>}
+      {appearance.surface === 'sidebar' && editingEntry !== undefined && <SidebarModal title={t('runtime.editContent')} description={t(`runtime.target.${editingEntry.target}` as MnemonKey)} busy={saving} onClose={() => setEditing(null)} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close className={css.ghostButton} disabled={saving} onClick={() => setEditing(null)}>{t('common.cancel')}</button><button type="submit" form={runtimeEditFormId} className={css.primaryButton} disabled={saving || editContent.trim() === ''}>{t('runtime.saveEdit')}</button></div>}>{editForm}</SidebarModal>}
+      {appearance.surface === 'sidebar' && removingEntry !== undefined && <SidebarModal title={t('runtime.removeTitle')} description={t(`runtime.target.${removingEntry.target}` as MnemonKey)} busy={saving} onClose={() => setRemoving(null)} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close data-autofocus className={css.ghostButton} disabled={saving} onClick={() => setRemoving(null)}>{t('common.cancel')}</button><button type="button" className={css.dangerSolidButton} disabled={saving} onClick={() => void remove(removingEntry)}>{t('runtime.removeAction')}</button></div>}><div className={css.bodyDeleteConfirm}><p>{t('runtime.removeWarning')}</p><div className={css.bodyDeleteSummary}><p className={css.bodyDeleteContent}>{removingEntry.content}</p><span>{t(`runtime.importance.${removingEntry.importance}` as MnemonKey)}</span></div></div></SidebarModal>}
     </div>
   )
 }
@@ -1794,7 +1736,7 @@ function PersistenceStrategyDialog(props: {
     } catch (reason) { setError(message(reason)) } finally { setSaving(false) }
   }
 
-  return <SidebarModal title={t('strategy.title')} description={t('strategy.description')} busy={saving} contentReady={!loading} wide onClose={props.onClose} footer={<div className={css.modalFooterActions}><button type="button" className={css.ghostButton} disabled={saving} onClick={props.onClose}>{t('common.cancel')}</button><button type="submit" form={strategyFormId} className={css.primaryButton} disabled={loading || saving || !props.writable || !selectedProvidersValid}>{saving ? t('strategy.saving') : t('strategy.save')}</button></div>}>
+  return <SidebarModal title={t('strategy.title')} description={t('strategy.description')} busy={saving} contentReady={!loading} wide onClose={props.onClose} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close className={css.ghostButton} disabled={saving} onClick={props.onClose}>{t('common.cancel')}</button><button type="submit" form={strategyFormId} className={css.primaryButton} disabled={loading || saving || !props.writable || !selectedProvidersValid}>{saving ? t('strategy.saving') : t('strategy.save')}</button></div>}>
     <form id={strategyFormId} className={appearanceClass(css.bodyEdit, css.strategyForm)} onSubmit={event => void save(event)}>
       {loading && <div className={css.strategyLoading}><SectionSpinner label={t('strategy.loading')} /><span>{t('strategy.loading')}</span></div>}
       {error !== null && <div className={css.inlineError} role="alert">{error}</div>}
@@ -1902,7 +1844,7 @@ function RememberPage(props: { client: MnemonClient; agentAvailable: boolean; me
   </section>
 
   if (props.onClose !== undefined) {
-    return <SidebarModal title={t('remember.title')} description={t('remember.description')} busy={supervising || saving} onClose={props.onClose} footer={props.writeEnabled ? <div className={css.modalFooterActions}><button type="button" className={css.ghostButton} disabled={supervising || saving} onClick={props.onClose}>{t('common.cancel')}</button><button type="submit" form={rememberFormId} className={css.primaryButton} disabled={supervising || content.trim() === '' || !props.agentAvailable}>{supervising ? t('remember.processing') : t('remember.action')}</button></div> : undefined}>{props.writeEnabled ? composer : <EmptyState glyph="⊘" title={t('remember.readOnlyTitle')}>{t('remember.readOnlyText')}</EmptyState>}</SidebarModal>
+    return <SidebarModal title={t('remember.title')} description={t('remember.description')} busy={supervising || saving} onClose={props.onClose} footer={props.writeEnabled ? <div className={css.modalFooterActions}><button type="button" data-dialog-close className={css.ghostButton} disabled={supervising || saving} onClick={props.onClose}>{t('common.cancel')}</button><button type="submit" form={rememberFormId} className={css.primaryButton} disabled={supervising || content.trim() === '' || !props.agentAvailable}>{supervising ? t('remember.processing') : t('remember.action')}</button></div> : undefined}>{props.writeEnabled ? composer : <EmptyState glyph="⊘" title={t('remember.readOnlyTitle')}>{t('remember.readOnlyText')}</EmptyState>}</SidebarModal>
   }
 
   return <div className={css.page}>
@@ -2132,9 +2074,9 @@ function DocumentsPage(props: { client: MnemonClient; revision: number; writeEna
         </section>
       </div>
       <p className={css.runtimeFootnote}>{t('documents.footnote')}</p>
-      {composing && appearance.surface === 'sidebar' && <SidebarModal title={t('documents.newTitle')} description={t('documents.editorHint')} busy={saving} onClose={resetComposer} footer={<div className={css.modalFooterActions}><button type="button" className={css.ghostButton} disabled={saving} onClick={resetComposer}>{t('common.cancel')}</button><button type="submit" form={documentCreateFormId} className={css.primaryButton} disabled={saving || title.trim() === '' || content.trim() === ''}>{saving ? t('documents.saving') : t('documents.create')}</button></div>}>{composer}</SidebarModal>}
-      {editing && appearance.surface === 'sidebar' && selected !== null && <SidebarModal title={t('documents.editTitle')} description={selected.title} busy={saving} onClose={() => setEditing(false)} footer={<div className={css.modalFooterActions}><button type="button" className={css.ghostButton} disabled={saving} onClick={() => setEditing(false)}>{t('common.cancel')}</button><button type="submit" form={documentEditFormId} className={css.primaryButton} disabled={saving}>{saving ? t('documents.saving') : t('documents.save')}</button></div>}>{editComposer}</SidebarModal>}
-      {confirmArchive && appearance.surface === 'sidebar' && selected !== null && <SidebarModal title={t('documents.archiveConfirm')} description={selected.title} busy={saving} onClose={() => setConfirmArchive(false)} footer={<div className={css.modalFooterActions}><button type="button" data-autofocus className={css.ghostButton} disabled={saving} onClick={() => setConfirmArchive(false)}>{t('common.cancel')}</button><button type="button" className={css.dangerSolidButton} disabled={saving} onClick={() => void archive()}>{saving ? t('documents.archiving') : t('documents.archiveNow')}</button></div>}><div className={css.bodyDeleteConfirm}><p>{t('documents.archiveDescription')}</p><div className={css.bodyDeleteSummary}><strong>{selected.title}</strong><span>{selected.relativePath} · {humanBytes(selected.sizeBytes)}</span></div></div></SidebarModal>}
+      {composing && appearance.surface === 'sidebar' && <SidebarModal title={t('documents.newTitle')} description={t('documents.editorHint')} busy={saving} onClose={resetComposer} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close className={css.ghostButton} disabled={saving} onClick={resetComposer}>{t('common.cancel')}</button><button type="submit" form={documentCreateFormId} className={css.primaryButton} disabled={saving || title.trim() === '' || content.trim() === ''}>{saving ? t('documents.saving') : t('documents.create')}</button></div>}>{composer}</SidebarModal>}
+      {editing && appearance.surface === 'sidebar' && selected !== null && <SidebarModal title={t('documents.editTitle')} description={selected.title} busy={saving} onClose={() => setEditing(false)} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close className={css.ghostButton} disabled={saving} onClick={() => setEditing(false)}>{t('common.cancel')}</button><button type="submit" form={documentEditFormId} className={css.primaryButton} disabled={saving}>{saving ? t('documents.saving') : t('documents.save')}</button></div>}>{editComposer}</SidebarModal>}
+      {confirmArchive && appearance.surface === 'sidebar' && selected !== null && <SidebarModal title={t('documents.archiveConfirm')} description={selected.title} busy={saving} onClose={() => setConfirmArchive(false)} footer={<div className={css.modalFooterActions}><button type="button" data-dialog-close data-autofocus className={css.ghostButton} disabled={saving} onClick={() => setConfirmArchive(false)}>{t('common.cancel')}</button><button type="button" className={css.dangerSolidButton} disabled={saving} onClick={() => void archive()}>{saving ? t('documents.archiving') : t('documents.archiveNow')}</button></div>}><div className={css.bodyDeleteConfirm}><p>{t('documents.archiveDescription')}</p><div className={css.bodyDeleteSummary}><strong>{selected.title}</strong><span>{selected.relativePath} · {humanBytes(selected.sizeBytes)}</span></div></div></SidebarModal>}
     </div>
   )
 }
@@ -2222,7 +2164,7 @@ function VersionDialog(props: { client: MnemonClient; writeEnabled: boolean; onC
   }
   const updatingBusy = updating !== null
   const controlsBusy = checking || updatingBusy
-  return <SidebarModal title={t('versions.title')} description={t('versions.description')} busy={updatingBusy} contentReady={!checking} onClose={props.onClose} footer={<><span className={css.modalFooterMeta}>{snapshot === null ? '' : t('versions.checkedAt', { time: new Date(snapshot.checkedAt).toLocaleTimeString() })}</span><div className={css.modalFooterActions}><button type="button" className={css.ghostButton} disabled={updatingBusy} onClick={props.onClose}>{t('common.cancel')}</button><button type="button" data-autofocus className={css.secondaryButton} disabled={controlsBusy} onClick={() => void check()}>{checking ? t('versions.checkingShort') : t('versions.recheck')}</button></div></>}>
+  return <SidebarModal title={t('versions.title')} description={t('versions.description')} busy={updatingBusy} contentReady={!checking} onClose={props.onClose} footer={<><span className={css.modalFooterMeta}>{snapshot === null ? '' : t('versions.checkedAt', { time: new Date(snapshot.checkedAt).toLocaleTimeString() })}</span><div className={css.modalFooterActions}><button type="button" data-dialog-close className={css.ghostButton} disabled={updatingBusy} onClick={props.onClose}>{t('common.cancel')}</button><button type="button" data-autofocus className={css.secondaryButton} disabled={controlsBusy} onClick={() => void check()}>{checking ? t('versions.checkingShort') : t('versions.recheck')}</button></div></>}>
     <div className={css.versionDialogBody}>
       {checking && snapshot === null && <div className={css.versionChecking} role="status"><span />{t('versions.checking')}</div>}
       {error !== null && <div className={css.versionError} role="alert"><strong>{t('versions.failed')}</strong><p>{error}</p></div>}

--- a/tests/client-dialog.spec.tsx
+++ b/tests/client-dialog.spec.tsx
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MnemonDialog } from '../src/client/MnemonDialog.tsx'
+
+const animateDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'animate')
+const getAnimationsDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'getAnimations')
+const matchMediaDescriptor = Object.getOwnPropertyDescriptor(window, 'matchMedia')
+
+interface AnimationCall {
+  element: HTMLElement
+  keyframes: Keyframe[] | PropertyIndexedKeyframes | null
+  finish: () => void
+  cancel: ReturnType<typeof vi.fn>
+}
+
+function restoreProperty(target: object, key: PropertyKey, descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor === undefined) Reflect.deleteProperty(target, key)
+  else Object.defineProperty(target, key, descriptor)
+}
+
+function setMedia(options: { mobile?: boolean; reduced?: boolean } = {}): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      matches: query.includes('max-width') ? options.mobile === true : query.includes('prefers-reduced-motion') && options.reduced === true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(() => true),
+    } satisfies MediaQueryList)),
+  })
+}
+
+function installAnimationMock(): AnimationCall[] {
+  const calls: AnimationCall[] = []
+  const animations = new WeakMap<HTMLElement, Animation[]>()
+  Object.defineProperty(HTMLElement.prototype, 'getAnimations', {
+    configurable: true,
+    value(this: HTMLElement): Animation[] {
+      return animations.get(this) ?? []
+    },
+  })
+  Object.defineProperty(HTMLElement.prototype, 'animate', {
+    configurable: true,
+    value(this: HTMLElement, keyframes: Keyframe[] | PropertyIndexedKeyframes | null): Animation {
+      let finish = (): void => {}
+      const finished = new Promise<void>(resolve => { finish = resolve })
+      const cancel = vi.fn()
+      const animation = { finished, cancel } as unknown as Animation
+      animations.set(this, [...(animations.get(this) ?? []), animation])
+      calls.push({ element: this, keyframes, finish, cancel })
+      return animation
+    },
+  })
+  return calls
+}
+
+function pointer(target: Element, type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel', clientY: number, pointerId = 7): void {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperties(event, {
+    button: { value: 0 },
+    clientY: { value: clientY },
+    isPrimary: { value: true },
+    pointerId: { value: pointerId },
+    pointerType: { value: 'touch' },
+  })
+  fireEvent(target, event)
+}
+
+function renderDialog(options: { busy?: boolean; onClose?: () => void; cancelClick?: () => void } = {}) {
+  const onClose = options.onClose ?? vi.fn()
+  const cancelClick = options.cancelClick ?? vi.fn()
+  const result = render(
+    <MnemonDialog
+      title="测试弹窗"
+      closeLabel="关闭"
+      {...(options.busy === undefined ? {} : { busy: options.busy })}
+      onClose={onClose}
+      footer={<button type="button" data-dialog-close onClick={cancelClick}>取消</button>}
+    >
+      <label>名称<input aria-label="名称" /></label>
+    </MnemonDialog>,
+  )
+  return { ...result, onClose, cancelClick }
+}
+
+afterEach(() => {
+  cleanup()
+  restoreProperty(HTMLElement.prototype, 'animate', animateDescriptor)
+  restoreProperty(HTMLElement.prototype, 'getAnimations', getAnimationsDescriptor)
+  restoreProperty(window, 'matchMedia', matchMediaDescriptor)
+  document.body.style.overflow = ''
+  vi.restoreAllMocks()
+})
+
+describe('MnemonDialog', () => {
+  it('portals to document.body, locks background scrolling, and restores both on unmount', () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    const { unmount } = renderDialog()
+    const portal = document.querySelector<HTMLElement>('[data-mnemon-dialog-portal]')
+
+    expect(portal?.parentElement).toBe(document.body)
+    expect(host.contains(portal)).toBe(false)
+    expect(document.body.style.overflow).toBe('hidden')
+
+    unmount()
+    expect(document.querySelector('[data-mnemon-dialog-portal]')).toBeNull()
+    expect(document.body.style.overflow).toBe('')
+    host.remove()
+  })
+
+  it('waits for the smooth downward exit before invoking a footer cancel', async () => {
+    setMedia({ mobile: true })
+    const calls = installAnimationMock()
+    const { onClose, cancelClick } = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: '取消' }))
+    const dialog = screen.getByRole('dialog', { name: '测试弹窗' })
+    expect(onClose).not.toHaveBeenCalled()
+    expect(cancelClick).not.toHaveBeenCalled()
+    expect(dialog.dataset.closing).toBe('true')
+    expect(calls).toHaveLength(2)
+    expect(JSON.stringify(calls[0]?.keyframes)).toContain('calc(100% + 32px)')
+
+    await act(async () => { calls.forEach(call => call.finish()); await Promise.resolve() })
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+  })
+
+  it('tracks a mobile drag and closes after crossing the distance threshold', async () => {
+    setMedia({ mobile: true })
+    const calls = installAnimationMock()
+    const { onClose } = renderDialog()
+    const dialog = screen.getByRole('dialog', { name: '测试弹窗' })
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue({ x: 0, y: 100, top: 100, right: 390, bottom: 600, left: 0, width: 390, height: 500, toJSON: () => ({}) })
+    const handle = dialog.querySelector('[data-dialog-drag-handle]')
+    if (handle === null) throw new Error('drag handle missing')
+
+    pointer(handle, 'pointerdown', 100)
+    pointer(handle, 'pointermove', 260)
+    expect(dialog.style.getPropertyValue('--mn-modal-drag-y')).toBe('160px')
+
+    pointer(handle, 'pointerup', 260)
+    expect(dialog.dataset.closing).toBe('true')
+    expect(onClose).not.toHaveBeenCalled()
+    expect(calls).toHaveLength(2)
+
+    await act(async () => { calls.forEach(call => call.finish()); await Promise.resolve() })
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+  })
+
+  it('springs a short drag back without closing', async () => {
+    setMedia({ mobile: true })
+    const calls = installAnimationMock()
+    const { onClose } = renderDialog()
+    const dialog = screen.getByRole('dialog', { name: '测试弹窗' })
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue({ x: 0, y: 100, top: 100, right: 390, bottom: 600, left: 0, width: 390, height: 500, toJSON: () => ({}) })
+    const handle = dialog.querySelector('[data-dialog-drag-handle]')
+    if (handle === null) throw new Error('drag handle missing')
+
+    pointer(handle, 'pointerdown', 100)
+    pointer(handle, 'pointermove', 112)
+    pointer(handle, 'pointerup', 112)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(calls).toHaveLength(2)
+
+    await act(async () => { calls.forEach(call => call.finish()); await Promise.resolve() })
+    await waitFor(() => expect(dialog.style.getPropertyValue('--mn-modal-drag-y')).toBe(''))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('recovers an active drag when the window loses focus', async () => {
+    setMedia({ mobile: true })
+    const calls = installAnimationMock()
+    const { onClose } = renderDialog()
+    const dialog = screen.getByRole('dialog', { name: '测试弹窗' })
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue({ x: 0, y: 100, top: 100, right: 390, bottom: 600, left: 0, width: 390, height: 500, toJSON: () => ({}) })
+    const handle = dialog.querySelector('[data-dialog-drag-handle]')
+    if (handle === null) throw new Error('drag handle missing')
+
+    pointer(handle, 'pointerdown', 100)
+    pointer(handle, 'pointermove', 170)
+    expect(dialog.dataset.dragging).toBe('true')
+    fireEvent.blur(window)
+    expect(dialog.dataset.dragging).toBeUndefined()
+    expect(calls).toHaveLength(2)
+
+    await act(async () => { calls.forEach(call => call.finish()); await Promise.resolve() })
+    await waitFor(() => expect(dialog.style.getPropertyValue('--mn-modal-drag-y')).toBe(''))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not let stale snap-back cleanup interrupt a quick re-grab', async () => {
+    setMedia({ mobile: true })
+    const calls = installAnimationMock()
+    renderDialog()
+    const dialog = screen.getByRole('dialog', { name: '测试弹窗' })
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue({ x: 0, y: 100, top: 100, right: 390, bottom: 600, left: 0, width: 390, height: 500, toJSON: () => ({}) })
+    const handle = dialog.querySelector('[data-dialog-drag-handle]')
+    if (handle === null) throw new Error('drag handle missing')
+
+    pointer(handle, 'pointerdown', 100)
+    pointer(handle, 'pointermove', 112)
+    pointer(handle, 'pointerup', 112)
+    expect(calls).toHaveLength(2)
+
+    pointer(handle, 'pointerdown', 100, 8)
+    pointer(handle, 'pointermove', 150, 8)
+    const activeDragOffset = dialog.style.getPropertyValue('--mn-modal-drag-y')
+    expect(dialog.dataset.dragging).toBe('true')
+    expect(activeDragOffset).not.toBe('')
+
+    await act(async () => { calls.slice(0, 2).forEach(call => call.finish()); await Promise.resolve() })
+    expect(dialog.dataset.dragging).toBe('true')
+    expect(dialog.style.getPropertyValue('--mn-modal-drag-y')).toBe(activeDragOffset)
+
+    pointer(handle, 'pointercancel', 150, 8)
+    expect(calls).toHaveLength(4)
+    await act(async () => { calls.slice(2).forEach(call => call.finish()); await Promise.resolve() })
+    await waitFor(() => expect(dialog.style.getPropertyValue('--mn-modal-drag-y')).toBe(''))
+  })
+
+  it('disables dismissal gestures while a destructive action is busy', () => {
+    setMedia({ mobile: true })
+    const calls = installAnimationMock()
+    const { onClose } = renderDialog({ busy: true })
+    const dialog = screen.getByRole('dialog', { name: '测试弹窗' })
+    const handle = dialog.querySelector('[data-dialog-drag-handle]')
+    const backdrop = dialog.parentElement
+    if (handle === null || backdrop === null) throw new Error('dialog surface missing')
+
+    pointer(handle, 'pointerdown', 100)
+    pointer(handle, 'pointermove', 240)
+    fireEvent.pointerDown(backdrop)
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(dialog.style.getPropertyValue('--mn-modal-drag-y')).toBe('')
+    expect(onClose).not.toHaveBeenCalled()
+    expect(calls).toHaveLength(0)
+  })
+
+  it('closes immediately when reduced motion is requested', () => {
+    setMedia({ mobile: true, reduced: true })
+    const calls = installAnimationMock()
+    const { onClose } = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: '关闭' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/tests/client-modal-css.spec.ts
+++ b/tests/client-modal-css.spec.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from 'vitest'
 const viewCss = readFileSync(new URL('../src/client/MnemonView.module.css', import.meta.url), 'utf8')
 const sidebarCss = readFileSync(new URL('../src/client/MnemonSidebarView.module.css', import.meta.url), 'utf8')
 const saveActionCss = readFileSync(new URL('../src/client/MnemonSaveAction.module.css', import.meta.url), 'utf8')
+const dialogSource = readFileSync(new URL('../src/client/MnemonDialog.tsx', import.meta.url), 'utf8')
+const viewSource = readFileSync(new URL('../src/client/MnemonView.tsx', import.meta.url), 'utf8')
 
 describe('responsive dialog layout invariants', () => {
   it('keeps the dialog body as the only scrollport and the action footer outside it', () => {
@@ -22,6 +24,33 @@ describe('responsive dialog layout invariants', () => {
     expect(sidebarCss).toContain('.shell .modal, .shell .modal.modalWide { width: 100vw;')
     expect(sidebarCss).toContain(".shell .modal > [class*='modalBody'] button { min-height: 44px; }")
     expect(sidebarCss).toContain(".shell .modal > [class*='modalFooter'] [class*='modalFooterActions'] button { min-height: 44px;")
+  })
+
+  it('escapes host stacking contexts through one body-level top layer', () => {
+    expect(dialogSource).toContain("import { createPortal } from 'react-dom'")
+    expect(dialogSource).toContain('document.body,')
+    expect(dialogSource).toContain('data-mnemon-dialog-portal')
+    expect(viewCss).toContain('.modalPortal { position: fixed; z-index: 2147483647; inset: 0; isolation: isolate; pointer-events: none; }')
+    expect(viewCss).toContain('.modalTheme.modalTheme.modalTheme { position: absolute; inset: 0;')
+  })
+
+  it('uses compositor motion and a real drag surface for mobile sheets', () => {
+    expect(dialogSource).toContain('data-dialog-drag-handle')
+    expect(dialogSource).toContain("dialog.style.setProperty('--mn-modal-drag-y'")
+    expect(dialogSource).toContain('setPointerCapture?.(event.pointerId)')
+    expect(dialogSource).toContain("window.addEventListener('pointermove', moveDrag, { passive: false })")
+    expect(dialogSource).toContain('onLostPointerCapture={event =>')
+    expect(viewCss).toContain('@keyframes mnemon-sheet-enter')
+    expect(viewCss).toContain('transform: translate3d(0, var(--mn-modal-drag-y, 0px), 0);')
+    expect(viewCss).toContain('.modalDragHandle { display: grid; width: 100%; height: 28px;')
+    expect(viewCss).toContain('.modalBackdrop, .modal { animation: none !important; }')
+    expect(sidebarCss).toContain('.shell .modalDragHandle span { background: var(--dsw-alias-border-l2); }')
+  })
+
+  it('routes every shared footer cancel action through the exit animation', () => {
+    const dialogCallsWithCancel = viewSource.split('\n').filter(line => line.includes('<SidebarModal') && line.includes("t('common.cancel')"))
+    expect(dialogCallsWithCancel.length).toBeGreaterThan(10)
+    for (const call of dialogCallsWithCancel) expect(call).toContain('data-dialog-close')
   })
 
   it('keeps every modal control touch-sized on coarse-pointer tablets', () => {


### PR DESCRIPTION
## 摘要 / Summary

修复 dsh-mnemon 在真实手机和压缩视口中的共享弹窗：弹窗现在通过统一的 `MnemonDialog` 挂载到页面顶层，不再被 DSH 导航栏遮挡；移动端底部弹层获得平滑的进入、退出与回弹动画，并支持从顶部拖拽条下拉关闭。

Fixes shared dsh-mnemon dialogs on real phones and compressed viewports. A single top-layer `MnemonDialog` prevents the DSH navigation rail from covering sheets, while mobile sheets gain smooth enter, exit, snap-back, and drag-handle dismissal behavior.

## 关联 Issue 或背景 / Related Issue or Context

N/A — 这是维护者直接提出的现有移动端弹窗缺陷修复，范围限于现有 Web UI 的分层、动画、手势和稳定性；没有新增能力、Provider、持久化格式、RPC 权限或安全边界。 / This is a maintainer-requested fix to existing mobile dialog behavior. It is limited to layering, motion, gestures, and stability, with no new capability, Provider, persistence format, RPC authority, or security boundary.

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [x] 运行时记忆 / Runtime Memory
- [x] 项目档案 / Project Documents
- [x] 记忆体或 Provider / Memory Spaces or Providers
- [x] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [x] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [x] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [x] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [x] Bug 修复 / Bug fix
- [x] 增强或优化 / Enhancement or optimization
- [x] 兼容性适配 / Compatibility change
- [x] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin main
git merge-base --is-ancestor origin/main HEAD
```

`origin/main` at `b91fd7a` is an ancestor of this branch head `abd35a0`.

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

OpenAI GPT-5 (Codex)

使用的编码 Agent 工具 / Coding Agent tool used:

Codex

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

- 仅修改 Client 端弹窗结构、样式和交互；DSH Host、Mnemon Host、Provider、RPC、配置、凭据、持久化格式和现有数据均不受影响，不需要迁移。
- `MnemonDialog` 通过 `createPortal(..., document.body)` 脱离宿主堆叠上下文，同时重新附着现有主题类；没有修改正式的 `@deepseek-ai/*` 契约。
- 拖拽仅在不大于 760px 的 sheet 形态、且从顶部拖拽条开始时生效，正文仍保持原生纵向滚动，桌面弹窗行为保持不变。
- 不支持 Web Animations API 或启用 `prefers-reduced-motion` 时使用即时关闭回退；动画等待还带有超时保护，不会因浏览器未派发完成事件而卡住。
- 回滚只需恢复这两个小步提交或降级包版本，不涉及数据回滚。

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm run verify
```

结果摘要 / Result summary:

- 完整验证通过：369 项测试通过，1 项仅适用于其他平台的测试按预期跳过。
- TypeScript、确定性双构建、隔离 Headless profile 激活、包内容检查、publint 和类型包检查均通过。
- 新增 8 项 `MnemonDialog` 回归测试，覆盖 body portal 与滚动锁、动画后关闭、距离阈值关闭、短拖拽回弹、窗口失焦恢复、回弹中快速二次抓取、busy 禁止关闭以及 reduced-motion 回退。
- CSS/结构回归检查确认共享 portal、最高层级、全局 pointer 监听、触控尺寸和所有共享调用点。
- 在 `390×844` 竖屏及 `667×375` 横屏真实浏览器交互中验证：长短弹窗、展开宿主导航栏后的左边缘命中、正文滚动、固定 footer、拖拽关闭、未过阈值回弹、回弹中再次抓取、背景滚动恢复以及版本检查异步状态。
- GitHub Actions 的 Ubuntu 与 Windows CI 均通过。

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence:

以下截图均来自本 PR 分支头 `abd35a0` 的本地运行结果；测试数据不含凭据、私有记忆或敏感路径。静态关键帧用于展示层级和运动路径，动画流畅度另通过真实 pointer 拖拽及上述自动化测试验证。 / The screenshots below were captured from local branch head `abd35a0`. They contain no credentials, private memory, or sensitive paths. Static keyframes show layering and motion paths; smoothness was additionally verified with real pointer gestures and automated tests.

### 真实手机遮挡：修复前后 / Real-phone occlusion: before and after

| 修复前：宿主导航栏覆盖弹窗左侧 / Before: host rail covers the sheet | 修复后：展开导航栏仍位于弹窗之后 / After: expanded rail remains behind the sheet |
| --- | --- |
| <img width="280" alt="Real iPhone before fix: navigation rail obscures the dialog" src="https://github.com/user-attachments/assets/1a8b5df4-7b85-4206-b979-029f3589dc47" /> | <img width="280" alt="After fix at 390 by 844 with expanded navigation rail behind the strategy sheet" src="https://github.com/user-attachments/assets/14bf5ad9-38e1-42c9-a8e9-10d98a21fae4" /> |

### 拖拽与动画关键帧 / Drag and animation keyframes

<details open>
<summary>展开查看进入、回弹、退出和关闭完成状态 / Show enter, snap-back, exit, and fully closed states</summary>

| 完全打开 / Open | 未过阈值回弹中 / Under-threshold snap-back |
| --- | --- |
| <img width="250" alt="Strategy sheet fully open with drag handle" src="https://github.com/user-attachments/assets/ebdf4c74-1dea-406e-b2cc-9e75637b5613" /> | <img width="250" alt="Strategy sheet during smooth snap-back" src="https://github.com/user-attachments/assets/ebb9990a-8b71-49e3-910c-41314e08c3ef" /> |

| 向下退出中 / Exiting downward | 拖拽关闭完成 / Drag dismissal complete |
| --- | --- |
| <img width="250" alt="Strategy sheet during downward exit motion" src="https://github.com/user-attachments/assets/1d555493-8e63-4744-b9d6-f308513a8d3f" /> | <img width="250" alt="Strategy sheet fully dismissed after drag" src="https://github.com/user-attachments/assets/9917d9b7-6627-4a89-8ff7-b814dc461fe9" /> |

</details>

### 同类弹窗覆盖 / Representative shared-dialog coverage

<details open>
<summary>展开查看记住、编辑记忆体和版本检查 / Show Remember, Edit Memory Body, and Version Check</summary>

| 记住 / Remember | 编辑记忆体 / Edit Memory Body |
| --- | --- |
| <img width="250" alt="Remember dialog at 390 by 844" src="https://github.com/user-attachments/assets/3a96e07b-e04b-4ab8-a00c-b20f5272b3fc" /> | <img width="250" alt="Edit Memory Body dialog at 390 by 844" src="https://github.com/user-attachments/assets/b73c394b-f397-4d99-bf7d-7a758e58d6a5" /> |

| 检查更新竖屏 / Version Check portrait | 检查更新横屏 / Version Check landscape |
| --- | --- |
| <img width="250" alt="Version Check dialog at 390 by 844" src="https://github.com/user-attachments/assets/1b695a0e-aa36-4da7-a0fc-d98d27fc52a1" /> | <img width="360" alt="Version Check dialog at 667 by 375" src="https://github.com/user-attachments/assets/a7a44133-1544-4bb4-8c23-aa8ce669070d" /> |

</details>

## 设计与稳定性说明 / Design and Stability Notes

- 新增一个 dsh-mnemon Client 级共享组件 `MnemonDialog`，15 个 Sidebar action 弹窗调用点统一使用同一套 portal、焦点、动画、拖拽和滚动锁逻辑；14 个 footer 取消入口统一走完成退出动画后再关闭的路径。
- Portal 根节点使用隔离的页面顶层，解决真实手机上宿主导航栏创建更高堆叠上下文的问题；展开导航栏时在 `x=2/36/74` 的命中测试均仍落在弹窗层。
- 动画只改变 `transform` 和 `opacity`，进入 220ms、关闭 240ms、回弹 280ms；拖动超过高度的 22%（最少 96px、最多 180px）或满足向下速度阈值时关闭，否则平滑回弹。
- 手势只绑定顶部 28px 拖拽区，避免与长表单正文滚动竞争；全局 pointer 监听保证手指离开 handle 后仍能完成手势。
- 丢失 pointer capture、`pointercancel`、窗口失焦、应用切后台和回弹中快速再次抓取都有恢复路径；generation 隔离避免旧回弹清理覆盖新手势。
- 保留并集中处理 focus trap、打开后自动聚焦、异步内容就绪后的焦点转移、关闭后的焦点返回、busy 状态关闭保护、背景滚动恢复和 reduced-motion。

## 风险与回滚 / Risk and Rollback

- 主要风险是 portal 后主题作用域丢失、手势与正文滚动冲突、动画完成事件缺失以及快速连续操作产生竞态；本 PR 分别通过主题桥接、仅 handle 起手、动画超时保护、全局取消恢复和 generation 隔离处理，并有对应回归测试。
- 改动不触碰数据或 Host 契约。若需回滚，可按顺序恢复 `abd35a0` 和 `8a9e802`，无需迁移或修复用户数据。
