### PR TITLE
fix(subagent): tolerate invalid AI metadata candidates

### DIFF
--- a/docs/en/ui-guide.md
+++ b/docs/en/ui-guide.md
@@ -108,7 +108,7 @@ The receipt keeps decision source, confidence, and reason. Provider credentials 
 
 [![AI metadata across Providers with multi-select isolated tasks](../assets/screenshots/ai-metadata-dialog.png)](../assets/screenshots/ai-metadata-dialog.png)
 
-Select several active spaces. Each task uses that Provider's fastest native query to fetch a small sample, then follows system-prompt length and capability constraints for title and description. Tasks share no state; a failure appears only on its card. The dialog stays open and each card plays a rightward same-tone refresh animation before updating in place.
+Select several active spaces. Each task uses that Provider's fastest native query to fetch a small sample, then follows system-prompt length and capability constraints for title and description. Tasks share no state; a failure appears only on its card. If a model-generated title or description fails the local length check, that card keeps its previous metadata while valid results still update. The dialog stays open and each card plays a rightward same-tone refresh animation before updating in place.
 
 Generated title and description are local catalog metadata and survive ordinary reconnects. Disabling a Provider clears mapping and metadata. Re-enabling rebuilds them from Provider data, using the closest default only for unmapped fields.
 

--- a/docs/zh-CN/ui-guide.md
+++ b/docs/zh-CN/ui-guide.md
@@ -108,7 +108,7 @@
 
 [![AI 维护元信息：跨 Provider 多选与独立异步任务](../assets/screenshots/ai-metadata-dialog.png)](../assets/screenshots/ai-metadata-dialog.png)
 
-可多选已激活记忆体。每个任务先调用对应 Provider 最快的原生查询方式读取少量样本，再按 system prompt 的长度和能力约束生成 title / description。任务互不共享状态；一个失败只在自己的卡片显示错误。生成过程不关闭弹窗，卡片向右播放同色调刷新动画并原位更新。
+可多选已激活记忆体。每个任务先调用对应 Provider 最快的原生查询方式读取少量样本，再按 system prompt 的长度和能力约束生成 title / description。任务互不共享状态；一个失败只在自己的卡片显示错误。如果模型生成的标题或说明未通过本地长度校验，该卡片会保留原有元数据，同时其他合法结果仍会更新。生成过程不关闭弹窗，卡片向右播放同色调刷新动画并原位更新。
 
 人工生成的标题与说明属于本地目录元数据，普通重连不会覆盖；关闭 Provider 会清理映射和元数据，重新启用后从 Provider 重建，映射不到的字段用最近似默认值补充。
 

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -548,7 +548,7 @@ export function createWriteHandler(input: RuntimeInput, lifecycle?: MnemonLifecy
               if (!body.active || body.providerEnabled === false) throw new Error(`metadata maintenance requires an active Memory Space: ${id}`)
             }
             const maintained = await lifecycle.maintainMetadata(String(payload.sessionId ?? ''), memoryBodyIds, selectedWorkspace?.path)
-            service.updateBodyMetadata(maintained.updates)
+            if (maintained.updates.length > 0) service.updateBodyMetadata(maintained.updates)
             return success(maintained)
           }
         // Compatibility route for clients released before card reconnect was

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -732,18 +732,17 @@ Traversal depth: 2`
     if (!Array.isArray(value.updates)) throw new Error('metadata subagent returned no updates')
     const allowed = new Set(selected)
     const seen = new Set<string>()
-    const updates = value.updates.map((entry): MemoryBodyMetadataUpdate => {
+    const updates: MemoryBodyMetadataUpdate[] = []
+    for (const entry of value.updates) {
       const item = object(entry)
       const memoryBodyId = typeof item.memoryBodyId === 'string' ? item.memoryBodyId.trim() : ''
       const title = typeof item.title === 'string' ? item.title.trim() : ''
       const description = typeof item.description === 'string' ? item.description.trim() : ''
       if (!allowed.has(memoryBodyId) || seen.has(memoryBodyId)) throw new Error('metadata subagent returned an unexpected or duplicate Memory Space')
-      if (title.length < 2 || title.length > 48) throw new Error(`metadata title for ${memoryBodyId} must contain 2 through 48 characters`)
-      if (description.length < 12 || description.length > 200) throw new Error(`metadata description for ${memoryBodyId} must contain 12 through 200 characters`)
       seen.add(memoryBodyId)
-      return { memoryBodyId, title, description }
-    })
-    if (seen.size !== allowed.size) throw new Error('metadata subagent omitted a selected Memory Space')
+      if (title.length < 2 || title.length > 48 || description.length < 12 || description.length > 200) continue
+      updates.push({ memoryBodyId, title, description })
+    }
     return {
       delegated: true,
       runId,

--- a/tests/rpc.spec.ts
+++ b/tests/rpc.spec.ts
@@ -260,6 +260,24 @@ describe('Mnemon RPC', () => {
     expect(service.updateBodyMetadata).toHaveBeenCalledWith(maintained.updates)
   })
 
+  it('does not commit when metadata maintenance returns no valid updates', async () => {
+    const service = fakeService()
+    const maintained = {
+      delegated: true as const,
+      runId: 'metadata-2',
+      provider: 'spawn',
+      summary: 'No valid metadata.',
+      updates: [],
+    }
+    const lifecycle = { maintainMetadata: vi.fn(async () => maintained) } as unknown as MnemonLifecycle
+
+    await expect(createWriteHandler(service, lifecycle)('body-metadata-maintain', {
+      sessionId: 'session-1', memoryBodyIds: ['project'],
+    })).resolves.toMatchObject({ ok: true, value: { runId: 'metadata-2', updates: [] } })
+
+    expect(service.updateBodyMetadata).not.toHaveBeenCalled()
+  })
+
   it('routes supervised Tab writeback through an independent task Agent', async () => {
     const service = fakeService()
     const lifecycle = {

--- a/tests/subagent.spec.ts
+++ b/tests/subagent.spec.ts
@@ -428,12 +428,12 @@ describe('Mnemon memory subagent coordinator', () => {
     expect(coordinator.snapshot()).toMatchObject({ placements: 1, lastOperation: 'placement' })
   })
 
-  it('curates metadata in a read-only child and validates exact selected-space coverage', async () => {
+  it('curates metadata in a read-only child and keeps valid entries when another candidate is invalid', async () => {
     const host = subagents({
-      summary: 'Updated both scopes.',
+      summary: 'Updated one scope.',
       updates: [
         { memoryBodyId: 'product', title: '产品决策', description: '记录稳定的产品范围、取舍与依据，在规划和复盘产品方向时召回。' },
-        { memoryBodyId: 'release', title: '发布运行手册', description: '沉淀发布门禁、部署约束和回滚经验，在准备上线或处理故障时召回。' },
+        { memoryBodyId: 'release', title: 'x'.repeat(49), description: '沉淀发布门禁、部署约束和回滚经验，在准备上线或处理故障时召回。' },
       ],
     })
     const memoryService = service()
@@ -443,7 +443,7 @@ describe('Mnemon memory subagent coordinator', () => {
     await expect(coordinator.maintainMetadata(parent(), ['product', 'release'], new AbortController().signal)).resolves.toMatchObject({
       delegated: true,
       runId: 'child-run-1',
-      updates: [{ memoryBodyId: 'product', title: '产品决策' }, { memoryBodyId: 'release', title: '发布运行手册' }],
+      updates: [{ memoryBodyId: 'product', title: '产品决策' }],
     })
     expect(host.start).toHaveBeenCalledWith('spawn', expect.objectContaining({
       toolFilter: { allow: [expect.stringMatching(/^mnemon_subagent_result_/)] },
@@ -459,7 +459,12 @@ describe('Mnemon memory subagent coordinator', () => {
     expect(coordinator.snapshot()).toMatchObject({ metadataMaintenances: 1, lastOperation: 'metadata-maintenance' })
 
     const incomplete = subagents({ summary: 'Only one.', updates: [{ memoryBodyId: 'product', title: '产品决策', description: '记录稳定的产品范围与取舍，在规划和复盘产品方向时召回。' }] })
-    await expect(createCoordinator(incomplete.value, runtime).maintainMetadata(parent(), ['product', 'release'], new AbortController().signal)).rejects.toThrow('omitted')
+    await expect(createCoordinator(incomplete.value, runtime).maintainMetadata(parent(), ['product', 'release'], new AbortController().signal)).resolves.toMatchObject({
+      updates: [{ memoryBodyId: 'product' }],
+    })
+
+    const invalid = subagents({ summary: 'No valid metadata.', updates: [{ memoryBodyId: 'product', title: 'x', description: 'too short' }] })
+    await expect(createCoordinator(invalid.value, runtime).maintainMetadata(parent(), ['product'], new AbortController().signal)).resolves.toMatchObject({ updates: [] })
   })
 
   it('reviews a completed full-context checkpoint through fork with a maintenance-only tool set', async () => {


### PR DESCRIPTION
## 摘要 / Summary

AI metadata maintenance now skips only model-generated title or description candidates that violate the existing local length bounds. Valid candidates still update normally, while a rejected Memory Space keeps its previous metadata instead of aborting the maintenance operation.

The RPC handler also avoids calling the strict persistence layer with an empty update list.

## 关联 Issue 或背景 / Related Issue or Context

Related to #47. The issue was automatically closed for an incomplete issue form, but the reported failure remains reproducible in the current implementation: one out-of-range model field throws from `src/subagent.ts` and aborts the metadata task.

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [x] 记忆体或 Provider / Memory Spaces or Providers
- [x] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [ ] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [x] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [ ] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin main
git merge-base --is-ancestor origin/main HEAD
```

The branch was created from `origin/main` at `8cefff7`.

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor reviewed and accepted.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used: Claude Sonnet 4.6

使用的编码 Agent 工具 / Coding Agent tool used: Claude Code

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for Client and Host wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / No persistence format, RPC authority, path, or credential behavior was changed; strict persistence rejection remains covered by existing tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing documentation is synchronized in Chinese and English.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

No storage format, Provider protocol, configuration, or credential behavior changes. Existing metadata is preserved when a generated candidate fails the local title or description length bounds. Valid updates continue through the existing atomic `updateBodyMetadata` path; unknown or duplicate IDs remain fail-closed. Empty filtered results do not invoke the strict persistence method.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
./node_modules/.bin/vitest run tests/subagent.spec.ts tests/rpc.spec.ts tests/memory-bodies.spec.ts
./node_modules/.bin/tsc -p tsconfig.json --noEmit
git diff --check
```

结果摘要 / Result summary:

- 146 tests passed across `tests/subagent.spec.ts`, `tests/rpc.spec.ts`, and `tests/memory-bodies.spec.ts`.
- TypeScript check passed.
- Whitespace check passed.
- The repository `pnpm` wrapper attempted dependency verification but could not complete because the current registry was intermittently unreachable and the freshly published rc.8 dependencies were rejected by the configured minimum-release-age policy. The installed local binaries above were used for the focused validation instead.

## 用户可见变更证据 / Local Feature Evidence

Evidence: N/A. This is an internal reliability fix: it preserves the existing UI success/error states and persistence contract, without adding or changing a visual surface. The focused coordinator test covers a valid candidate alongside an overlong candidate, and the RPC test covers an all-invalid result without persistence mutation. The UI guide is synchronized in both languages.