### PR TITLE
fix: keep Mnemon sidebar readable with transparent-base skins

### DIFF
--- a/src/client/MnemonSidebarView.module.css
+++ b/src/client/MnemonSidebarView.module.css
@@ -3,7 +3,7 @@
  * host tokens. Buildin never receives these classes and retains its original UI.
  */
 .shell.shell {
-  background: var(--dsw-alias-bg-base);
+  background: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base));
   font-family: var(--dsw-font-family);
 }
 
@@ -14,7 +14,7 @@
   gap: 12px;
   padding: 10px 16px 6px;
   border-bottom: 0;
-  background: var(--dsw-alias-bg-base);
+  background: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base));
 }
 
 .shell .brand { flex: 1 1 auto; gap: 8px; overflow: hidden; }
@@ -90,7 +90,7 @@
   border-radius: 6px;
   padding: 0 8px;
   color: var(--dsw-alias-state-business-primary);
-  background: var(--dsw-alias-bg-base);
+  background: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base));
   font-size: 11px;
   cursor: pointer;
 }
@@ -101,7 +101,7 @@
   gap: 0;
   padding: 0 16px;
   border-bottom: 0;
-  background: var(--dsw-alias-bg-base);
+  background: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base));
 }
 
 .shell .topNavigation::after { display: none; }
@@ -131,7 +131,7 @@
   flex: 0 0 auto;
   padding: 12px 16px 0;
   border-bottom: 1px solid var(--dsw-alias-border-l1);
-  background: var(--dsw-alias-bg-base);
+  background: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base));
 }
 .shell .memoryWorkspace > [class*='pageHeader'] { margin-bottom: 8px; }
 
@@ -194,7 +194,7 @@
   overflow: hidden;
   border: 1px solid var(--dsw-alias-border-l2);
   border-radius: 14px;
-  background: var(--dsw-alias-bg-base);
+  background: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base));
   box-shadow: var(--dsw-shadow-lv3);
 }
 .shell .modal.modalWide { width: min(780px, calc(100vw - 48px)); }
@@ -216,7 +216,7 @@
   line-height: 1.5;
 }
 .shell .modal > [class*='modalBody'] { min-height: 0; overflow-x: hidden; overflow-y: auto; overscroll-behavior: contain; padding: 18px; scrollbar-gutter: stable; touch-action: pan-y; -webkit-overflow-scrolling: touch; }
-.shell .modal > [class*='modalFooter'] { border-top-color: var(--dsw-alias-border-l1); background: var(--dsw-alias-bg-base); }
+.shell .modal > [class*='modalFooter'] { border-top-color: var(--dsw-alias-border-l1); background: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base)); }
 @supports (height: 100dvh) { .shell .modal { max-height: calc(100dvh - 48px); } }
 .shell .modal form[class*='runtimeComposer'],
 .shell .modal form[class*='documentEditor'] {
@@ -375,7 +375,7 @@
   opacity: .45;
 }
 
-.shell .canvas { background: var(--dsw-alias-bg-base); }
+.shell .canvas { background: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base)); }
 .shell button,
 .shell input,
 .shell select,
@@ -408,7 +408,7 @@
   margin: -14px -16px 12px;
   padding: 14px 16px 10px;
   border-bottom: 1px solid var(--dsw-alias-border-l1);
-  background: var(--dsw-alias-bg-base);
+  background: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base));
 }
 
 /*

--- a/src/client/MnemonView.module.css
+++ b/src/client/MnemonView.module.css
@@ -1,5 +1,5 @@
 .shell {
-  --mn-bg: var(--dsw-alias-bg-base);
+  --mn-bg: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base));
   --mn-layer-1: var(--dsw-alias-bg-layer-1);
   --mn-layer-2: var(--dsw-alias-bg-layer-2);
   --mn-input: var(--dsw-specific-input-major, var(--dsw-alias-bg-layer-2));

--- a/src/client/MnemonWorkspace.module.css
+++ b/src/client/MnemonWorkspace.module.css
@@ -11,7 +11,7 @@
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  background: var(--dsw-alias-bg-base);
+  background: var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base));
 }
 
 .panelView {

--- a/tests/client-sidebar-css.spec.ts
+++ b/tests/client-sidebar-css.spec.ts
@@ -2,8 +2,19 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 const sidebarCss = readFileSync(new URL('../src/client/MnemonSidebarView.module.css', import.meta.url), 'utf8')
+const viewCss = readFileSync(new URL('../src/client/MnemonView.module.css', import.meta.url), 'utf8')
+const workspaceCss = readFileSync(new URL('../src/client/MnemonWorkspace.module.css', import.meta.url), 'utf8')
+
+const sidebarSurface = 'var(--dsw-alias-bg-overlay, var(--dsw-alias-bg-base))'
 
 describe('Sidebar layout invariants', () => {
+  it('keeps the workspace surfaces opaque under transparent-base skins with a default-theme fallback', () => {
+    expect(workspaceCss).toContain(`background: ${sidebarSurface};`)
+    expect(viewCss).toContain(`--mn-bg: ${sidebarSurface};`)
+    expect(sidebarCss).toContain(`.shell.shell {\n  background: ${sidebarSurface};`)
+    expect(sidebarCss).not.toContain('background: var(--dsw-alias-bg-base);')
+  })
+
   it('pins primary page headers at the canvas origin without an initial sticky settling distance', () => {
     expect(sidebarCss).toContain(".shell .canvas[data-lock-page-header] [class*='pageHeader'] {\n  position: sticky;\n  z-index: 12;\n  top: 0;")
     expect(sidebarCss).not.toContain("top: -14px")


### PR DESCRIPTION
## Summary

- Prefer `--dsw-alias-bg-overlay` for the mounted Mnemon workspace, shared view background, and Sidebar surface overrides.
- Preserve default-theme behavior by falling back to `--dsw-alias-bg-base` when the overlay token is absent.
- Add a focused CSS invariant test covering the fallback chain and preventing direct base-only Sidebar surfaces.

## Testing

- `pnpm test` (371 passed, 1 skipped)
- `pnpm run build`

## Risks / manual review

- Low risk: the change is limited to Mnemon CSS surface tokens.
- Automated checks cover the source invariants and compiled bundle. Live verification with maid-atelier was not available in this checkout; please confirm the visual opacity with that skin during review.

Closes #56