### PR TITLE
chore: prepare v0.2.14 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center"><strong>English</strong> · <a href="./README.zh-CN.md">简体中文</a></p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.13-5b5bd6" alt="release v0.2.13">
+  <img src="https://img.shields.io/badge/release-v0.2.14-5b5bd6" alt="release v0.2.14">
   <img src="https://img.shields.io/badge/memory-3%20tiers-087c5b" alt="three memory tiers">
   <img src="https://img.shields.io/badge/providers-9-c66a09" alt="nine providers">
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A520-43853d" alt="Node.js 20 or newer">
@@ -22,7 +22,7 @@
 <p align="center">
   <a href="./docs/en/capabilities.md"><strong>Explore the capability map</strong></a> ·
   <a href="./docs/en/getting-started.md">Start in five minutes</a> ·
-  <a href="./docs/en/releases/v0.2.13.md">Read the v0.2.13 notes</a> ·
+  <a href="./docs/en/releases/v0.2.14.md">Read the v0.2.14 notes</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">Watch the widescreen demo</a>
 </p>
 
@@ -190,7 +190,7 @@ See [Operations, security, and troubleshooting](./docs/en/operations.md) for bac
 | Configure scope, routing, and model selection | [Configuration](./docs/en/configuration.md) |
 | Back up, update, or troubleshoot | [Operations](./docs/en/operations.md) |
 | Integrate tools, commands, or RPC | [Interface reference](./docs/en/interfaces.md) |
-| Review the release | [v0.2.13 release notes](./docs/en/releases/v0.2.13.md) |
+| Review the release | [v0.2.14 release notes](./docs/en/releases/v0.2.14.md) |
 
 See the [documentation hub](./docs/en/README.md) for the full map.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 <p align="center"><a href="./README.md">English</a> · <strong>简体中文</strong></p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.13-5b5bd6" alt="发布版本 v0.2.13">
+  <img src="https://img.shields.io/badge/release-v0.2.14-5b5bd6" alt="发布版本 v0.2.14">
   <img src="https://img.shields.io/badge/%E8%AE%B0%E5%BF%86-3%20%E5%B1%82-087c5b" alt="三层记忆">
   <img src="https://img.shields.io/badge/Provider-9-c66a09" alt="九种 Provider">
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A520-43853d" alt="Node.js 20 或更新版本">
@@ -22,7 +22,7 @@
 <p align="center">
   <a href="./docs/zh-CN/capabilities.md"><strong>先看能力地图</strong></a> ·
   <a href="./docs/zh-CN/getting-started.md">5 分钟开始</a> ·
-  <a href="./docs/zh-CN/releases/v0.2.13.md">v0.2.13 升级说明</a> ·
+  <a href="./docs/zh-CN/releases/v0.2.14.md">v0.2.14 升级说明</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">观看宽屏实机演示</a>
 </p>
 
@@ -190,7 +190,7 @@ dsh plugin --profile headless add "link:/absolute/path/to/dsh-mnemon"
 | 配置范围、路由与模型 | [配置参考](./docs/zh-CN/configuration.md) |
 | 备份、更新或排障 | [运维指南](./docs/zh-CN/operations.md) |
 | 接入工具、命令或 RPC | [接口参考](./docs/zh-CN/interfaces.md) |
-| 查看本次升级 | [v0.2.13 发布说明](./docs/zh-CN/releases/v0.2.13.md) |
+| 查看本次升级 | [v0.2.14 发布说明](./docs/zh-CN/releases/v0.2.14.md) |
 
 完整目录见[文档中心](./docs/zh-CN/README.md)。
 

--- a/docs/en/releases/v0.2.14.md
+++ b/docs/en/releases/v0.2.14.md
@@ -18,6 +18,7 @@ v0.2.14 is a focused Web UI patch that keeps the Mnemon Sidebar workspace readab
 
 ## Verification
 
+- Two real isolated DSH 0.1.0-rc.8 Web profiles load v0.2.13 and this release with maid-atelier pinned at `d0419da`; same-viewport captures confirm that the workspace changes from fully transparent to a high-opacity surface and remains readable in both light and dark modes.
 - The complete local verification passes with 371 tests; one Windows-only smoke test is skipped only on the non-Windows local run.
 - Focused CSS coverage verifies the overlay-to-base fallback in source and compiled output and prevents direct base-only Sidebar surfaces from returning.
 - Type checking, deterministic builds, Headless activation, package validation, publint, attw, and CI on Ubuntu and Windows pass.

--- a/docs/en/releases/v0.2.14.md
+++ b/docs/en/releases/v0.2.14.md
@@ -1,0 +1,26 @@
+# v0.2.14: Readable Sidebar Surfaces
+
+[简体中文](../../zh-CN/releases/v0.2.14.md) | **English** | [Capability map](../capabilities.md)
+
+v0.2.14 is a focused Web UI patch that keeps the Mnemon Sidebar workspace readable when a DSH skin makes the base background transparent.
+
+## Fixed
+
+- The mounted Mnemon workspace, shared view surface, and Sidebar-specific chrome now prefer `--dsw-alias-bg-overlay` and fall back to `--dsw-alias-bg-base` when the overlay token is unavailable.
+- The fallback is applied consistently to the Sidebar shell, headers, navigation, page surfaces, dialogs, footers, canvas, and update banner, preventing the conversation and full-screen skin artwork from showing through the workspace.
+- Default-theme behavior is preserved because themes without the overlay token continue to use the existing base surface.
+
+## Safety and compatibility
+
+- This release changes Client CSS only. Host behavior, Runtime Memory, Project Documents, Memory Spaces, Providers, configuration, RPC permissions, storage formats, credentials, and existing data are unchanged.
+- Skins such as maid-atelier can retain their transparent conversation canvas while providing Mnemon with their high-opacity overlay color. No skin-specific selector or dependency is introduced.
+- Update dsh-mnemon and restart the affected DSH profile. A normal downgrade to v0.2.13 restores the previous surface selection and requires no data rollback.
+
+## Verification
+
+- The complete local verification passes with 371 tests; one Windows-only smoke test is skipped only on the non-Windows local run.
+- Focused CSS coverage verifies the overlay-to-base fallback in source and compiled output and prevents direct base-only Sidebar surfaces from returning.
+- Type checking, deterministic builds, Headless activation, package validation, publint, attw, and CI on Ubuntu and Windows pass.
+- The fix resolves [issue #56](https://github.com/omdsh-dev/dsh-mnemon/issues/56).
+
+See the [v0.2.13 release notes](./v0.2.13.md) for the previous patch release.

--- a/docs/zh-CN/releases/v0.2.14.md
+++ b/docs/zh-CN/releases/v0.2.14.md
@@ -18,6 +18,7 @@ v0.2.14 是一次聚焦 Web UI 的补丁发布：当 DSH 皮肤把基础背景�
 
 ## 验证
 
+- 两个真实隔离的 DSH 0.1.0-rc.8 Web profile 分别加载 v0.2.13 与本版本，并共同启用 maid-atelier 固定提交 `d0419da`；同视口截图确认工作台由完全透明恢复为高不透明表面，浅色与暗色模式均清晰可读。
 - 本地完整验证共 371 项测试通过；Windows 专用 smoke test 只会在非 Windows 本地环境跳过。
 - 定向 CSS 测试同时检查源码与构建产物中的 overlay → base 回退链，并防止侧边栏重新出现只使用透明 base 的表面。
 - 类型检查、确定性构建、Headless 激活、发布包校验、publint、attw，以及 Ubuntu 与 Windows CI 均通过。

--- a/docs/zh-CN/releases/v0.2.14.md
+++ b/docs/zh-CN/releases/v0.2.14.md
@@ -1,0 +1,26 @@
+# v0.2.14：透明皮肤下清晰可读的侧边栏
+
+**简体中文** | [English](../../en/releases/v0.2.14.md) | [能力地图](../capabilities.md)
+
+v0.2.14 是一次聚焦 Web UI 的补丁发布：当 DSH 皮肤把基础背景设为透明时，Mnemon 侧边栏工作台仍能保持清晰可读。
+
+## 修复
+
+- Mnemon 挂载工作区、共享视图表面与侧边栏专用界面现在优先使用 `--dsw-alias-bg-overlay`；主题未提供该令牌时，继续回退到 `--dsw-alias-bg-base`。
+- 回退链统一覆盖侧边栏外壳、页眉、导航、页面表面、弹窗、底部操作区、画布与更新提示，避免背后的对话内容和皮肤全屏角色图层透显到工作台中。
+- 默认主题未定义 overlay 令牌时仍使用原有基础表面，因此默认外观保持不变。
+
+## 安全与兼容性
+
+- 本次只修改 Client CSS。Host 行为、运行时记忆、项目档案、记忆体、Provider、配置、RPC 权限、存储格式、凭据与已有数据均不变。
+- maid-atelier 等皮肤仍可保留透明的对话画布，同时通过自身的高不透明 overlay 颜色保证 Mnemon 可读；插件没有引入任何皮肤专用选择器或依赖。
+- 更新 dsh-mnemon 后重启受影响的 DSH profile 即可。如需回滚，可正常降级到 v0.2.13，无需回滚数据。
+
+## 验证
+
+- 本地完整验证共 371 项测试通过；Windows 专用 smoke test 只会在非 Windows 本地环境跳过。
+- 定向 CSS 测试同时检查源码与构建产物中的 overlay → base 回退链，并防止侧边栏重新出现只使用透明 base 的表面。
+- 类型检查、确定性构建、Headless 激活、发布包校验、publint、attw，以及 Ubuntu 与 Windows CI 均通过。
+- 本版本修复 [issue #56](https://github.com/omdsh-dev/dsh-mnemon/issues/56)。
+
+上一个补丁版本见 [v0.2.13 发布说明](./v0.2.13.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mnemon",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Three-tier memory control plane for DeepSeek Harness: persistent runtime context, searchable project documents, pluggable long-term memory, smart routing, supervised agent workflows, WebUI, and headless tools.",
   "keywords": [
     "deepseek-harness",


### PR DESCRIPTION
## 摘要 / Summary

准备 v0.2.14 补丁发布，更新包版本、根 README 发布入口与双语发布说明。版本内容聚焦已合并的 #57：当皮肤把基础背景设为透明时，Mnemon 侧边栏工作台改用高不透明 overlay 表面并保持可读。

## 关联 Issue 或背景 / Related Issue or Context

#56（已由 #57 修复并合并）；本 PR 负责发布元数据与真实 WebUI 验证记录。

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [x] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [ ] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [x] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command: `git fetch origin main`；发布分支基于合并提交 `721f049`。

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used: GPT-5

使用的编码 Agent 工具 / Coding Agent tool used: Codex

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

本 PR 只更新版本号与双语发布文档。已合并修复只涉及 Client CSS；Host、Runtime、Documents、Memory Spaces、Providers、配置、RPC 权限、存储格式与现有数据均不变。可正常降级到 v0.2.13，无需数据回滚。

## 本地验证 / Local Validation

执行的命令 / Commands run:

`pnpm run verify`; `npm pack --ignore-scripts --dry-run`; 两个隔离 DSH 0.1.0-rc.8 Web profile 的同视口前后对照。

结果摘要 / Result summary:

371 项测试通过，1 项 Windows 专用 smoke test 在本地非 Windows 环境跳过；类型检查、确定性构建、Headless 激活、包内容、publint 与 attw 全部通过。dry-run 制品为 dsh-mnemon@0.2.14，72 个文件，约 308.9 kB。v0.2.13 与 v0.2.14 profile 均启用 maid-atelier `d0419da`：修复前工作台完全透明，修复后浅色为 `rgba(248,250,255,.96)`、暗色为 `rgba(13,25,59,.97)`，内容清晰可读。

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence: 真实隔离 WebUI 的同视口前后截图已人工核对；#56 中的透明叠层可稳定复现，v0.2.14 下角色图层不再穿透 Mnemon 工作台。