### PR TITLE
docs: link memory provider repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 `dsh-mnemon` gives DSH one memory control plane without forcing every kind of knowledge into one database. Runtime Memory keeps compact context available every turn. Project Documents preserve complete narratives. Memory Spaces retrieve durable evidence on demand and can use **Mnemon, OpenViking, Honcho, Mem0, Hindsight, Holographic, RetainDB, ByteRover, or Supermemory**.
 
-Mnemon remains the official, prioritized native engine. The third tier is replaceable; the first two keep the same storage, workspace, and interaction model regardless of provider.
+[Mnemon](https://github.com/mnemon-dev/mnemon) remains the official, prioritized native engine. The third tier is replaceable; the first two keep the same storage, workspace, and interaction model regardless of provider.
 
 ## Understand the scope in 30 seconds
 
@@ -58,15 +58,15 @@ These tasks do not reuse or consume the main conversation history. By default th
 
 | Provider | Shape | Best fit |
 |---|---|---|
-| **Mnemon** | Official native local CLI + SQLite | Exact writes, entities, typed relationships, local-first sharing |
-| **OpenViking** | HTTP + `viking://` | Resource trees and asynchronous extraction |
-| **Honcho** | HTTP workspace / peers | Team and Agent-peer conclusions |
-| **Mem0** | Platform or self-hosted HTTP | Existing user / Agent memory |
-| **Hindsight** | HTTP memory bank | Banks, entities, provider-native graph |
-| **Holographic** | Local structured fact files | Auditable facts, trust scores, local entities |
-| **RetainDB** | HTTP project / user | Project- and user-scoped profiles |
-| **ByteRover** | Local `brv` CLI | Code knowledge trees and curate workflows |
-| **Supermemory** | HTTP container | Document ingestion and container sharing |
+| **[Mnemon](https://github.com/mnemon-dev/mnemon)** | Official native local CLI + SQLite | Exact writes, entities, typed relationships, local-first sharing |
+| **[OpenViking](https://github.com/volcengine/OpenViking)** | HTTP + `viking://` | Resource trees and asynchronous extraction |
+| **[Honcho](https://github.com/plastic-labs/honcho)** | HTTP workspace / peers | Team and Agent-peer conclusions |
+| **[Mem0](https://github.com/mem0ai/mem0)** | Platform or self-hosted HTTP | Existing user / Agent memory |
+| **[Hindsight](https://github.com/vectorize-io/hindsight)** | HTTP memory bank | Banks, entities, provider-native graph |
+| **[Holographic](https://github.com/NousResearch/hermes-agent/tree/main/plugins/memory/holographic)** | Local structured fact files | Auditable facts, trust scores, local entities |
+| **[RetainDB](https://github.com/RetainDB/RetainDB)** | HTTP project / user | Project- and user-scoped profiles |
+| **[ByteRover](https://github.com/campfirein/byterover-cli)** | Local `brv` CLI | Code knowledge trees and curate workflows |
+| **[Supermemory](https://github.com/supermemoryai/supermemory)** | HTTP container | Document ingestion and container sharing |
 
 Provider capability differences stay visible. dsh-mnemon never invents graph edges, deletion semantics, or enumerable content for an engine that does not provide them. **Settings owns reusable Provider services; Memory Spaces owns concrete instances, activation, scope, and metadata.** External Providers are off by default.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@
 
 `dsh-mnemon` 为 DSH 提供统一的记忆控制面，但不要求所有知识进入同一种数据库。运行时记忆让紧凑上下文每轮可用；项目档案保留完整叙事；记忆体按需召回长期证据，底层可选择 **Mnemon、OpenViking、Honcho、Mem0、Hindsight、Holographic、RetainDB、ByteRover 或 Supermemory**。
 
-Mnemon 仍是官方优先的原生引擎。可以替换的是第三层；无论选择哪个 Provider，前两层的存储、工作区和交互心智保持不变。
+[Mnemon](https://github.com/mnemon-dev/mnemon) 仍是官方优先的原生引擎。可以替换的是第三层；无论选择哪个 Provider，前两层的存储、工作区和交互心智保持不变。
 
 ## 30 秒理解能力边界
 
@@ -58,15 +58,15 @@ Mnemon 仍是官方优先的原生引擎。可以替换的是第三层；无论�
 
 | Provider | 形态 | 适合场景 |
 |---|---|---|
-| **Mnemon** | 官方原生，本地 CLI + SQLite | 精确写入、实体、类型关系、本地优先共享 |
-| **OpenViking** | HTTP + `viking://` | 资源树与异步提炼 |
-| **Honcho** | HTTP workspace / peers | 团队与 Agent peer conclusions |
-| **Mem0** | Platform 或自托管 HTTP | 已有用户 / Agent 记忆 |
-| **Hindsight** | HTTP memory bank | bank、实体与 Provider 原生图谱 |
-| **Holographic** | 本地结构化事实文件 | 可审计事实、信任评分、本地实体 |
-| **RetainDB** | HTTP project / user | 项目与用户双作用域画像 |
-| **ByteRover** | 本地 `brv` CLI | 代码知识树与 curate 流程 |
-| **Supermemory** | HTTP container | 文档摄取与容器级共享 |
+| **[Mnemon](https://github.com/mnemon-dev/mnemon)** | 官方原生，本地 CLI + SQLite | 精确写入、实体、类型关系、本地优先共享 |
+| **[OpenViking](https://github.com/volcengine/OpenViking)** | HTTP + `viking://` | 资源树与异步提炼 |
+| **[Honcho](https://github.com/plastic-labs/honcho)** | HTTP workspace / peers | 团队与 Agent peer conclusions |
+| **[Mem0](https://github.com/mem0ai/mem0)** | Platform 或自托管 HTTP | 已有用户 / Agent 记忆 |
+| **[Hindsight](https://github.com/vectorize-io/hindsight)** | HTTP memory bank | bank、实体与 Provider 原生图谱 |
+| **[Holographic](https://github.com/NousResearch/hermes-agent/tree/main/plugins/memory/holographic)** | 本地结构化事实文件 | 可审计事实、信任评分、本地实体 |
+| **[RetainDB](https://github.com/RetainDB/RetainDB)** | HTTP project / user | 项目与用户双作用域画像 |
+| **[ByteRover](https://github.com/campfirein/byterover-cli)** | 本地 `brv` CLI | 代码知识树与 curate 流程 |
+| **[Supermemory](https://github.com/supermemoryai/supermemory)** | HTTP container | 文档摄取与容器级共享 |
 
 Provider 能力差异会如实展示：引擎没有图谱边、删除语义或可枚举内容时，dsh-mnemon 不会伪造。**设置页管理可复用的 Provider 服务；记忆体页管理具体实例、激活、作用域与元信息。**三方 Provider 默认关闭。
 


### PR DESCRIPTION
## 摘要 / Summary

Adds direct repository links to the first Mnemon statement and to all nine entries in the Provider table. The English and Simplified Chinese root READMEs remain synchronized.

## 关联 Issue 或背景 / Related Issue or Context

N/A — maintainer-requested bilingual README maintenance; no product behavior, Provider integration, persistence format, or security boundary changes.

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [x] 记忆体或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [ ] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [ ] Bug 修复 / Bug fix
- [x] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [ ] 维护或重构 / Maintenance or refactor
- [ ] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin main
git worktree add -b codex/readme-provider-repository-links <temporary-worktree> origin/main
```

## AI 编码披露 / AI Coding Disclosure

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

OpenAI GPT-5 family

使用的编码 Agent 工具 / Coding Agent tool used:

Codex

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

N/A — documentation-only link additions. No code, configuration, credentials, storage formats, Provider data, upgrade behavior, or rollback behavior changes.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm install --frozen-lockfile
pnpm run verify
git diff --check origin/main...HEAD
git diff --name-status origin/main...HEAD
```

结果摘要 / Result summary:

- TypeScript passed.
- Vitest passed: 39 files and 371 tests; 1 Windows-only file/test skipped.
- Deterministic double build passed for 65 generated files.
- Isolated Headless activation passed with 35 total tools and 5 representative Mnemon tools.
- Package validation passed: 72 files, 309,773 packed bytes, 1,439,882 unpacked bytes.
- `publint --strict` and attw ESM-only package checks passed.
- Branch comparison contains exactly `README.md` and `README.zh-CN.md`.

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence:

N/A — this PR changes Markdown links only and does not alter application behavior or UI rendering.
