### PR TITLE
chore(compat): declare dsh.compat metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,19 @@
         "@deepseek-ai/dsh-client-locale"
       ],
       "platform": "web"
+    },
+    "compat": {
+      "requires": ">=0.1.0-rc.7",
+      "tested": [
+        "0.1.0-rc.7",
+        "0.1.0-rc.8",
+        "0.1.1-rc.1",
+        "0.1.1-rc.2"
+      ],
+      "storageFormats": [
+        "zstd-jsonl"
+      ],
+      "kind": "memory"
     }
   },
   "scripts": {


### PR DESCRIPTION
Declares machine-readable compatibility metadata (dsh.compat) so tooling can
gate upgrades before they break:

- \equires\: >=0.1.0-rc.7
- \	ested\: 0.1.0-rc.7 0.1.0-rc.8 0.1.1-rc.1 0.1.1-rc.2 (verified 2026-08-25 by dsh-compat-guard local matrix:
  install + full tree mount + clean exit on all four DSH versions)
- \storageFormats\: zstd-jsonl

Generated by dsh-compat-guard (https://github.com/Shizuku-keop/dsh-compat-guard).
Note: the tested list covers the plugin's API surface across DSH rc.7 -> rc.2;
the per-version results live in the compatibility registry (Blue-Whale-Harness/compat).