### PR TITLE
docs(readme): add dshfind downloads badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://github.com/omdsh-dev/dsh-mnemon/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/omdsh-dev/dsh-mnemon" /></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg" /></a>
   <a href="https://dshfind.com/en/plugins/omdsh-dev/dsh-mnemon?ref=badge"><img alt="dshfind" src="https://dshfind.com/api/badge/omdsh-dev/dsh-mnemon?lang=en" /></a>
+  <a href="https://dshfind.com/en/plugins/omdsh-dev/dsh-mnemon?ref=badge"><img alt="dshfind downloads" src="https://dshfind.com/api/badge/omdsh-dev/dsh-mnemon?metric=downloads&amp;lang=en" /></a>
 </p>
 
 <p align="center"><strong>The three-tier, pluggable, Agent-driven memory system for DeepSeek Harness.</strong></p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,7 @@
   <a href="https://github.com/omdsh-dev/dsh-mnemon/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/omdsh-dev/dsh-mnemon" /></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg" /></a>
   <a href="https://dshfind.com/zh/plugins/omdsh-dev/dsh-mnemon?ref=badge"><img alt="dshfind" src="https://dshfind.com/api/badge/omdsh-dev/dsh-mnemon?lang=zh" /></a>
+  <a href="https://dshfind.com/zh/plugins/omdsh-dev/dsh-mnemon?ref=badge"><img alt="dshfind 下载量" src="https://dshfind.com/api/badge/omdsh-dev/dsh-mnemon?metric=downloads&amp;lang=zh" /></a>
 </p>
 
 <p align="center"><strong>DeepSeek Harness 的三层、可插拔、Agent 驱动记忆系统。</strong></p>


### PR DESCRIPTION
## 摘要 / Summary

Add the dshfind downloads badge to both root READMEs, using the localized English and Simplified Chinese badge variants. Each badge reports dshfind's dynamic all-channel download total and links to the matching localized dshfind plugin page.

## 关联 Issue 或背景 / Related Issue or Context

N/A — this is directly requested maintainer documentation maintenance and does not introduce a new capability or change runtime behavior.

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [ ] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [ ] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [x] 维护或重构 / Maintenance or refactor
- [ ] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

    git fetch origin
    git switch -c codex/add-dshfind-downloads-badge origin/main

The branch was created from origin/main at 65bdb93d7b2deec762a72c5b1a70224f14a8738d.

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used: GPT-5

使用的编码 Agent 工具 / Coding Agent tool used: Codex

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 @deepseek-ai/* NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published @deepseek-ai/* NPM contracts.
- [x] Client 与 Host 边界仍以 src/shared/contracts.ts 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses src/shared/contracts.ts as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 lib/ 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated lib/ files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

N/A — the change only adds external SVG badge markup to the two READMEs. It does not affect DSH, Mnemon, Providers, configuration, storage formats, upgrades, rollback behavior, credentials, or existing data. Reverting the two added lines fully rolls back the change.

## 本地验证 / Local Validation

执行的命令 / Commands run:

    git diff --check
    pnpm run verify
    curl -fsSL https://dshfind.com/api/badge/omdsh-dev/dsh-mnemon?metric=downloads\&lang=en
    curl -fsSL https://dshfind.com/api/badge/omdsh-dev/dsh-mnemon?metric=downloads\&lang=zh

结果摘要 / Result summary:

- git diff --check passed.
- Both localized badge endpoints returned valid SVG output with the downloads label.
- pnpm run verify passed: typecheck, 45 test files and 485 tests, deterministic double build, Headless activation, package contents, public entry imports, publint, and attw. The Windows-only smoke test was skipped as expected. Vite emitted non-fatal missing-source-map warnings for the published @deepseek-ai/dsh-client-ui-primitives package.

## 用户可见变更证据 / Local Feature Evidence

The live SVGs added by this PR render below and link to the same endpoints used in the READMEs:

- English: ![dshfind downloads](https://dshfind.com/api/badge/omdsh-dev/dsh-mnemon?metric=downloads&lang=en)
- 简体中文: ![dshfind 下载量](https://dshfind.com/api/badge/omdsh-dev/dsh-mnemon?metric=downloads&lang=zh)

No credentials, private memory, or sensitive paths are exposed.
