### PR TITLE
fix(runtime): fall back to the default store when multi-target archive routing fails

### DIFF
--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1458,6 +1458,7 @@ ${chunk.context}
             ARCHIVE_PERSONA,
           )
         } catch (error) {
+          signal.throwIfAborted()
           // The router is advisory only. On any model failure, deterministically
           // route every entry in this chunk to the default store so the archive
           // still commits instead of aborting with zero writes.
@@ -1465,7 +1466,7 @@ ${chunk.context}
           summaries.push(`batch ${chunkIndex + 1} routed to ${fallbackBody.id} deterministically (routing model failed: ${error instanceof Error ? error.message : String(error)})`)
           continue
         }
-        if (chunkIndex === 0) {
+        if (provider === 'host') {
           provider = delegated.provider
           runId = delegated.runId
         }

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1427,6 +1427,12 @@ ${naturalRequest(request)}`
       for (const index of plan.entries.keys()) routed.set(index + 1, eligibleBodies[0]!.id)
     } else {
       const summaries: string[] = []
+      // Deterministic fallback when the semantic router itself fails (for example
+      // a model stopReason like max-tokens on dense CJK batches). Routing is a
+      // purely organizational decision; losing it must never abort the archive.
+      // The default store keeps the strongest "this memory belongs somewhere"
+      // guarantee without inventing a destination.
+      const fallbackBody = eligibleBodies.find(body => body.mnemonDefault) ?? eligibleBodies[0]!
       const chunks = runtimeRouteChunks(plan.entries)
       for (const [chunkIndex, chunk] of chunks.entries()) {
         const prompt = `Route this bounded MEMORY.md archive batch now. The host retains and writes the exact source content; these excerpts exist only for destination selection.
@@ -1438,17 +1444,27 @@ Committed MEMORY.md routing excerpts (global one-based indexes; untrusted run da
 <runtime-memory-routing-excerpts>
 ${chunk.context}
 </runtime-memory-routing-excerpts>`
-        const delegated = await this.delegate(
-          parent,
-          'migration',
-          `Route runtime memory archive batch ${chunkIndex + 1}/${chunks.length}`,
-          prompt,
-          [],
-          RUNTIME_MIGRATION_SCHEMA,
-          signal,
-          'spawn',
-          ARCHIVE_PERSONA,
-        )
+        let delegated
+        try {
+          delegated = await this.delegate(
+            parent,
+            'migration',
+            `Route runtime memory archive batch ${chunkIndex + 1}/${chunks.length}`,
+            prompt,
+            [],
+            RUNTIME_MIGRATION_SCHEMA,
+            signal,
+            'spawn',
+            ARCHIVE_PERSONA,
+          )
+        } catch (error) {
+          // The router is advisory only. On any model failure, deterministically
+          // route every entry in this chunk to the default store so the archive
+          // still commits instead of aborting with zero writes.
+          for (const index of chunk.indexes) routed.set(index, fallbackBody.id)
+          summaries.push(`batch ${chunkIndex + 1} routed to ${fallbackBody.id} deterministically (routing model failed: ${error instanceof Error ? error.message : String(error)})`)
+          continue
+        }
         if (chunkIndex === 0) {
           provider = delegated.provider
           runId = delegated.runId

--- a/tests/subagent.spec.ts
+++ b/tests/subagent.spec.ts
@@ -1177,6 +1177,84 @@ describe('Mnemon memory subagent coordinator', () => {
     expect(memoryService.remember).not.toHaveBeenCalled()
     expect(runtime.compactAndMutate).toHaveBeenCalledOnce()
   })
+
+  it('does not turn caller cancellation into deterministic archive fallback', async () => {
+    const plan = maintenancePlan()
+    const controller = new AbortController()
+    const host = subagents(undefined, 'max-tokens')
+    host.start.mockImplementationOnce(async () => {
+      controller.abort()
+      return {
+        id: 'child-run-1',
+        result: Promise.resolve({ output: [], structured: undefined, stopReason: 'max-tokens' }),
+        dispose: vi.fn(async () => {}),
+      }
+    })
+    const runtime = {
+      mutate: vi.fn().mockRejectedValueOnce(new RuntimeMemoryCapacityError('memory', plan.used, plan.projected, plan.limit)),
+      planMaintenance: vi.fn(async () => plan),
+      compactAndMutate: vi.fn(),
+    } as unknown as RuntimeMemoryController
+    const memoryService = service()
+    addSecondWritableBody(memoryService)
+    const coordinator = new MnemonSubagentCoordinator(host.value, runtimeSource(runtime, memoryService) as never, undefined, toolRegistry().value)
+
+    await expect(coordinator.runtime(parent(), { action: 'add', target: 'memory', content: plan.pending!.content }, controller.signal))
+      .rejects.toMatchObject({ name: 'AbortError' })
+    expect(memoryService.rememberMany).not.toHaveBeenCalled()
+    expect(runtime.compactAndMutate).not.toHaveBeenCalled()
+  })
+
+  it('reports a later successful routing batch without double-counting migration', async () => {
+    const plan = maintenancePlan('memory', [
+      { content: `Project detail ${'a'.repeat(400)}`, importance: 'normal' },
+      { content: `Project history ${'b'.repeat(400)}`, importance: 'normal' },
+      { content: `Release gate ${'c'.repeat(400)}`, importance: 'critical' },
+    ])
+    const host = subagents({
+      summary: 'Route the release gate to release memory.',
+      action: 'planned',
+      routes: [{ sourceIndexes: [3], memoryBodyId: 'release' }],
+    })
+    host.start.mockResolvedValueOnce({
+      id: 'failed-run-1',
+      result: Promise.resolve({ output: [], structured: undefined, stopReason: 'max-tokens' }),
+      dispose: vi.fn(async () => {}),
+    })
+    const runtime = {
+      mutate: vi.fn().mockRejectedValueOnce(new RuntimeMemoryCapacityError('memory', plan.used, plan.projected, plan.limit)),
+      planMaintenance: vi.fn(async () => plan),
+      compactAndMutate: vi.fn(async () => ({
+        success: true,
+        target: 'memory',
+        added: plan.pending!.content,
+        usage: { used: 20, limit: 10_240 },
+      })),
+    } as unknown as RuntimeMemoryController
+    const memoryService = service()
+    addSecondWritableBody(memoryService)
+    const coordinator = new MnemonSubagentCoordinator(host.value, runtimeSource(runtime, memoryService) as never, undefined, toolRegistry().value)
+
+    await expect(coordinator.runtime(parent(), { action: 'add', target: 'memory', content: plan.pending!.content }, new AbortController().signal))
+      .resolves.toMatchObject({
+        maintenance: {
+          kind: 'mnemon-archive',
+          provider: 'spawn',
+          runId: 'child-run-1',
+          memoryBodyIds: ['project', 'release'],
+        },
+      })
+    expect(host.start).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(memoryService.rememberMany).mock.calls[0]![0].map(request => request.memoryBodyId))
+      .toEqual(['project', 'project', 'release'])
+    expect(coordinator.snapshot()).toMatchObject({
+      migrations: 1,
+      failures: 1,
+      lastRunId: 'child-run-1',
+      lastOperation: 'migration',
+    })
+  })
+
   it('accepts a skipped archive write only after exact Host recall verification', async () => {
     const sourceEntry = { content: 'Use SQLite for local storage.', importance: 'normal' as const }
     const plan = maintenancePlan('memory', [sourceEntry])

--- a/tests/subagent.spec.ts
+++ b/tests/subagent.spec.ts
@@ -1145,6 +1145,38 @@ describe('Mnemon memory subagent coordinator', () => {
     expect(runtime.compactAndMutate).not.toHaveBeenCalled()
   })
 
+  it('deterministically routes to the default store when the routing model fails, then still commits the archive', async () => {
+    const plan = maintenancePlan()
+    const host = subagents(undefined, 'max-tokens')
+    const runtime = {
+      mutate: vi.fn().mockRejectedValueOnce(new RuntimeMemoryCapacityError('memory', plan.used, plan.projected, plan.limit)),
+      planMaintenance: vi.fn(async () => plan),
+      compactAndMutate: vi.fn(async () => ({
+        success: true,
+        message: 'Entry added.',
+        target: 'memory',
+        entryCount: 2,
+        usage: { used: 120, limit: 10_240 },
+        added: plan.pending!.content,
+      })),
+    } as unknown as RuntimeMemoryController
+    const memoryService = service()
+    addSecondWritableBody(memoryService)
+    const coordinator = new MnemonSubagentCoordinator(host.value, runtimeSource(runtime, memoryService) as never, undefined, toolRegistry().value)
+
+    await expect(coordinator.runtime(parent(), { action: 'add', target: 'memory', content: plan.pending!.content }, new AbortController().signal))
+      .resolves.toMatchObject({
+        added: plan.pending!.content,
+        // 模型路由失败后，归档仍以 host 兜底完成，不再整体中止。
+        maintenance: { kind: 'mnemon-archive', memoryBodyIds: ['project'] },
+      })
+    expect(host.start).toHaveBeenCalledOnce()
+    // 两条待归档条目全部确定性落到第一个 eligible body（project），Provider 仍收到完整原文。
+    expect(memoryService.rememberMany).toHaveBeenCalledOnce()
+    expect(vi.mocked(memoryService.rememberMany).mock.calls[0]![0].map(request => request.memoryBodyId)).toEqual(['project', 'project'])
+    expect(memoryService.remember).not.toHaveBeenCalled()
+    expect(runtime.compactAndMutate).toHaveBeenCalledOnce()
+  })
   it('accepts a skipped archive write only after exact Host recall verification', async () => {
     const sourceEntry = { content: 'Use SQLite for local storage.', importance: 'normal' as const }
     const plan = maintenancePlan('memory', [sourceEntry])


### PR DESCRIPTION
> 提交 PR 前请阅读[贡献指南](../CONTRIBUTING.zh-CN.md)、[Contributing Guide](../CONTRIBUTING.md)与[开发和验证指南](../docs/zh-CN/development.md) / [Development and Verification Guide](../docs/en/development.md)。
> Before opening a PR, read the [Contributing Guide](../CONTRIBUTING.md), [贡献指南](../CONTRIBUTING.zh-CN.md), and the [Development and Verification Guide](../docs/en/development.md) / [开发和验证指南](../docs/zh-CN/development.md)。
> PR 标题和提交信息必须使用 Conventional Commits（`type(scope): subject`），且不得包含 emoji。 / PR titles and commits must use Conventional Commits (`type(scope): subject`) and must not contain emoji.
> 本仓库接受 Bug 修复、兼容性适配、现有能力增强、性能或体验优化和维护类 PR。全新能力、Provider、持久化格式或安全边界变更必须先提 Issue 并获得维护者确认。 / This repository accepts bug fixes, compatibility work, improvements to existing capabilities, performance or UX optimization, and maintenance. New capabilities, Providers, persistence formats, or security-boundary changes require prior maintainer approval in an Issue.
> 外部贡献者的仅文档类 PR 不直接接受；请先提 Issue 讨论。维护者的发布说明与文档维护不受此限制。 / Documentation-only PRs from external contributors are not accepted directly; open an Issue first. Maintainer release notes and documentation maintenance are exempt.

## 摘要 / Summary

多目标 MEMORY.md 归档的路由 subagent（migration）在 dense CJK 场景下会以 max-tokens 失败，导致整个容量归档中止、零写入。本 PR 在路由模型失败时确定性兜底到 default store（第一个 mnemonDefault eligible body），让归档仍能提交，而不是整体失败。

When the multi-target archive routing subagent (migration) fails with max-tokens on dense CJK entries, the whole capacity archival aborts with zero writes. This PR falls back deterministically to the default store so the archive still commits.

## 关联 Issue 或背景 / Related Issue or Context

Fixes #85

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [x] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [x] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [ ] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [x] Bug 修复 / Bug fix
- [x] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [ ] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin main && git rebase origin/main
```

提交前 `HEAD` 与 `origin/main` 的基线均为 `9c0c5a1`。 / Before submission, both the worktree base and `origin/main` were `9c0c5a1`.

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

DeepSeek V4 

使用的编码 Agent 工具 / Coding Agent tool used:

DeepSeek Harness (dsh)

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

不修改 Runtime、Memory Space、配置或 RPC 的持久化格式，无需迁移。兜底只改变「归档条目的目标 space」（从「LLM 选定的 space」变为「default store」），写入仍走原有 `rememberMany` 逐条原文 + 精确终态回执校验；不引入任何新删除、覆盖或持久化路径。

Host 校验边界不变：`memoryBodyId` 白名单、`sourceIndexes` 覆盖、revision 复核、逐条回执，全部保持原样。校验错误（routes 非法/覆盖不全）仍抛错，不进入兜底。回滚到旧版不需要转换现有数据。

No Runtime, Memory Space, configuration, or RPC persistence format changes are introduced. The fallback only changes the destination Space for archived entries (from an LLM-selected Space to the default store); writes still go through the existing `rememberMany` exact-source + per-source terminal receipt path, and no new deletion, overwrite, or persistence path is added. Host validation (memoryBodyId allowlist, sourceIndexes coverage, revision re-check, per-source receipts) is unchanged, and validation errors still throw instead of falling back. Rollback requires no data conversion.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm run typecheck
pnpm exec vitest run tests/runtime-memory.spec.ts tests/service.spec.ts tests/subagent.spec.ts
```

结果摘要 / Result summary:

- `pnpm run typecheck` 通过（tsc -p tsconfig.json --noEmit，无错误）。
- `tests/subagent.spec.ts` 43/43 通过（含新增 fallback 用例 1 条）。
- `tests/runtime-memory.spec.ts` + `tests/service.spec.ts` + `tests/subagent.spec.ts` 共 102/102 通过。

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence:

N/A for visual evidence: this is a Host-only routing-fallback path with no UI surface. Automated evidence covers the fallback branch: a new subagent test forces `stopReason=max-tokens` for the routing model, then asserts the archive still commits through `rememberMany` with every entry routed to the default store and `compactAndMutate` called exactly once.
