### PR TITLE
fix(lifecycle): re-compose the guided reminder after a rewind

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -152,6 +152,12 @@ export interface HostAgent {
   session: {
     header?: { origin?: 'subagent'; parentSession?: string; delegationDepth?: number; cwd?: string; agentPreset?: string }
     events: readonly HostSessionEvent[]
+    /**
+     * Model-visible event sequences, in order. Optional because not every host
+     * publishes a surface projection; when absent, callers fall back to
+     * session-scoped state.
+     */
+    surface?: { readonly nodes: readonly number[] }
   }
   ctx: HostAgentContext
   followup(message: HostUserMessage): void

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -106,6 +106,17 @@ function sourceOf(message: HostUserMessage): { kind?: string; plugin?: string } 
   return message.source
 }
 
+/**
+ * Whether an event is a durable user message this plugin produced.
+ */
+function isOwnUserMessageEvent(event: HostSessionEvent | undefined): boolean {
+  if (event?.type !== 'user/message') return false
+  const source = event.data.source
+  if (typeof source !== 'object' || source === null) return false
+  const { kind, plugin } = source as { kind?: unknown; plugin?: unknown }
+  return kind === 'plugin' && plugin === MNEMON_PLUGIN_SOURCE
+}
+
 function eventTurn(event: HostSessionEvent): number | undefined {
   return typeof event.data.turn === 'number' ? event.data.turn : undefined
 }
@@ -200,6 +211,11 @@ class MnemonAgentLifecycle {
     explicitCandidate: boolean
     noMaintenance: boolean
   }>()
+  /**
+   * Fallback presence marker for hosts that publish no surface projection.
+   * A host with a surface answers the question from what the model can
+   * actually see, which is what makes a rewind self-correcting.
+   */
   private cueInjected = false
   private idleReviewTimer: ReturnType<typeof setTimeout> | undefined
   private reviewController: AbortController | undefined
@@ -290,6 +306,27 @@ class MnemonAgentLifecycle {
     return pinned === undefined ? undefined : pinned.manager.wake(pinned.context.viewId)
   }
 
+  /**
+   * Whether the reminder is still visible to the model.
+   *
+   * Read from the surface rather than from `cueInjected`, because a rewind is a
+   * surface replacement inside the same live session: it does not emit
+   * `agent/session-start`, so a session-scoped flag stays set and the reminder
+   * never returns. The durable event log cannot answer this either, since it is
+   * append-only and still contains the discarded message.
+   *
+   * Scanning forward is cheap: the reminder sits near the head of the surface,
+   * so the loop exits after a few nodes even on a long session.
+   */
+  private cueAlreadyVisible(): boolean {
+    const nodes = this.agent.session.surface?.nodes
+    if (nodes === undefined) return this.cueInjected
+    for (const seq of nodes) {
+      if (isOwnUserMessageEvent(this.agent.session.events[seq])) return true
+    }
+    return false
+  }
+
   private async preStep(payload: PreStepPayload, next: () => Promise<HostPreStepDecision>): Promise<HostPreStepDecision> {
     if (payload.step === 1) this.cancelIdleReview(true)
     const decision = await next()
@@ -317,7 +354,7 @@ class MnemonAgentLifecycle {
       this.counters.primes += 1
       this.mark('prime')
     }
-    if (this.cueInjected) return decision
+    if (this.cueAlreadyVisible()) return decision
     const reminder = guidedReminder(this.config)
     if (reminder === undefined) return decision
     this.cueInjected = true

--- a/tests/lifecycle.spec.ts
+++ b/tests/lifecycle.spec.ts
@@ -208,6 +208,48 @@ function fixture(config = resolveConfig({ cliPath: '/fake/mnemon' }), options: {
 afterEach(() => vi.useRealTimers())
 
 describe('Mnemon DSH lifecycle integration', () => {
+
+  it('re-composes the guided reminder after a rewind drops it from the surface', async () => {
+    const value = fixture()
+    // The real host publishes a model-visible projection; the base stub does not.
+    const surface: { nodes: number[] } = { nodes: [] }
+    ;(value.agent.session as { surface?: { nodes: readonly number[] } }).surface = surface
+
+    // Commit an injected message to the durable log and the surface, the way the
+    // host does once a step is admitted.
+    const commit = (message: HostUserMessage): void => {
+      const seq = value.events.length
+      value.events.push({ type: 'user/message', seq, data: { source: message.source, turn: 1 } })
+      surface.nodes.push(seq)
+    }
+
+    const first = await value.preStep([userMessage()], 1)
+    expect(first.kind).toBe('enter')
+    const reminder = first.kind === 'enter' ? first.messages.at(-1) : undefined
+    expect(reminder?.source).toMatchObject({ kind: 'plugin', plugin: 'dsh-mnemon' })
+    commit(reminder as HostUserMessage)
+
+    // Still visible: a later first step must not duplicate it.
+    const second = await value.preStep([userMessage()], 2)
+    expect(second.kind === 'enter' && second.messages).toHaveLength(1)
+
+    // Rewind replaces the surface and drops the reminder. The append-only event
+    // log still contains it, which is why presence cannot be read from there.
+    surface.nodes.length = 0
+
+    const third = await value.preStep([userMessage()], 3)
+    expect(third.kind).toBe('enter')
+    const reissued = third.kind === 'enter' ? third.messages.at(-1) : undefined
+    expect(reissued?.source).toMatchObject({ kind: 'plugin', plugin: 'dsh-mnemon' })
+  })
+
+  it('falls back to session-scoped state when the host publishes no surface', async () => {
+    const value = fixture()
+    const first = await value.preStep([userMessage()], 1)
+    expect(first.kind === 'enter' && first.messages).toHaveLength(2)
+    const second = await value.preStep([userMessage()], 2)
+    expect(second.kind === 'enter' && second.messages).toHaveLength(1)
+  })
   it('pins one immutable Wake across every model step and releases it at the turn boundary', async () => {
     const value = fixture()
     const context = value.agentContexts[0]


### PR DESCRIPTION
## 摘要 / Summary

The guided memory reminder never returns after a rewind. It is injected once per session and gated on `cueInjected`, an instance field reset only by `agent/session-start`; a rewind is a surface replacement inside the same live session and emits no such event, so the reminder is absent from the surface while the flag still reports it delivered. This derives presence from the model-visible surface instead, so a rewind is self-correcting.

## 关联 Issue 或背景 / Related Issue or Context

N/A. Reported and reproduced while building an unrelated DSH plugin that injects on the same `agent/pre-step` seam. `dsh-agent-instructions` re-emits correctly under the identical rewind, which isolated the difference to the gating strategy rather than to the extension point. Submitting directly as a small, reproducible bug fix with regression coverage, per the Contributing Guide's PR scope.

## 涉及区域 / Affected Areas

- [x] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [x] 测试、构建或文档 / Tests, build, or documentation

## PR 类型 / PR Type

- [x] Bug 修复 / Bug fix

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin && git rebase origin/main
```

Branched from `91af2d8` (Merge pull request #87).

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.

使用的 AI 模型 / AI model used:

Claude Opus 5

使用的编码 Agent 工具 / Coding Agent tool used:

Claude Code

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs. This change touches only the Host-side `src/contracts.ts` and adds no Client or wire DTO.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests. None of these are touched.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English. No user-facing copy, configuration key, or path changed; the reminder text is unmodified.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

No persistence format, storage path, RPC authority, or Provider credential is touched, and no configuration key is added or renamed.

`HostAgent['session']` gains an **optional** `surface?: { readonly nodes: readonly number[] }`. It is optional deliberately: a host that publishes no surface projection keeps the previous session-scoped `cueInjected` behaviour exactly, so this is source- and behaviour-compatible in both directions and needs no migration or rollback path. The second added test pins that fallback.

Behaviour change is limited to one case that is currently broken: after a rewind removes the reminder from the model-visible surface, the next first step composes a new one. Reminder text, ordering, counters, and `guidedTurns` bookkeeping are unchanged.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm run typecheck
pnpm run test
pnpm run verify:build
```

结果摘要 / Result summary:

- `pnpm run typecheck` — **passed** (exit 0).
- `pnpm run test` — **485 passed, 9 failed, 1 skipped**. The 9 failures are all in `tests/pack.spec.ts` (`withLocks`, `src/pack.ts:354`) and are **pre-existing on unmodified `main`**: I ran that file on a clean checkout with this change stashed and got the identical 9 failures, so they are unrelated to this PR. Every other file passes, including the 2 new tests.
- `pnpm run verify:build` — **could not run** in this environment: `ERROR Error: Failed to import module "unrun". Please ensure it is installed.` `unrun` is a tsdown toolchain dependency that is absent after a clean `pnpm install` and is not declared in `package.json`. This blocks `verify:build`, and `verify:headless` and `verify:package` in turn, since both consume build output. Not caused by this change — it fails identically on unmodified `main`.
- Remaining risk: the deterministic-build, headless-activation, and package-content checks are unverified locally and need CI. The change is confined to two source files, adds no export, no dependency, and no build-graph edge, so build-shape risk is low. Please re-run full `verify` in CI.

Targeted regression coverage, per Contributing rule 3 (must fail before the fix, pass after):

```
# with the fix stashed, on upstream source:
x  re-composes the guided reminder after a rewind drops it from the surface
   -> expected { kind: 'user' } to match object { Object (kind, plugin) }
   Tests  1 failed | 29 skipped (30)

# with the fix applied:
✓  tests/lifecycle.spec.ts (30 tests | 29 skipped)
   Tests  1 passed | 29 skipped (30)
```

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence:

Reproduced on DSH Desktop 2.0.2 with `dsh-mnemon@0.3.2` installed in the desktop profile.

1. Start a session and send a first message. The trajectory shows a `dsh-mnemon` context injection, `form: instructions`, `summary: "Optional memory recall and remember reminder"`, carrying the `[MNEMON] Search Documents for substantial project records; ...` text.
2. Rewind to that first message and resend it with different text.
3. Before this change: no `dsh-mnemon` injection appears, for the rest of the session. After: the reminder is composed again for the new first step.

The failing and passing test output above is the redacted evidence for the Host-side behaviour, per the Contributing Guide's allowance for Host changes. No screenshot is attached because the visible artifact is the absence of a trajectory row, which the regression test captures more precisely; the surrounding session content is private memory and would need redacting.
