### PR TITLE
fix(subagent): raise maintenance delegate token ceilings for dense archives

### DIFF
--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1702,8 +1702,13 @@ ${runtimeSnapshotContext('user', plan.entries)}`
       const completionPersona = `${persona}
 
 Completion protocol: call \`${resultToolName}\` exactly once with the final result matching its parameter schema. This is the only completion channel for this run. Do not finish with a plain-text answer.`
-      const perOpMaxTokens = operation === 'migration' || operation === 'compaction' || operation === 'document-archive' ? 8_192
-        : operation === 'metadata-maintenance' ? 4_096
+      // Maintenance delegates emit small structured results, but reasoning-style
+      // models can burn a large completion budget on analysis before emitting
+      // them. Undersized static caps abort the whole operation with
+      // stopReason=max-tokens (e.g. dense CJK capacity archives, see #70), so
+      // keep generous ceilings instead of tight ones.
+      const perOpMaxTokens = operation === 'migration' || operation === 'compaction' || operation === 'document-archive' ? 32_768
+        : operation === 'metadata-maintenance' ? 16_384
         : undefined
       const fixed = this.taskAgentModelResolver?.()
       const baseAgentOptions = perOpMaxTokens === undefined ? undefined : { maxTokens: perOpMaxTokens }

--- a/tests/subagent.spec.ts
+++ b/tests/subagent.spec.ts
@@ -815,7 +815,7 @@ describe('Mnemon memory subagent coordinator', () => {
     })
     expect(host.start).toHaveBeenCalledWith('spawn', expect.objectContaining({
       toolFilter: { allow: [expect.stringMatching(/^mnemon_subagent_result_/)] },
-      agentOptions: { maxTokens: 4_096 },
+      agentOptions: { maxTokens: 16_384 },
       persona: expect.stringContaining('fastest bounded metadata-sampling path'),
     }))
     expect(memoryService.metadataSample).toHaveBeenCalledWith('product', expect.any(AbortSignal))
@@ -1001,7 +1001,7 @@ describe('Mnemon memory subagent coordinator', () => {
     })
     expect(host.start).toHaveBeenCalledWith('spawn', expect.objectContaining({
       toolFilter: { allow: [expect.stringMatching(/^mnemon_subagent_result_/)] },
-      agentOptions: { maxTokens: 8_192 },
+      agentOptions: { maxTokens: 32_768 },
     }))
     const migrationCall = (host.start.mock.calls[0] as unknown as [string, { prompt: Array<{ text: string }>; persona: string; toolFilter: { allow: string[] } }])[1]
     const migrationPrompt = migrationCall.prompt[0]!.text
@@ -1244,7 +1244,7 @@ describe('Mnemon memory subagent coordinator', () => {
     })
     expect(host.start).toHaveBeenCalledWith('spawn', expect.objectContaining({
       toolFilter: { allow: [expect.stringMatching(/^mnemon_subagent_result_/)] },
-      agentOptions: { maxTokens: 8_192 },
+      agentOptions: { maxTokens: 32_768 },
       persona: expect.stringContaining('local USER.md compactor'),
     }))
     const compactionCall = (host.start.mock.calls[0] as unknown as [string, { prompt: Array<{ text: string }>; persona: string }])[1]
@@ -1384,7 +1384,7 @@ describe('Mnemon memory subagent coordinator', () => {
       maintenance: { kind: 'local-compaction' },
     })
     expect(host.start).toHaveBeenCalledWith('spawn', expect.objectContaining({
-      agentOptions: { provider: 'pinned-provider', model: 'pinned-model', maxTokens: 8_192 },
+      agentOptions: { provider: 'pinned-provider', model: 'pinned-model', maxTokens: 32_768 },
     }))
   })
 })


### PR DESCRIPTION
## Problem

When runtime `MEMORY.md` is at capacity, every `mnemon_runtime_memory` add delegates to maintenance workers (archive routing / local compaction / metadata sampling). Those workers are capped at **8192** (and **4096** for metadata-maintenance) completion tokens. Reasoning models spend most of that budget on analysis before emitting the small structured result, so the worker stops with `stopReason=max-tokens` and the whole tool call aborts — with zero writes.

Reproducible with dense CJK content. Reported upstream as [#70](https://github.com/omdsh-dev/dsh-mnemon/issues/70) (still fails on 0.3.0) and [#83](https://github.com/omdsh-dev/dsh-mnemon/issues/83)/[#85](https://github.com/omdsh-dev/dsh-mnemon/issues/85) (same symptom, auto-closed for form issues).

## Root cause

`src/subagent.ts` — static per-op ceilings override the host-resolved token budget:

```ts
const perOpMaxTokens = operation === 'migration' || operation === 'compaction' || operation === 'document-archive' ? 8_192
  : operation === 'metadata-maintenance' ? 4_096
  : undefined
```

## Fix

Raise the ceilings to **32768 / 16384**. The structured output of these workers is still small; the caps only bounded the analysis budget, which is the part that needs headroom. Fixes-class change: no new config surface, no issue gate required.

- `src/subagent.ts`: 8_192 → 32_768, 4_096 → 16_384
- `tests/subagent.spec.ts`: update the pinned expectations (metadata 4_096 → 16_384; migration/compaction/merge 8_192 → 32_768)

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/subagent.spec.ts` — 42/42 passing

## Notes

The static ceilings remain finite. [#70](https://github.com/omdsh-dev/dsh-mnemon/issues/70)'s deterministic bulk-import direction would remove the LLM dependency entirely; this PR is a targeted stopgap until that lands.