### PR TITLE
fix(guidance): carry the runtime memory snapshot as this plugin's own message

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -140,7 +140,13 @@ export interface HostSessionEvent {
 export type HostPreStepDecision = { kind: 'reject' } | { kind: 'enter'; messages: HostUserMessage[] }
 
 export interface HostAgentContext {
-  on(name: string, listener: (...args: never[]) => unknown): () => unknown
+  /**
+   * `options` is optional and forwarded verbatim to the host. `prepend`
+   * places the listener at the head of the chain, which for a waterfall
+   * means it observes the fully assembled result. Omitting it keeps the
+   * previous two-argument behaviour exactly.
+   */
+  on(name: string, listener: (...args: never[]) => unknown, options?: { prepend?: boolean }): () => unknown
   effect(callback: () => (() => unknown) | void, label?: string): () => unknown
   get?(name: string): unknown
 }
@@ -257,6 +263,12 @@ export interface HostContextShape {
   /** Cordis service publication; optional only for narrow test/headless shims. */
   provide?(name: string, value?: unknown, check?: () => boolean): unknown
   inject(services: string[], callback: (ctx: HostContextShape) => void): unknown
-  on(name: string, listener: (...args: never[]) => unknown): () => unknown
+  /**
+   * `options` is optional and forwarded verbatim to the host. `prepend`
+   * places the listener at the head of the chain, which for a waterfall
+   * means it observes the fully assembled result. Omitting it keeps the
+   * previous two-argument behaviour exactly.
+   */
+  on(name: string, listener: (...args: never[]) => unknown, options?: { prepend?: boolean }): () => unknown
   effect(callback: () => (() => unknown) | void, label?: string): () => unknown
 }

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -24,7 +24,7 @@ function scopedSystemPrompt(agent: HostAgent): SystemPromptRegistry | undefined 
   return agent.ctx.get?.('systemPrompt') as SystemPromptRegistry | undefined
 }
 
-function memoryPromptText(value: string): string {
+export function memoryPromptText(value: string): string {
   return value.replaceAll(
     LITERAL_OPEN_BRACES,
     `{{${RUNTIME_MEMORY_LITERAL_OPEN_BRACES_VARIABLE}}}`,
@@ -53,14 +53,12 @@ export function applyAgentMemoryViewWake<T extends { sections: Array<{ name: str
   })
   if (!protocolFound && protocol !== '') sections.push({ name: RUNTIME_MEMORY_PROTOCOL_SECTION_NAME, text: protocol })
 
-  const rendered = wake === undefined ? '' : memoryPromptText(wake.text)
-  let found = false
-  const contexts = assembly.contexts.map(context => {
-    if (context.name !== RUNTIME_MEMORY_CONTEXT_NAME) return context
-    found = true
-    return { ...context, text: rendered }
-  })
-  if (!found) contexts.push({ name: RUNTIME_MEMORY_CONTEXT_NAME, text: rendered })
+  // The snapshot is no longer a shared runtime-context contribution: it is
+  // injected as this plugin's own message (see MnemonAgentLifecycle.injectMemory)
+  // so it is attributed to dsh-mnemon and cannot invalidate other plugins'
+  // stable context. Any inherited contribution is cleared here so a profile
+  // upgraded in place stops emitting it through the shared projection.
+  const contexts = assembly.contexts.filter(context => context.name !== RUNTIME_MEMORY_CONTEXT_NAME)
   return { ...assembly, sections, contexts }
 }
 
@@ -119,13 +117,6 @@ export function registerAgentMemoryViewContext(agent: HostAgent, wake: () => Mem
     order: 145,
     text: () => wakeHasRuntimeMemory(wake()) ? RUNTIME_MEMORY_PROTOCOL : '',
   })
-  const stopContext = prompt?.context?.({
-    name: RUNTIME_MEMORY_CONTEXT_NAME,
-    order: 145,
-    text: () => {
-      const current = wake()
-      return current === undefined ? '' : memoryPromptText(current.text)
-    },
-  })
-  return disposer(stopProtocol, stopContext)
+  // No context contribution: the snapshot travels as this plugin's own message.
+  return disposer(stopProtocol)
 }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -17,7 +17,7 @@ import type { DocumentMutation } from './documents.ts'
 import { MnemonSubagentCoordinator, type DelegatedWriteResult } from './subagent.ts'
 import { scoreReviewActivity } from './review-activity.ts'
 import { TurnActivityProjection, type TurnMemoryActivity, type TurnMemoryActivitySnapshot } from './activity.ts'
-import { applyAgentMemoryViewWake, registerAgentMemoryViewContext } from './guidance.ts'
+import { applyAgentMemoryViewWake, memoryPromptText, registerAgentMemoryViewContext } from './guidance.ts'
 import type { AssistantMessageText, LifecycleAgentSnapshot, LifecycleCounters, LifecyclePhase, LifecycleSnapshot, ReviewActivityScore, TaskAgentModelCatalog } from './shared/contracts.ts'
 import type { PreparedMemoryPlacement } from './provider-placement.ts'
 import type { MemoryOperationScope, MemoryTurnContext, MemoryWake } from '../packages/contracts/src/index.ts'
@@ -217,6 +217,14 @@ class MnemonAgentLifecycle {
    * actually see, which is what makes a rewind self-correcting.
    */
   private cueInjected = false
+  /**
+   * Text of the runtime memory snapshot most recently injected as this
+   * plugin's own message. `.context()` used to get supersede-on-change for free
+   * from the host's runtime-context projection; carrying the snapshot as an own
+   * message means re-emitting on change is this plugin's responsibility, and
+   * the rendered text (which carries the revision digest) is the key.
+   */
+  private injectedMemoryText: string | undefined
   private idleReviewTimer: ReturnType<typeof setTimeout> | undefined
   private reviewController: AbortController | undefined
   private reviewRunning = false
@@ -255,7 +263,12 @@ class MnemonAgentLifecycle {
       }) as never),
       this.agent.ctx.on('session/event', ((session: HostAgent['session'], event: HostSessionEvent) => this.sessionEvent(session, event)) as never),
       this.agent.ctx.on('system-prompt/assemble', ((assembly: PromptAssembly, context: PromptAssemblyContext, next: () => Promise<PromptAssembly>) => this.assemblePrompt(assembly, context, next)) as never),
-      this.agent.ctx.on('agent/pre-step', ((payload: PreStepPayload, next: () => Promise<HostPreStepDecision>) => this.preStep(payload, next)) as never),
+      // `prepend: true` makes this the outermost pre-step participant, so it
+      // observes the fully assembled batch and appends after every other
+      // contributor's context. The snapshot therefore has no byte-stable
+      // context behind it, and `recordTurnMessages` sees the complete batch
+      // rather than a partial one.
+      this.agent.ctx.on('agent/pre-step', ((payload: PreStepPayload, next: () => Promise<HostPreStepDecision>) => this.preStep(payload, next)) as never, { prepend: true }),
       this.agent.ctx.on('agent/turn-stopping', ((payload: TurnStoppingPayload) => this.finishTurn(payload)) as never),
     ]
     return () => {
@@ -327,6 +340,24 @@ class MnemonAgentLifecycle {
     return false
   }
 
+  /**
+   * The runtime memory snapshot, as this plugin's own message, when it changed.
+   *
+   * `.context()` used to carry this inside the host's shared runtime-context
+   * projection. Carrying it here instead attributes it to dsh-mnemon and keeps
+   * a memory write from re-emitting other contributors' sections; supersede
+   * stays intact because the block is still a complete state replacing its
+   * predecessor, keyed on the rendered text's revision digest.
+   */
+  private memorySnapshotMessage(): HostUserMessage | undefined {
+    const wake = this.memoryWake()
+    if (wake === undefined) return undefined
+    const text = memoryPromptText(wake.text)
+    if (text.trim() === '' || text === this.injectedMemoryText) return undefined
+    this.injectedMemoryText = text
+    return createPluginMessage(text, 'recall', 'Runtime memory snapshot')
+  }
+
   private async preStep(payload: PreStepPayload, next: () => Promise<HostPreStepDecision>): Promise<HostPreStepDecision> {
     if (payload.step === 1) this.cancelIdleReview(true)
     const decision = await next()
@@ -348,21 +379,27 @@ class MnemonAgentLifecycle {
       return decision
     }
     if (decision.messages.length === 0) return decision
+    // Independent of the one-shot reminder gate below: memory can change at any
+    // point in a session, and each change must supersede the previous snapshot.
+    // Appended last so the snapshot sits at the bottom of this plugin's block.
+    const snapshot = this.memorySnapshotMessage()
+    const withSnapshot = (messages: HostUserMessage[]): HostUserMessage[] =>
+      snapshot === undefined ? messages : [...messages, snapshot]
 
     if (this.primePending) {
       this.primePending = false
       this.counters.primes += 1
       this.mark('prime')
     }
-    if (this.cueAlreadyVisible()) return decision
+    if (this.cueAlreadyVisible()) return { kind: 'enter', messages: withSnapshot(decision.messages) }
     const reminder = guidedReminder(this.config)
-    if (reminder === undefined) return decision
+    if (reminder === undefined) return { kind: 'enter', messages: withSnapshot(decision.messages) }
     this.cueInjected = true
     this.guidedTurns.add(payload.turn)
     if (this.config.recallMode === 'guided') this.counters.recallCues += 1
     if (this.config.writebackMode === 'guided' && this.config.writeEnabled) this.counters.writebackCues += 1
     this.mark(this.config.recallMode === 'guided' ? 'recall' : 'writeback')
-    return { kind: 'enter', messages: [...decision.messages, createPluginMessage(reminder, 'instructions', 'Optional memory recall and remember reminder')] }
+    return { kind: 'enter', messages: withSnapshot([...decision.messages, createPluginMessage(reminder, 'instructions', 'Optional memory recall and remember reminder')]) }
   }
 
   private async assemblePrompt(assembly: PromptAssembly, context: PromptAssemblyContext, next: () => Promise<PromptAssembly>): Promise<PromptAssembly> {

--- a/tests/guidance.spec.ts
+++ b/tests/guidance.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { renderContextSnapshot, renderPrompt, type PromptAssembly } from '@deepseek-ai/dsh-system-prompt'
 import type { HostAgent, HostContextShape } from '../src/contracts.ts'
-import { registerAgentMemoryViewContext, registerAgentRuntimeMemoryContext, registerRuntimeMemoryContext, RUNTIME_MEMORY_CONTEXT_NAME, RUNTIME_MEMORY_PROTOCOL_SECTION_NAME } from '../src/guidance.ts'
+import { memoryPromptText, registerAgentMemoryViewContext, registerAgentRuntimeMemoryContext, registerRuntimeMemoryContext, RUNTIME_MEMORY_CONTEXT_NAME, RUNTIME_MEMORY_PROTOCOL_SECTION_NAME } from '../src/guidance.ts'
 import { RUNTIME_MEMORY_PROTOCOL, type RuntimeMemoryController } from '../src/runtime-memory.ts'
 import type { MemoryWake } from '../packages/contracts/src/index.ts'
 
@@ -77,15 +77,17 @@ describe('agent-scoped runtime memory context', () => {
     let wake: MemoryWake = { viewId: 'view-1', viewDigest: 'digest-1', text: 'Pinned {{model}} memory.', sections: [{ layerId: 'runtime', mode: 'eager', text: 'Pinned {{model}} memory.' }] }
 
     registerAgentMemoryViewContext(agent, () => wake)
-    const registeredContext = context.mock.calls[0]![0]
+    // The snapshot is no longer a shared runtime-context contribution; it is
+    // injected as this plugin's own message. Only the static protocol section
+    // is still registered here.
+    expect(context).not.toHaveBeenCalled()
     const registeredProtocol = section.mock.calls[0]![0]
-    expect(registeredContext?.text()).toBe('Pinned {{mnemon_runtime_memory_literal_open_braces}}model}} memory.')
     expect(registeredProtocol?.text()).toBe(RUNTIME_MEMORY_PROTOCOL)
-    wake = { viewId: 'view-1', viewDigest: 'digest-1', text: 'Same pinned memory.', sections: [{ layerId: 'runtime', mode: 'eager', text: 'Same pinned memory.' }] }
-    expect(registeredContext?.text()).toBe('Same pinned memory.')
     wake = { viewId: 'view-2', viewDigest: 'digest-2', text: 'Only routed memory.', sections: [{ layerId: 'documents', mode: 'routed', text: 'One active project Document.' }] }
     expect(registeredProtocol?.text()).toBe('')
-    expect(registeredContext?.text()).toBe('Only routed memory.')
+
+    // Interpolation is still neutralized as literal data, now on the injected text.
+    expect(memoryPromptText('Pinned {{model}} memory.')).toBe('Pinned {{mnemon_runtime_memory_literal_open_braces}}model}} memory.')
   })
 
   it('registers a same-named per-Agent runtime context that resolves the current workspace lazily', () => {

--- a/tests/lifecycle-host-order.spec.ts
+++ b/tests/lifecycle-host-order.spec.ts
@@ -58,7 +58,9 @@ describe('Mnemon lifecycle with the real DSH SystemPrompt', () => {
       agentId: 'real-prompt-session',
     })
     expect(assembly.sections).toContainEqual({ name: 'mnemon:runtime-memory-protocol', text: RUNTIME_MEMORY_PROTOCOL })
-    expect(assembly.contexts).toContainEqual({ name: 'mnemon:runtime-memory', text: 'First-turn Wake' })
+    // The Wake no longer travels as a shared runtime-context contribution; it is
+    // appended as a dsh-mnemon message so it cannot invalidate other plugins' context.
+    expect(assembly.contexts).not.toContainEqual(expect.objectContaining({ name: 'mnemon:runtime-memory' }))
     expect(runtimeSource.bindAgentRuntime).toHaveBeenCalledOnce()
     stop()
     expect(memoryViews.endTurn).toHaveBeenCalledWith('real-prompt-session:1')

--- a/tests/lifecycle.spec.ts
+++ b/tests/lifecycle.spec.ts
@@ -231,7 +231,9 @@ describe('Mnemon DSH lifecycle integration', () => {
 
     // Still visible: a later first step must not duplicate it.
     const second = await value.preStep([userMessage()], 2)
-    expect(second.kind === 'enter' && second.messages).toHaveLength(1)
+    // Reminder not repeated; the snapshot rides along because this fixture's
+    // Wake text is turn-derived, so turn 2 renders a different revision.
+    expect(second.kind === 'enter' && second.messages).toHaveLength(2)
 
     // Rewind replaces the surface and drops the reminder. The append-only event
     // log still contains it, which is why presence cannot be read from there.
@@ -246,20 +248,23 @@ describe('Mnemon DSH lifecycle integration', () => {
   it('falls back to session-scoped state when the host publishes no surface', async () => {
     const value = fixture()
     const first = await value.preStep([userMessage()], 1)
-    expect(first.kind === 'enter' && first.messages).toHaveLength(2)
+    expect(first.kind === 'enter' && first.messages).toHaveLength(3)
     const second = await value.preStep([userMessage()], 2)
-    expect(second.kind === 'enter' && second.messages).toHaveLength(1)
+    expect(second.kind === 'enter' && second.messages).toHaveLength(2)
   })
   it('pins one immutable Wake across every model step and releases it at the turn boundary', async () => {
     const value = fixture()
-    const context = value.agentContexts[0]
-    expect(context).toMatchObject({ name: 'mnemon:runtime-memory', order: 145 })
-    expect(context?.text()).toBe('')
+    // The snapshot is no longer a shared runtime-context contribution.
+    expect(value.agentContexts).toHaveLength(0)
 
-    await value.preStep([userMessage('First step')], 7, 1)
+    const first = await value.preStep([userMessage('First step')], 7, 1)
     expect(value.promptAssemblies[0]?.sections).toContainEqual({ name: 'mnemon:runtime-memory-protocol', text: RUNTIME_MEMORY_PROTOCOL })
-    expect(value.promptAssemblies[0]?.contexts).toContainEqual({ name: 'mnemon:runtime-memory', text: 'Pinned Wake view-7' })
-    expect(context?.text()).toBe('Pinned Wake view-7')
+    expect(value.promptAssemblies[0]?.contexts).not.toContainEqual(expect.objectContaining({ name: 'mnemon:runtime-memory' }))
+    // The pinned Wake reaches the model as this plugin's own message, appended last.
+    if (first.kind !== 'enter') throw new Error('unexpected rejection')
+    const snapshot = first.messages.at(-1)
+    expect(snapshot?.source).toMatchObject({ kind: 'plugin', plugin: 'dsh-mnemon', form: 'recall' })
+    expect(snapshot?.content[0]?.text).toBe('Pinned Wake view-7')
     expect(value.memoryViews.beginTurn).toHaveBeenCalledOnce()
     expect(value.runtimeSource.bindAgentRuntime).toHaveBeenCalledOnce()
     expect(value.memoryViews.beginTurn).toHaveBeenCalledWith('session-1:7', {
@@ -268,17 +273,19 @@ describe('Mnemon DSH lifecycle integration', () => {
       agentId: 'session-1',
     })
 
-    await value.preStep([userMessage('Tool continuation')], 7, 2)
-    expect(context?.text()).toBe('Pinned Wake view-7')
+    // Same pinned Wake on a later step: unchanged text is not re-injected.
+    const continuation = await value.preStep([userMessage('Tool continuation')], 7, 2)
+    if (continuation.kind !== 'enter') throw new Error('unexpected rejection')
+    expect(continuation.messages.some(message => message.content[0]?.text === 'Pinned Wake view-7')).toBe(false)
     expect(value.memoryViews.beginTurn).toHaveBeenCalledOnce()
 
     await value.turnStopping(7)
     expect(value.memoryViews.endTurn).toHaveBeenCalledWith('session-1:7')
     expect(value.memoryViews.reconcile).toHaveBeenCalledWith({ storage: 'global', sessionId: 'session-1', agentId: 'session-1' })
-    expect(context?.text()).toBe('')
 
-    await value.preStep([userMessage('Next turn')], 8, 1)
-    expect(context?.text()).toBe('Pinned Wake view-8')
+    const nextTurn = await value.preStep([userMessage('Next turn')], 8, 1)
+    if (nextTurn.kind !== 'enter') throw new Error('unexpected rejection')
+    expect(nextTurn.messages.at(-1)?.content[0]?.text).toBe('Pinned Wake view-8')
     expect(value.memoryViews.beginTurn).toHaveBeenCalledTimes(2)
   })
 
@@ -431,15 +438,20 @@ describe('Mnemon DSH lifecycle integration', () => {
 
     expect(decision).toMatchObject({ kind: 'enter' })
     if (decision.kind !== 'enter') throw new Error('unexpected rejection')
-    expect(decision.messages).toHaveLength(2)
+    expect(decision.messages).toHaveLength(3)
     expect(decision.messages[1]?.source).toMatchObject({ kind: 'plugin', plugin: 'dsh-mnemon', form: 'instructions' })
+    expect(decision.messages[2]?.source).toMatchObject({ kind: 'plugin', plugin: 'dsh-mnemon', form: 'recall' })
     expect(decision.messages[1]?.content[0]?.text).toBe('[MNEMON] Search Documents for substantial project records; use mnemon_recall only for missing durable history or exact prior details, and mnemon_runtime_memory only for new user-supplied facts or explicit save/correction requests—never retrieved evidence. Otherwise use none.')
     expect(value.coordinator.recall).not.toHaveBeenCalled()
     expect(value.service.status).not.toHaveBeenCalled()
 
     const second = await value.preStep([userMessage('Second turn')], 2)
     if (second.kind !== 'enter') throw new Error('unexpected rejection')
-    expect(second.messages).toHaveLength(1)
+    // The reminder is not repeated. The snapshot is present because this
+    // fixture derives Wake text from the turn, so turn 2 is a new revision.
+    expect(second.messages).toHaveLength(2)
+    expect(second.messages.some(message => (message.source as { form?: string }).form === 'instructions')).toBe(false)
+    expect(second.messages.at(-1)?.source).toMatchObject({ kind: 'plugin', plugin: 'dsh-mnemon', form: 'recall' })
     expect(value.coordinator.recall).not.toHaveBeenCalled()
     expect(value.lifecycle.snapshot('session-1').counters).toMatchObject({ primes: 1, recallCues: 1, writebackCues: 1 })
   })


### PR DESCRIPTION
## 摘要 / Summary

`mnemon:runtime-memory` was contributed through `systemPrompt.context()`, so the host merged it into the shared `@deepseek-ai/dsh-system-prompt` runtime-context projection. Two consequences followed, and this changes only the carrier to fix both.

**Attribution.** The snapshot rendered as `Context injection · @deepseek-ai/dsh-system-prompt`, as though the harness produced it. Mnemon's own block carried only the 275-character `[MNEMON]` routing line. The snapshot is now a `dsh-mnemon` message and is attributed correctly.

**Cache.** DSH joins every `.context()` contribution into one string and diffs the whole (`RuntimeContext.project()` over `joinContextSections(sections)`), so a memory write re-emitted `sandbox:policy` and `approval:policy` along with it. At session start that projection is also composed ahead of `skill-catalog`, so across sessions a memory write invalidated roughly a thousand tokens of byte-stable catalog that had not changed.

The block remains a complete state superseding its predecessor — only the carrier changed. Supersede is keyed on the rendered text, which already carries the revision digest.

## 关联 Issue 或背景 / Related Issue or Context

Closes #111.

#111 is a verbatim refile of #106, which the template enforcer auto-closed nine seconds after submission: the body used level-2 (`##`) headings while `.github/workflows/issue-template-enforcer.yml` matches sections only at level 3 (`###`), so every required section read as empty. The content is unchanged.

Adjacent and complementary, not overlapping:
- **#26** (closed) moved the projection out of the system prompt. This continues that direction one step: out of the *shared* projection as well.
- **#40** (open) covers the *size* of each replay within a session. This PR does not change content or introduce diffs, so it neither implements nor blocks #40 — an incremental payload would sit in this same message. I read @Grivn's reply there about DSH's runtime-context contract defining the newest message as the complete state; that reasoning applies to changing content to a diff, which this deliberately does not do.

### Why the ordering half is included

`dsh-tool-skill` ships inside `@deepseek-ai/dsh-base` and registers its `agent/pre-step` listener before `dsh-mnemon` does. Neither used `prepend`, so both are pushed onto the listener list in load order. Cordis runs waterfall listeners outermost-first, so the *innermost* returns first and appends first — meaning the later-loading plugin lands **earlier** in the batch. Mnemon therefore sat ahead of `skill-catalog`, and moving the snapshot to an own message without changing that would leave the catalog still behind it.

The existing lifecycle listener is now registered with `prepend: true` rather than adding a second listener. A second listener looked cleaner but the test harness keys listeners by event name (`agentListeners.set(name, listener)`), so a second `agent/pre-step` registration silently replaces the first; a one-listener change avoids a harness rewrite. Running outermost also means `recordTurnMessages` observes the complete batch rather than a partial one.

### Why this matters disproportionately for local inference

Prefix caching is strictly positional: one changed token invalidates everything downstream, so a single memory write forfeits every byte behind it in the next session. On a hosted API that is a discounted line item. On local inference it is wall-clock time to first token, on hardware the user is also running the model on.

Measured on this setup, DSH against a local oMLX server (`DeepSeek-V4-Flash-8bit`, Apple silicon):

- Two fresh sessions differing only in the first prompt: cache hit **42% → 94%**, TTFT **10s → 3s**, purely from moving stable context ahead of the variable part. ~2,000 tokens of misplaced context was worth 7 seconds at every session start.
- oMLX quantizes its KV cache to 2048-token blocks. `skill-catalog` alone is ~1,073 tokens, so it straddles roughly a whole block that is reusable in principle and lost in practice whenever memory changed since the previous session.
- The local cache is single-tenant and disk-backed, so cross-session reuse is near-guaranteed on a prefix match — no TTL, no multi-tenant eviction. Local is exactly where correct placement pays the most.
- Local users also run many short sessions, which concentrates a per-session-start tax.

## 涉及区域 / Affected Areas

- [x] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [x] 测试、构建或文档 / Tests, build, or documentation

## PR 类型 / PR Type

- [x] Bug 修复 / Bug fix

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

Branched from `e118094` (Merge pull request #104, v0.3.4).

同步命令 / Sync command:

```bash
git fetch origin && git rebase origin/main
```

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.

使用的 AI 模型 / AI model used:

Claude Opus 5

使用的编码 Agent 工具 / Coding Agent tool used:

Claude Code

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs. This change touches only the Host-side `src/contracts.ts` and adds no Client or wire DTO.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests. None of these are touched.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized. No user-facing copy, configuration key, or path changed; the snapshot text and the routing reminder are unmodified.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

No persistence format, storage path, RPC authority, or Provider credential is touched, and no configuration key is added or renamed.

- `HostAgentContext['on']` and `HostContextShape['on']` gain an **optional** third `options` parameter. Omitting it keeps the previous two-argument behaviour exactly, so this is source- and behaviour-compatible in both directions.
- `applyAgentMemoryViewWake` now filters any inherited `mnemon:runtime-memory` contribution out of `assembly.contexts`, so a profile upgraded in place stops emitting it through the shared projection rather than emitting it twice.
- `memoryPromptText` is exported so the same `{{}}` neutralization applies to the injected text; interpolation is still never parsed.
- `registerRuntimeMemoryContext` and `registerAgentRuntimeMemoryContext` are left as they are. Neither is wired in production — only `registerAgentMemoryViewContext` is, at `lifecycle.ts` — and their tests still pass, so the diff stays minimal. Happy to migrate or remove them if you would rather they not diverge.
- The static `mnemon:runtime-memory-protocol` section is unchanged and stays in the system prompt.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm install
./node_modules/.bin/tsc --noEmit -p tsconfig.json
TZ=UTC pnpm run verify
```

结果摘要 / Result summary:

All checks pass: typecheck clean; Vitest 511 passed, 1 skipped, 0 failed; deterministic double builds verified across 106 files; Headless profile activation verified with 35 total tools and 5 representative Mnemon tools; package contents verified (113 files); 10 Node-compatible public entries imported on v24.20.0; `publint --strict` and `attw --pack . --profile esm-only` both pass. Nothing skipped or failed.

`TZ=UTC` is needed only because `tests/pack.spec.ts` fails 11 tests on unmodified `main` in timezones behind UTC, unrelated to this change (filed separately as #112): `src/pack.ts` pins `mtime: new Date('1980-01-01T00:00:00.000Z')` for reproducible archives, and fflate validates against local date parts, so in any negative-UTC-offset timezone that reads as 1979 and trips `date not in range 1980-2099`. Reproduced on unmodified `main` at `e118094`; `TZ=UTC` passes 12/12. Details and a suggested one-line fix are in #112.

## 测试改动 / Test changes

Existing assertions were updated where they pinned the old carrier or the old message count, and the pinning test now observes the Wake through the injected message instead of the context callback — covering both directions of supersede: unchanged text on a later step is not re-injected, and a new turn's Wake is.


