### PR TITLE
fix(client): bind store methods in MnemonPanel to keep `this` under dsh 0.1.2+

### DIFF
--- a/src/client/workspace-mount.tsx
+++ b/src/client/workspace-mount.tsx
@@ -29,8 +29,16 @@ function MnemonPanel({ ctx, settings, t, onClose }: MnemonPanelProps): JSX.Eleme
   const subscribeLocale = useCallback((listener: () => void) => ctx.locale.subscribe(listener), [ctx.locale])
   const getLocaleSnapshot = useCallback(() => ctx.locale.getSnapshot(), [ctx.locale])
   const locale = useSyncExternalStore(subscribeLocale, getLocaleSnapshot, getLocaleSnapshot)
-  const sessions = useSyncExternalStore(ctx.sessions.list.subscribe, ctx.sessions.list.getSnapshot, ctx.sessions.list.getSnapshot)
-  const workspaces = useSyncExternalStore(ctx.workspaces.list.subscribe, ctx.workspaces.list.getSnapshot, ctx.workspaces.list.getSnapshot)
+  const sessions = useSyncExternalStore(
+    listener => ctx.sessions.list.subscribe(listener),
+    () => ctx.sessions.list.getSnapshot(),
+    () => ctx.sessions.list.getSnapshot(),
+  )
+  const workspaces = useSyncExternalStore(
+    listener => ctx.workspaces.list.subscribe(listener),
+    () => ctx.workspaces.list.getSnapshot(),
+    () => ctx.workspaces.list.getSnapshot(),
+  )
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>()
   const currentCwd = sessions.current === undefined ? undefined : sessions.byId[sessions.current]?.cwd
   const normalizePath = (value: string): string => value.replace(/[\\/]+$/u, '')

--- a/tests/client-sidebar.spec.tsx
+++ b/tests/client-sidebar.spec.tsx
@@ -80,6 +80,23 @@ function context(locale?: { getSnapshot(): { active: 'zh' | 'en'; locales: reado
   }
 }
 
+function receiverSensitiveStore<T>(snapshot: T) {
+  let reads = 0
+  const store = {
+    get reads(): number { return reads },
+    getSnapshot(): T {
+      if (this !== store) throw new Error('store receiver was lost')
+      reads += 1
+      return snapshot
+    },
+    subscribe(_listener?: () => void): () => void {
+      if (this !== store) throw new Error('store receiver was lost')
+      return () => {}
+    },
+  }
+  return store
+}
+
 describe('Mnemon sidebar workspace', () => {
   beforeEach(() => { renderShell() })
   afterEach(() => {
@@ -90,6 +107,20 @@ describe('Mnemon sidebar workspace', () => {
     document.documentElement.removeAttribute('data-dsh-ssh-active')
     document.body.replaceChildren()
     vi.restoreAllMocks()
+  })
+
+  it('keeps receiver-sensitive DSH 0.1.2 list stores bound', async () => {
+    const ctx = context()
+    const sessions = receiverSensitiveStore(ctx.sessions.list.getSnapshot())
+    const workspaces = receiverSensitiveStore(ctx.workspaces.list.getSnapshot())
+    ctx.sessions.list = sessions
+    ctx.workspaces.list = workspaces
+
+    currentDispose = mountMnemonWorkspace(ctx as never, {} as never, key => String(key))
+
+    await waitFor(() => expect(document.querySelector('[data-testid="mnemon-panel-content"]')).not.toBeNull())
+    expect(sessions.reads).toBeGreaterThan(0)
+    expect(workspaces.reads).toBeGreaterThan(0)
   })
 
   it('mounts after the official panel family and toggles the center workspace', async () => {


### PR DESCRIPTION
## Problem
Clicking the "记忆系统" (Mnemon) sidebar entry blanks the main content area on dsh 0.1.2-alpha.1:

- `MnemonPanel` passes `ctx.sessions.list.subscribe/getSnapshot` and `ctx.workspaces.list.subscribe/getSnapshot` as bare method references to `useSyncExternalStore`.
- On 0.1.1-rc.2 these stores are closures (`() => api.getState()`), so detached invocation was harmless.
- Since 0.1.2-alpha.1, `ctx.workspaces.list` is provided by `@deepseek-ai/dsh-api-workspace-controller`, whose `WorkspaceController.getSnapshot()` is a **class method** (`getSnapshot() { this.refreshSnapshot(); return this.snapshotCache; }`).
- React invokes the detached reference with `this === undefined` → `TypeError: Cannot read properties of undefined (reading 'refreshSnapshot')` → the panel render crashes → the panel container stays empty while the plugin CSS hides the conversation column (`display:none !important`) → the page appears to vanish.

## Fix
Wrap every `subscribe`/`getSnapshot` argument in an arrow function so `this` stays bound to the store. Applies to both `sessions` and `workspaces` subscriptions in `MnemonPanel`.

## Verification
- Reproduced with headless Edge + CDP against a live 0.1.2-alpha.1 instance; the panel renders fully after the fix (system status, memory bodies 10/10, 92 active memories, 28 documents, provider states).
- Applied as a local patch to the installed 0.3.2 client bundle; hot-reloaded via `dsh-client-hmr` (500 ms poll + SSE rebuilt) without restart.
- The same detached-call pattern exists in 0.3.4 (unchanged code) and in current `main` (v0.3.5), so this PR fixes the published line too.

## Note
dsh 0.1.2-alpha.1 is not yet published to npm; compatibility target is the current upstream main.