### PR TITLE
fix(subagent): fall back to owner latest view when parent turn ended

### DIFF
--- a/packages/kernel/src/view.ts
+++ b/packages/kernel/src/view.ts
@@ -266,6 +266,29 @@ export class MemoryTurnViewManager {
     return [...this.turns.values()].findLast(turn => turn.scope.agentId === id)
   }
 
+  /**
+   * Latest reconciled MemoryTurnView owned by an agent, even after its turn
+   * ended. Used by subagents that outlive the parent turn: the parent session's
+   * pin is released on turn end, but recall authority for that same agent scope
+   * remains valid on its most recently published view. Returns undefined when
+   * the agent never reconciled a view.
+   */
+  lastViewForAgent(agentId: string): MemoryTurnView | undefined {
+    const id = text(agentId, 'memory agent id', 300)
+    let match: MemoryTurnView | undefined
+    for (const [key, view] of this.currentByScope) {
+      let owner: string | undefined
+      try {
+        owner = (JSON.parse(key) as { agentId?: unknown }).agentId as string | undefined
+      } catch {
+        continue
+      }
+      if (owner !== id) continue
+      if (match === undefined || view.createdAt > match.createdAt) match = view
+    }
+    return match
+  }
+
   endTurn(turnId: string): boolean {
     const deleted = this.turns.delete(turnId)
     if (deleted) this.collect()

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1836,11 +1836,15 @@ Completion protocol: call \`${resultToolName}\` exactly once with the final resu
     const parentId = isSubagent(agent) ? agent.session.header?.parentSession?.trim() : undefined
     const ownerId = parentId === undefined || parentId === '' ? agent.id : parentId
     const pinned = views.activeTurn(ownerId)
-    if (pinned === undefined) {
-      if (required) throw new Error('Recall requires the MemorySource generation pinned to the current turn')
-      return undefined
-    }
-    return { turnId: pinned.turnId, viewId: pinned.viewId }
+    if (pinned !== undefined) return { turnId: pinned.turnId, viewId: pinned.viewId }
+    // Subagents can outlive the parent turn: the parent's pin is released on
+    // turn end, but recall authority stays scoped to the same owner's latest
+    // reconciled view. Fall back to it instead of failing outright, keeping the
+    // Host-pinned Source authority model intact (same owner, same memoryBodyIds).
+    const lastView = views.lastViewForAgent(ownerId)
+    if (lastView !== undefined) return { turnId: ownerId, viewId: lastView.id }
+    if (required) throw new Error('Recall requires the MemorySource generation pinned to the current turn')
+    return undefined
   }
 
   private turnRetrievalState(turnId: string): TurnRetrievalState {

--- a/tests/memory-view.spec.ts
+++ b/tests/memory-view.spec.ts
@@ -240,6 +240,31 @@ describe('MemoryTurnViewManager', () => {
     expect(views.lastFailure()).toContain('is too long')
   })
 
+  it('lastViewForAgent returns the owner latest view after the turn ended', async () => {
+    let revision = 1
+    const snapshot = vi.fn(() => ({ revision: `runtime-${revision}`, wake: `runtime ${revision}` }))
+    const { views } = harness([{ layerId: 'runtime', mode: 'eager', snapshot }])
+    const turnOne = await views.beginTurn('session:1', { storage: 'workspace', sessionId: 'session', agentId: 'session' })
+    views.endTurn('session:1')
+    expect(views.activeTurn('session')).toBeUndefined()
+    const last = views.lastViewForAgent('session')
+    expect(last).toBeDefined()
+    expect(last!.id).toBe(turnOne.viewId)
+
+    revision = 2
+    const turnTwo = await views.beginTurn('session:2', { storage: 'workspace', sessionId: 'session', agentId: 'session' })
+    views.endTurn('session:2')
+    expect(views.lastViewForAgent('session')!.id).toBe(turnTwo.viewId)
+  })
+
+  it('lastViewForAgent is scoped per agent and returns undefined for unknown agents', async () => {
+    const { views } = harness([{ layerId: 'runtime', mode: 'eager', snapshot: () => ({ revision: 'runtime-1', wake: 'valid' }) }])
+    await views.beginTurn('alpha:1', { storage: 'workspace', sessionId: 'alpha', agentId: 'alpha' })
+    views.endTurn('alpha:1')
+    expect(views.lastViewForAgent('alpha')?.id).toBeTruthy()
+    expect(views.lastViewForAgent('unknown-agent')).toBeUndefined()
+  })
+
   it('keeps last-valid Views isolated by snapshot scope', async () => {
     let failBeta = false
     const { views } = harness([{

--- a/tests/subagent.spec.ts
+++ b/tests/subagent.spec.ts
@@ -542,6 +542,7 @@ describe('Mnemon memory subagent coordinator', () => {
     const memoryService = service()
     const memoryViews = {
       activeTurn: vi.fn(() => undefined as { turnId: string; viewId: string } | undefined),
+      lastViewForAgent: vi.fn(() => undefined),
       sourceState: vi.fn(() => ({ memoryBodyIds: ['project'] })),
     }
     const source = { forAgent: vi.fn(() => ({ service: memoryService, runtimeMemory: {}, documents: {}, memoryViews })) }
@@ -1546,6 +1547,55 @@ describe('Mnemon root/child tool split', () => {
     expect(registered.find(tool => tool.name === 'mnemon_memory_bodies')!.description).toContain('Never call it to route Recall')
     expect(hotMemory.description).toContain('answering a read question must stay read-only')
     expect(hotMemory.description).toContain('unless the user explicitly asks to save that exact evidence')
+  })
+
+  it('falls back to the owner latest view when the parent turn already ended', async () => {
+    const host = subagents(undefined)
+    const memoryService = service()
+    vi.mocked(memoryService.search).mockResolvedValueOnce({
+      query: 'stale parent query',
+      mode: 'smart',
+      results: [{ id: 'stale-1', content: 'Stale fact', relevanceTier: 'high', memoryBodyId: 'project' }],
+    } as never)
+    const memoryViews = {
+      activeTurn: vi.fn(() => undefined),
+      lastViewForAgent: vi.fn(() => ({ id: 'view-stale', createdAt: '2026-08-29T00:00:00.000Z' })),
+      sourceState: vi.fn(() => ({ memoryBodyIds: ['project'] })),
+    }
+    const source = { forAgent: vi.fn(() => ({ service: memoryService, runtimeMemory: {}, documents: {}, memoryViews })) }
+    const coordinator = new MnemonSubagentCoordinator(host.value, source as never, undefined, toolRegistry().value)
+    const child = parent('subagent')
+    child.session.header!.parentSession = 'root'
+
+    const result = await coordinator.recall(child, { query: 'stale parent query' }, new AbortController().signal, { requirePinnedView: true })
+
+    expect(memoryViews.activeTurn).toHaveBeenCalledWith('root')
+    expect(memoryViews.lastViewForAgent).toHaveBeenCalledWith('root')
+    expect(memoryService.search).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'stale parent query', memoryBodyIds: ['project'] }),
+      expect.anything(),
+    )
+    expect(result.results).toEqual([{ id: 'stale-1', content: 'Stale fact', memoryBodyId: 'project' }])
+  })
+
+  it('throws when the owner has neither a pinned turn nor a latest view', async () => {
+    const host = subagents(undefined)
+    const memoryService = service()
+    const memoryViews = {
+      activeTurn: vi.fn(() => undefined),
+      lastViewForAgent: vi.fn(() => undefined),
+      sourceState: vi.fn(() => ({ memoryBodyIds: ['project'] })),
+    }
+    const source = { forAgent: vi.fn(() => ({ service: memoryService, runtimeMemory: {}, documents: {}, memoryViews })) }
+    const coordinator = new MnemonSubagentCoordinator(host.value, source as never, undefined, toolRegistry().value)
+    const child = parent('subagent')
+    child.session.header!.parentSession = 'root'
+
+    await expect(
+      coordinator.recall(child, { query: 'orphan query' }, new AbortController().signal, { requirePinnedView: true }),
+    ).rejects.toThrow('Recall requires the MemorySource generation pinned to the current turn')
+    expect(memoryViews.lastViewForAgent).toHaveBeenCalledWith('root')
+    expect(memoryService.search).not.toHaveBeenCalled()
   })
 
   it('projects status as a bounded health summary without control-plane paths or detailed statistics', async () => {


### PR DESCRIPTION
## 摘要 / Summary

Subagents dispatched asynchronously (e.g. `agent_dispatch` via `ctx.subagents.startContinuable`) can outlive the parent turn. The parent's MemorySource pin is released on turn end, so a child's `mnemon_recall` hits `activeTurn(parentId) === undefined` and fails with "Recall requires the MemorySource generation pinned to the current turn" — even though the parent session owns a valid reconciled View.

This PR adds `MemoryTurnViewManager.lastViewForAgent(agentId)` to resolve the owner's most recently published View, and falls back to it in `turnAuthority` when no live pin exists. Authority stays scoped to the same owner and the same `memoryBodyIds`, preserving the Host-pinned Source authority model.

## 关联 Issue 或背景 / Related Issue or Context

N/A — direct PR. This is a bug fix (subagent recall fails in an async-dispatch scenario); it does not change the authorization boundary (same owner, same memoryBodyIds, no new capability), so it does not require a prior Issue under the repository rules.

### Reproduction

1. Dispatch a subagent asynchronously via `ctx.subagents.startContinuable({ provider: 'spawn', signal, request: { label, prompt, parent, ... } })` — the dispatch returns immediately and the child runs in the background.
2. Let the parent turn finish (pin is released, `endTurn` deletes the turn entry).
3. The child calls `mnemon_recall`.

Before: throws `Recall requires the MemorySource generation pinned to the current turn`.
After: the child recalls against the parent owner's latest reconciled View.

This matches the existing intent in `tests/subagent.spec.ts` ("routes both root and child Recall through Host-pinned Source authority"): children are *supposed* to share the parent's authority — the gap was purely the pin's lifetime, not the authorization model.

## 涉及区域 / Affected Areas

- [x] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [x] 记忆体或 Provider / Memory Spaces or Providers

## PR 类型 / PR Type

- [x] Bug 修复 / Bug fix

## 最新代码确认 / Latest Codebase Confirmation

- [x] 已 rebase 到最新 upstream/main（46 commits，无冲突；rebase 后 62/62 touched specs 通过）

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.

使用的 AI 模型 / AI model used: deepseek-v4-flash-thinking

使用的编码 Agent 工具 / Coding Agent tool used: DeepSeek Harness

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，仅使用正式的 `@deepseek-ai/*` NPM 契约
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji

## 兼容性与数据安全 / Compatibility and Data Safety

No impact on DSH, Mnemon, Providers, configuration, storage formats, upgrade/rollback, or existing data.

**Why this is not a security-boundary change**: the fallback reuses the exact same `memoryBodyIds` snapshot that `recallAuthority` already validates from the owner's View (`sourceState(authority.viewId, 'memory-spaces')`); it never widens the recallable set. `lastViewForAgent` only resolves *which* View, not *what* it can access. The `turns` map and View retention semantics (`collect()` / `maxViews`) are unchanged; `lastViewForAgent` is purely additive.

**Design note on the fallback `turnId`**: when falling back, `turnId` is set to `ownerId` rather than an empty string, so the per-turn retrieval budget (`turnRetrievalState`) stays isolated per owner — all fallback recalls from the same owner share one budget, instead of every fallback call sharing a single global bucket.

## 本地验证 / Local Validation

Commands run:

```bash
pnpm vitest run tests/subagent.spec.ts tests/memory-view.spec.ts
pnpm vitest run          # full suite: 476 passed + 1 skipped (pre-rebase), 62/62 on touched specs (post-rebase)
pnpm tsc --noEmit        # clean
```

Result summary: All tests pass; TypeScript check clean. New regression tests cover (1) child recall falling back to the owner latest View after the parent turn ended, (2) fail-closed when the owner has neither a pin nor a View, (3) kernel `lastViewForAgent` retention after `endTurn` and per-agent scoping.
