### PR TITLE
fix(client): bind workspace list store methods for the 0.1.2 controller split

### DIFF
--- a/src/client/workspace-mount.tsx
+++ b/src/client/workspace-mount.tsx
@@ -29,8 +29,19 @@ function MnemonPanel({ ctx, settings, t, onClose }: MnemonPanelProps): JSX.Eleme
   const subscribeLocale = useCallback((listener: () => void) => ctx.locale.subscribe(listener), [ctx.locale])
   const getLocaleSnapshot = useCallback(() => ctx.locale.getSnapshot(), [ctx.locale])
   const locale = useSyncExternalStore(subscribeLocale, getLocaleSnapshot, getLocaleSnapshot)
-  const sessions = useSyncExternalStore(ctx.sessions.list.subscribe, ctx.sessions.list.getSnapshot, ctx.sessions.list.getSnapshot)
-  const workspaces = useSyncExternalStore(ctx.workspaces.list.subscribe, ctx.workspaces.list.getSnapshot, ctx.workspaces.list.getSnapshot)
+  // Arrow-bound on purpose: the 0.1.2 workspace-controller store exposes
+  // prototype methods, so a detached bare reference loses `this` and crashes
+  // getSnapshot (Cannot read properties of undefined (reading 'refreshSnapshot')).
+  const sessions = useSyncExternalStore(
+    listener => ctx.sessions.list.subscribe(listener),
+    () => ctx.sessions.list.getSnapshot(),
+    () => ctx.sessions.list.getSnapshot(),
+  )
+  const workspaces = useSyncExternalStore(
+    listener => ctx.workspaces.list.subscribe(listener),
+    () => ctx.workspaces.list.getSnapshot(),
+    () => ctx.workspaces.list.getSnapshot(),
+  )
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>()
   const currentCwd = sessions.current === undefined ? undefined : sessions.byId[sessions.current]?.cwd
   const normalizePath = (value: string): string => value.replace(/[\\/]+$/u, '')


### PR DESCRIPTION
## 摘要 / Summary

`MnemonPanel` 将 sessions/workspaces 两个 store 的 `subscribe/getSnapshot` 以裸方法引用传入 `useSyncExternalStore`。0.1.2 起 `ctx.workspaces.list` 由新的 workspace-controller 提供，其方法依赖 `this`；裸引用在 React 回调中丢失接收者，首次读取即抛 `TypeError: Cannot read properties of undefined (reading 'refreshSnapshot')`，面板渲染崩溃并在页面上留下空的灰屏容器。本 PR 将两处访问改为箭头包裹，使接收者在 0.1.1-rc.2 与 0.1.2+ 上都得到保留。

## 关联 Issue 或背景 / Related Issue or Context

Closes #120

相关背景：#113 提出了相同的修复但未按 PR 模板填写，贡献规范检查未通过；本 PR 为遵循模板的等价实现，打包版 DSH 0.1.2-alpha.1 上的完整复现、堆栈与冒烟测试记录见关联 Issue。

## 涉及区域 / Affected Areas

- [x] Web UI 或对话交互 / Web UI or conversation interaction

## PR 类型 / PR Type

- [x] Bug 修复 / Bug fix
- [x] 兼容性适配 / Compatibility change

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

`git fetch upstream && git rebase upstream/main`（分支自 82e586d 切出，与当前 upstream main 一致）

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.

使用的 AI 模型 / AI model used: GLM-5.3-Flash

使用的编码 Agent 工具 / Coding Agent tool used: DeepSeek Harness（dsh CLI coding agent）

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

N/A（不触及持久化格式、RPC authority、路径或凭据处理）：改动仅为将两处 store 方法访问改为箭头调用，在 0.1.1-rc.2（闭包式快照）与 0.1.2+（依赖 `this` 的类方法快照）上行为一致；无迁移、升级、回滚或数据保留方面的影响。

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm run typecheck
pnpm run build
```

结果摘要 / Result summary: `tsc --noEmit` 通过；tsdown host 与 client 双构建通过（client.js 为唯一变更产物）。完整 `pnpm run verify` 以 CI 矩阵为准——本 PR 与 #113 为逐字节等价的 diff，#113 的 Verify（ubuntu Node 22.19/24、windows Node 24）与 DSH 0.1.2-alpha.1 source 校验已全部通过。本地 Windows 环境在干净 main 基线上存在与本次改动无关的平台性测试失败（文件权限与路径断言类），故未以本地 vitest 结果作为门槛。

## 用户可见变更证据 / Local Feature Evidence

N/A —— 本 PR 修复崩溃并恢复既有面板行为，不新增用户可见变更；灰屏现象、控制台堆栈与修复后冒烟测试记录见关联 Issue 的「Bug 证据」与「冒烟测试」小节。
