### PR TITLE
fix(client): bind this-dependent settings scope before useSyncExternalStore

### DIFF
--- a/src/client/MnemonSaveAction.tsx
+++ b/src/client/MnemonSaveAction.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState, useSyncExternalStore, type JSX } from 'react'
+import { memo, useCallback, useEffect, useRef, useState, useSyncExternalStore, type JSX } from 'react'
 import { Button, IconDataOutline16, Modal, Tooltip } from '@deepseek-ai/dsh-client-ui-primitives'
 import type { ClientConnectionHandle, ClientSettingsScope, Config } from '../shared/contracts.ts'
 import { MnemonClient } from './api.ts'
@@ -24,7 +24,9 @@ const PREVIEW_LIMIT = 8000
 
 /** Save-to-memory action on finalized assistant messages, routed through the supervised writeback gate. */
 export const MnemonSaveAction = memo(function MnemonSaveAction({ messageId, sessionId, connection, settingsScope, t }: MnemonSaveActionProps): JSX.Element {
-  const settingsSnapshot = useSyncExternalStore(settingsScope.subscribe, settingsScope.getSnapshot, settingsScope.getSnapshot)
+  const subscribeSettings = useCallback((listener: () => void) => settingsScope.subscribe(listener), [settingsScope])
+  const getSettingsSnapshot = useCallback(() => settingsScope.getSnapshot(), [settingsScope])
+  const settingsSnapshot = useSyncExternalStore(subscribeSettings, getSettingsSnapshot, getSettingsSnapshot)
   const managementWritable = settingsSnapshot.status === 'ready' && settingsSnapshot.writable
   const [open, setOpen] = useState(false)
   const [writeEnabled, setWriteEnabled] = useState<boolean | undefined>(undefined)

--- a/src/client/MnemonView.tsx
+++ b/src/client/MnemonView.tsx
@@ -2256,7 +2256,9 @@ export function MnemonView(props: MnemonViewProps): JSX.Element {
 
 function MnemonWorkspace({ connection, settingsScope, sessionId, workspaceId, workspaceSelection, onClose }: MnemonViewProps): JSX.Element {
   const t = useT()
-  const settingsSnapshot = useSyncExternalStore(settingsScope.subscribe, settingsScope.getSnapshot, settingsScope.getSnapshot)
+  const subscribeSettings = useCallback((listener: () => void) => settingsScope.subscribe(listener), [settingsScope])
+  const getSettingsSnapshot = useCallback(() => settingsScope.getSnapshot(), [settingsScope])
+  const settingsSnapshot = useSyncExternalStore(subscribeSettings, getSettingsSnapshot, getSettingsSnapshot)
   const client = useMemo(() => new MnemonClient(connection, sessionId, workspaceId), [connection, sessionId, workspaceId])
   const clientContextKey = `${sessionId ?? ''}\u0000${workspaceId ?? ''}`
   const viewContextKey = `${clientContextKey}\u0000${settingsSnapshot.revision ?? 'loading'}`

--- a/tests/client-settings-this-binding.spec.tsx
+++ b/tests/client-settings-this-binding.spec.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+//
+// Regression test for a real DSH Host crash: the real `ClientSettingsScope`
+// implementation (e.g. @deepseek-ai/dsh-client-ui-settings) exposes
+// `getSnapshot`/`subscribe` as `this`-dependent class methods. React's
+// `useSyncExternalStore` invokes its callbacks as bare functions (`this` is
+// `undefined`), so passing `settingsScope.getSnapshot` unbound throws
+// `Cannot read properties of undefined` and the Memory System view goes blank.
+//
+// The scope mock below deliberately mirrors that `this`-dependent shape
+// (methods, not closure arrow properties) so this test is red against the
+// unbound call sites and green once they wrap the methods.
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ClientConnectionHandle, ClientSettingsScope, ClientSettingsSnapshot } from '../src/contracts.ts'
+import type { Config } from '../src/config.ts'
+import { MnemonSaveAction } from '../src/client/MnemonSaveAction.tsx'
+import { MnemonView } from '../src/client/MnemonView.tsx'
+
+class ThisBoundSettingsScope implements ClientSettingsScope<Config> {
+  private state: ClientSettingsSnapshot<Config>
+  private listeners = new Set<() => void>()
+  constructor() {
+    this.state = { status: 'ready', value: {}, revision: 1, writable: true, mode: 'host' }
+  }
+  getSnapshot(): ClientSettingsSnapshot<Config> {
+    return this.state
+  }
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+  async set(): Promise<void> {}
+  async unset(): Promise<void> {}
+  async setPath(): Promise<void> {}
+  async unsetPath(): Promise<void> {}
+}
+
+/** Rejecting RPC is fine: both views catch async load failures; only the synchronous render path matters here. */
+const connection = { rpc: { call: vi.fn(() => Promise.reject(new Error('no host'))) } } as unknown as ClientConnectionHandle
+
+describe('settings scope this-binding', () => {
+  afterEach(cleanup)
+
+  it('renders MnemonView with a this-bound settings scope (real Host shape)', () => {
+    expect(() => render(<MnemonView connection={connection} settingsScope={new ThisBoundSettingsScope()} sessionId="session-1" />)).not.toThrow()
+  })
+
+  it('renders MnemonSaveAction with a this-bound settings scope (real Host shape)', () => {
+    render(<MnemonSaveAction messageId="message-1" connection={connection} settingsScope={new ThisBoundSettingsScope()} t={key => key} />)
+    expect(screen.getByLabelText('saveAction.button')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## 摘要 / Summary

修复「记忆系统」在 DSH Desktop（DSH 0.1.2-alpha.1）上白屏的崩溃：`MnemonView` 与 `MnemonSaveAction` 把 `settingsScope.subscribe` / `settingsScope.getSnapshot` **未绑定**地传给 React `useSyncExternalStore`，而真实 DSH 宿主的 settings scope 是依赖 `this` 的类方法，裸调用时 `this === undefined` 抛 `Cannot read properties of undefined`，渲染中断。改为箭头包装并保持引用稳定（`useCallback`），使绑定正确、视图正常渲染。Fixes the Memory System white screen on DSH Desktop (DSH 0.1.2-alpha.1): `MnemonView` and `MnemonSaveAction` passed `settingsScope.subscribe`/`settingsScope.getSnapshot` unbound to `useSyncExternalStore`, and the real DSH host scope is a `this`-dependent class, so the bare call threw and aborted render. The methods are now wrapped (via `useCallback`) so `this` stays bound and the view renders.

## 关联 Issue 或背景 / Related Issue or Context

Closes #132

## 涉及区域 / Affected Areas

- [x] Web UI 或对话交互 / Web UI or conversation interaction

## PR 类型 / PR Type

- [x] Bug 修复 / Bug fix

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:
```bash
git fetch origin && git rebase origin/main
```

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.

使用的 AI 模型 / AI model used: deepseek-v4-pro

使用的编码 Agent 工具 / Coding Agent tool used: DeepSeek Harness (dsh)

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。（本次无此类变更 / N/A — no persistence/RPC-authority/path/credential change）
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。（本次无文案/文档变更 / N/A — no user-facing copy or doc change）
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。

## 兼容性与数据安全 / Compatibility and Data Safety

本次仅改动客户端渲染层的调用方式（把未绑定的方法引用改为箭头包装），不改变任何 wire DTO、持久化格式、RPC 权限、路径或凭据处理；对既有数据、升级与回滚无影响。DSH 侧 `sessions`/`workspaces` 的同款问题已在 `src/client/workspace-mount.tsx` 用箭头包装修复，本 PR 补齐遗漏的 `settingsScope` 调用点，采用一致方式（`useCallback` 稳定引用）。This changes only how the client invokes the settings scope (arrow wrappers instead of unbound method references). No wire DTO, persistence format, RPC authority, path, or credential handling changes; no impact on existing data, upgrade, or rollback. It mirrors the arrow-wrapper approach already applied to `sessions`/`workspaces` in `src/client/workspace-mount.tsx`.

## 本地验证 / Local Validation

执行的命令 / Commands run:
```bash
pnpm run typecheck
pnpm test
pnpm run build
```

结果摘要 / Result summary:
- `pnpm run typecheck`：通过（exit 0）。
- `pnpm test`：52 个测试文件、576 个用例通过，1 个跳过（windows-smoke）；新增 `tests/client-settings-this-binding.spec.tsx` 2 个用例通过。
- `pnpm run build`：通过（tsdown 客户端 bundle 与 ESM 产物均生成成功）。

红绿验证（regression）：`git stash` 掉修复后运行新增测试，2 个用例均失败，栈指向 `useSyncExternalStore → MnemonSaveAction/MnemonView` 的未绑定调用；恢复修复后全部通过。Red-green: with the fix stashed, the new test fails with the unbound-call stack; with the fix, it passes.

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence: 在 DSH Desktop（DSH 0.1.2-alpha.1）用 headless Chromium 驱动真实 GUI 验证——修复前点击「Memory System」控制台稳定抛出 `Cannot read properties of undefined (reading 'refreshSnapshot')`；修复后四个子页（Status / Runtime / Documents / Memory Spaces）均无异常渲染。新增回归测试用 `this` 依赖的 `ClientSettingsScope` mock（对齐真实宿主形态，见 `tests/client-settings-this-binding.spec.tsx`）锁定该问题。On DSH Desktop (0.1.2-alpha.1), a headless Chromium run against the real GUI reproduced the `reading 'refreshSnapshot'` crash before the fix and rendered all four sub-pages cleanly after. The added regression test uses a `this`-dependent `ClientSettingsScope` mock matching the real host shape to lock this down.
