### PR TITLE
fix(pack): make archive timestamps timezone-independent

### DIFF
--- a/src/pack.ts
+++ b/src/pack.ts
@@ -699,7 +699,9 @@ export class MnemonPackManager {
           'checksums.json': strToU8(`${JSON.stringify(checksums, null, 2)}\n`),
           ...payload,
         }
-        const archive = zipSync(entries, { level: 6, mtime: new Date('1980-01-01T00:00:00.000Z') })
+        // fflate writes ZIP timestamps using local date fields. Pin those fields
+        // to keep the archive in range and byte-identical across timezones.
+        const archive = zipSync(entries, { level: 6, mtime: new Date(1980, 0, 1) })
         if (archive.length > MNEMON_PACK_MAX_ARCHIVE_BYTES) throw new Error('exported Mnemon Pack exceeds the transport safety limit')
         const stamp = exportedAt.replace(/[:.]/gu, '-').replace('T', '_').replace('Z', '')
         return {

--- a/tests/pack.spec.ts
+++ b/tests/pack.spec.ts
@@ -53,6 +53,7 @@ async function fixture(label: string, seed: number, bodyId = 'project') {
 }
 
 afterEach(() => {
+  vi.unstubAllEnvs()
   for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true })
 })
 
@@ -87,6 +88,25 @@ describe('Mnemon Pack', () => {
       const files = unzipSync(Buffer.from(exported.base64, 'base64'))
       expect(exported.manifest).toMatchObject({ scope, components: [scope] })
       expect(Object.keys(files).filter(path => path.startsWith('payload/')).every(path => path.startsWith(`payload/${scope === 'memory-spaces' ? 'data' : scope}/`))).toBe(true)
+    }
+  })
+
+  it.each(['full', 'runtime', 'documents', 'memory-spaces'] as const)('exports byte-identical %s Packs across timezones', async (scope) => {
+    const source = await fixture('pack-timezones', 23)
+    vi.stubEnv('TZ', 'UTC')
+    const reference = await source.manager.exportPack(scope)
+
+    for (const [timeZone, offset] of [
+      ['UTC', 0],
+      ['America/Los_Angeles', 480],
+      ['Etc/GMT+12', 720],
+      ['Etc/GMT-14', -840],
+      ['Asia/Kolkata', -330],
+    ] as const) {
+      vi.stubEnv('TZ', timeZone)
+      expect(new Date('1980-01-01T00:00:00.000Z').getTimezoneOffset(), timeZone).toBe(offset)
+      const exported = await source.manager.exportPack(scope)
+      expect(exported.base64, timeZone).toBe(reference.base64)
     }
   })
 


### PR DESCRIPTION
> 提交 PR 前请阅读[贡献指南](../CONTRIBUTING.zh-CN.md)、[Contributing Guide](../CONTRIBUTING.md)与[开发和验证指南](../docs/zh-CN/development.md) / [Development and Verification Guide](../docs/en/development.md)。
> Before opening a PR, read the [Contributing Guide](../CONTRIBUTING.md), [贡献指南](../CONTRIBUTING.zh-CN.md), and the [Development and Verification Guide](../docs/en/development.md) / [开发和验证指南](../docs/zh-CN/development.md).
> PR 标题和提交信息必须使用 Conventional Commits（`type(scope): subject`），且不得包含 emoji。 / PR titles and commits must use Conventional Commits (`type(scope): subject`) and must not contain emoji.
> 本仓库接受 Bug 修复、兼容性适配、现有能力增强、性能或体验优化和维护类 PR。全新能力、Provider、持久化格式或安全边界变更必须先提 Issue 并获得维护者确认。 / This repository accepts bug fixes, compatibility work, improvements to existing capabilities, performance or UX optimization, and maintenance. New capabilities, Providers, persistence formats, or security-boundary changes require prior maintainer approval in an Issue.
> 外部贡献者的仅文档类 PR 不直接接受；请先提 Issue 讨论。维护者的发布说明与文档维护不受此限制。 / Documentation-only PRs from external contributors are not accepted directly; open an Issue first. Maintainer release notes and documentation maintenance are exempt.

## 摘要 / Summary

Pack export fails in timezones behind UTC because fflate converts the fixed UTC epoch into local ZIP date fields, which can fall in 1979. Pin those local fields to 1980-01-01 so exports succeed and identical payloads with the same export time produce identical ZIP bytes across timezones.

## 关联 Issue 或背景 / Related Issue or Context

Fixes #112

Moving the UTC epoch forward one day avoids the range error but still writes different ZIP timestamps in different timezones. Using a fixed local date addresses both the error and reproducibility, while preserving the previous UTC archive headers.

## 涉及区域 / Affected Areas

<!-- 至少勾选一项。 / Check at least one item. -->

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [x] 运行时记忆 / Runtime Memory
- [x] 项目档案 / Project Documents
- [x] 记忆体或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [ ] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

<!-- 至少勾选一项；仅文档类 PR 的限制见文件顶部说明。 / Check at least one item; see the note above for documentation-only PRs. -->

- [x] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [x] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [ ] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```sh
git fetch origin main
git merge-base --is-ancestor origin/main HEAD
git rev-list --left-right --count origin/main...HEAD
```

Created an isolated worktree from `origin/main` at `1f9d7cb`. Rechecked before opening this PR: zero commits behind main and one fix commit ahead (`54e8937`).

## AI 编码披露 / AI Coding Disclosure

<!-- 必填。勾选且仅勾选一项；模型和工具字段不得留空。 / Required. Check exactly one option; the model and tool fields must not be blank. -->

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

GPT-5

使用的编码 Agent 工具 / Coding Agent tool used:

Codex desktop. Code and tests were generated and self-reviewed with Codex; human PR review is pending.

## 仓库规范检查 / Repository Rules

<!-- 本仓库硬性规范，请逐项确认。 / Confirm every mandatory repository rule. -->

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

Only the fixed ZIP entry timestamp changes. The Pack version, manifest, payloads, checksums, import validation, RPC permissions, storage paths, and credential handling remain unchanged. Existing Packs remain readable; no migration, deletion, or retention change is required. Runtime, Documents, and Memory Space storage formats are unchanged. Rolling back restores the timezone bug but does not make newly exported Packs unreadable.

The regression uses synthetic fixtures, verifies actual timezone offsets, and restores the original environment after each test. No UI copy, configuration, documented workflow, DSH dependency, or generated output is changed.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm install --frozen-lockfile
TZ=America/Los_Angeles pnpm run verify
TZ=UTC pnpm exec vitest run tests/pack.spec.ts
TZ=America/Los_Angeles pnpm exec vitest run tests/pack.spec.ts
TZ=Etc/GMT+12 pnpm exec vitest run tests/pack.spec.ts
TZ=Etc/GMT-14 pnpm exec vitest run tests/pack.spec.ts
git diff --check origin/main...HEAD
```

结果摘要 / Result summary:

Validated on macOS arm64 with Node.js v25.1.0, pnpm 11.19.0, fflate 0.8.3, and published DSH 0.1.1-rc.2 dependencies.

- Before the fix, the original Pack suite reproduced 11 failures and 1 pass in America/Los_Angeles; UTC passed 12/12.
- The four new regression cases failed before the fix and passed afterward. They exercise full, runtime, documents, and memory-spaces exports across UTC, America/Los_Angeles, UTC-12, UTC+14, and Asia/Kolkata and compare complete archive bytes.
- Full verification in America/Los_Angeles passed: 586 tests passed, 1 Windows-only smoke test skipped on macOS; typecheck, deterministic double build (107 files), real Headless-profile activation, package contents, all 10 public entries, publint, and attw passed.
- The complete Pack suite passed 16/16 in each separately launched timezone listed above.
- No known local verification failures remain. Linux/Windows and the DSH alpha matrix are left to repository CI.

## 用户可见变更证据 / Local Feature Evidence

<!--
面向用户的功能或行为变更必填。 / Required for user-facing feature or behavior changes.
附截图或短视频，展示 / Attach screenshots or a short video showing:
- 使用的是本 PR 或最新代码 / the PR or latest code is running
- 功能已启用或配置 / the feature is enabled or configured
- 操作成功并出现可见结果 / the action succeeds with a visible result
- 没有泄露凭据、私有记忆或敏感路径 / no credentials, private memory, or sensitive paths are exposed
纯内部改动可填 N/A 并解释。 / For internal-only changes, enter N/A and explain.
-->

证据 / Evidence:

This is a Host-side Pack export correction with no UI layout changes. Redacted command results from the isolated worktree:

```text
Before: TZ=America/Los_Angeles pnpm exec vitest run tests/pack.spec.ts
Tests  11 failed | 1 passed (12)
Error: date not in range 1980-2099

After: TZ=America/Los_Angeles pnpm exec vitest run tests/pack.spec.ts
Tests  16 passed (16)

After: TZ=America/Los_Angeles pnpm run verify
Test Files  51 passed | 1 skipped (52)
Tests       586 passed | 1 skipped (587)
Verified deterministic output for 107 files.
Verified Headless profile activation with 35 total tools and 5 representative Mnemon tools.
Imported 10 Node-compatible public entries on v25.1.0.
All good!
```
