### PR TITLE
chore(release): prepare v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 <p align="center">
   <a href="./docs/en/capabilities.md"><strong>Explore the capability map</strong></a> ·
   <a href="./docs/en/getting-started.md">Start in five minutes</a> ·
-  <a href="./docs/en/releases/v0.4.0.md">Read the v0.4.0 notes</a> ·
+  <a href="./docs/en/releases/v0.4.1.md">Read the v0.4.1 notes</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">Watch the widescreen demo</a>
 </p>
 
@@ -35,6 +35,8 @@
 Since v0.3.0, the three tiers are the **default topology** of a composable kernel rather than the only shape hard-coded into every entry point. `MemoryBoot` wires trusted Layer, Adapter, Strategy, Guard, and `MemorySource` contributions into one runtime generation. Each user turn pins a lightweight `TurnView`: exact Runtime context enters Wake eagerly, while Documents and Memory Spaces contribute only bounded routing covers and keep complete recall authority Host-side. Users still install one `dsh-mnemon` package and keep the existing settings, tools, RPC, and UI workflow. See the [composable architecture](./docs/en/architecture.md#composable-memory-kernel) and [extension guide](./docs/en/extensions.md).
 
 v0.4.0 makes Sidebar the only Memory System workspace and removes the builtin display mode and its setting. Legacy display preferences are ignored without changing memory data; the complete view-based upgrade is planned for v0.5, not this release. Read the [upgrade and compatibility notes](./docs/en/releases/v0.4.0.md#upgrade-and-compatibility) before updating.
+
+v0.4.1 fixes Memory System and Save to memory rendering with this-dependent DSH settings stores, plus ZIP export failures and archive differences across timezones. It preserves the v0.4.0 workflow and existing memory formats. See the [patch release notes](./docs/en/releases/v0.4.1.md).
 
 ## Understand the scope in 30 seconds
 
@@ -210,7 +212,7 @@ See [Operations, security, and troubleshooting](./docs/en/operations.md) for bac
 | Back up, update, or troubleshoot | [Operations](./docs/en/operations.md) |
 | Integrate tools, commands, or RPC | [Interface reference](./docs/en/interfaces.md) |
 | Build a Layer, Adapter, Strategy, Guard, or MemorySource extension | [Extension guide](./docs/en/extensions.md) |
-| Review the release | [v0.4.0 release notes](./docs/en/releases/v0.4.0.md) |
+| Review the release | [v0.4.1 release notes](./docs/en/releases/v0.4.1.md) |
 
 See the [documentation hub](./docs/en/README.md) for the full map.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
 <p align="center">
   <a href="./docs/zh-CN/capabilities.md"><strong>先看能力地图</strong></a> ·
   <a href="./docs/zh-CN/getting-started.md">5 分钟开始</a> ·
-  <a href="./docs/zh-CN/releases/v0.4.0.md">v0.4.0 升级说明</a> ·
+  <a href="./docs/zh-CN/releases/v0.4.1.md">v0.4.1 升级说明</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">观看宽屏实机演示</a>
 </p>
 
@@ -35,6 +35,8 @@
 从 v0.3.0 开始，三层是可组合内核中的**默认拓扑**，不再是各入口各自写死的唯一结构。`MemoryBoot` 把受信任的 Layer、Adapter、Strategy、Guard 与 `MemorySource` 装配为一代运行图；每个用户回合固定一份轻量 `TurnView`：Runtime 精确内容 eager 进入 Wake，Documents 与 Memory Spaces 只给出有界路由封面，完整召回权限保留在 Host。用户仍只安装一个 `dsh-mnemon`，设置、工具、RPC 与 UI 工作流不变。参见[可组合架构](./docs/zh-CN/architecture.md#可组合记忆内核)与[扩展开发指南](./docs/zh-CN/extensions.md)。
 
 v0.4.0 将 Sidebar 设为记忆系统的唯一工作台入口，移除 builtin 展示模式及其设置。旧展示偏好会被忽略，不改变记忆数据；完整的 view-based 升级计划放在 v0.5，不包含在本版中。更新前请阅读[升级与兼容性说明](./docs/zh-CN/releases/v0.4.0.md#升级与兼容性)。
+
+v0.4.1 修复记忆系统和存入记忆在依赖 `this` 的 DSH settings store 上的渲染崩溃，以及 ZIP 导出失败和跨时区归档差异；保留 v0.4.0 工作流与既有记忆格式。详见[补丁发布说明](./docs/zh-CN/releases/v0.4.1.md)。
 
 ## 30 秒理解能力边界
 
@@ -210,7 +212,7 @@ dsh plugin --profile headless add "link:/absolute/path/to/dsh-mnemon"
 | 备份、更新或排障 | [运维指南](./docs/zh-CN/operations.md) |
 | 接入工具、命令或 RPC | [接口参考](./docs/zh-CN/interfaces.md) |
 | 开发 Layer、Adapter、Strategy、Guard 或 MemorySource 扩展 | [扩展开发指南](./docs/zh-CN/extensions.md) |
-| 查看本次升级 | [v0.4.0 发布说明](./docs/zh-CN/releases/v0.4.0.md) |
+| 查看本次升级 | [v0.4.1 发布说明](./docs/zh-CN/releases/v0.4.1.md) |
 
 完整目录见[文档中心](./docs/zh-CN/README.md)。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,9 +3,9 @@
 - [English](./en/README.md)
 - [简体中文](./zh-CN/README.md)
 
-Start with [Getting Started](./en/getting-started.md). Existing users should read the [v0.4.0 release notes](./en/releases/v0.4.0.md); extension authors should continue with [Architecture](./en/architecture.md) and [Building Memory Extensions](./en/extensions.md).
+Start with [Getting Started](./en/getting-started.md). Existing users should read the [v0.4.1 release notes](./en/releases/v0.4.1.md); extension authors should continue with [Architecture](./en/architecture.md) and [Building Memory Extensions](./en/extensions.md).
 
-第一次使用请从[快速开始](./zh-CN/getting-started.md)进入。已有用户先看 [v0.4.0 发布说明](./zh-CN/releases/v0.4.0.md)；扩展作者继续阅读[架构设计](./zh-CN/architecture.md)与[记忆扩展开发](./zh-CN/extensions.md)。
+第一次使用请从[快速开始](./zh-CN/getting-started.md)进入。已有用户先看 [v0.4.1 发布说明](./zh-CN/releases/v0.4.1.md)；扩展作者继续阅读[架构设计](./zh-CN/architecture.md)与[记忆扩展开发](./zh-CN/extensions.md)。
 
 The root README stays focused on orientation and quick start. Architecture, data model, lifecycle, interfaces, operations, and development details live here.
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -30,7 +30,7 @@ This hub is organized by what you need to accomplish. New users should follow Ge
 | Understand Host, workers, control plane, and data plane | [Architecture](./architecture.md) |
 | Build a Layer, Adapter, Strategy, Guard, or MemorySource plugin | [Building Memory Extensions](./extensions.md) |
 | Modify code, screenshots, tests, or releases | [Development and verification](./development.md) |
-| Upgrade from the previous release | [v0.4.0 release notes](./releases/v0.4.0.md) |
+| Upgrade from the previous release | [v0.4.1 release notes](./releases/v0.4.1.md) |
 | See planned work | [Roadmap](./roadmap.md) |
 
 ## Core terms

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -17,7 +17,7 @@ You need:
 
 Regular semantic work prefers a provider named `spawn` with `toolFilter`, `persona`, and `depthLimit`. Mnemon supplies a schema-validated, one-run result tool instead of depending on the Provider's `outputSchema` path. Optional score-based background review additionally requires a provider named `fork` with `inheritsParentContext=true`. Missing `fork` does not block deterministic pages or regular manual actions.
 
-This workflow uses dsh-mnemon v0.4.0, DSH 0.1.1-rc.2, and Mnemon 0.2.3 as the recommended registry baseline. Some compatible UI screenshots were captured on dsh-mnemon v0.2.0. DSH rc.2 uses `Promise.withResolvers` and the Node Zstd API, so Node 20 cannot boot its complete profile. Source compatibility is also verified against DSH 0.1.2-alpha.1, which is not published to npm. Back up and repeat this verification against an isolated root before upgrading.
+This workflow uses dsh-mnemon v0.4.1, DSH 0.1.1-rc.2, and Mnemon 0.2.3 as the recommended registry baseline. Some compatible UI screenshots were captured on dsh-mnemon v0.2.0. DSH rc.2 uses `Promise.withResolvers` and the Node Zstd API, so Node 20 cannot boot its complete profile. Source compatibility is also verified against DSH 0.1.2-alpha.1, which is not published to npm. Back up and repeat this verification against an isolated root before upgrading.
 
 Install and verify the tested DSH release with:
 

--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -155,6 +155,8 @@ Report vulnerabilities privately through [SECURITY.md](../../SECURITY.md), not a
 | Document source path rejected | Keep it inside the session workspace and outside managed Documents |
 | CLI timeout | Increase `timeoutMs`; large Stores may need more than 10 seconds for status or graph |
 | Lock timeout | Check other writers; never delete a lock owned by a live process |
+| Memory System goes blank with a `refreshSnapshot` or settings-store error | Upgrade dsh-mnemon to v0.4.1 and restart the owning DSH profile; settings callbacks preserve their host store receiver |
+| ZIP export reports `date not in range 1980-2099` | Upgrade dsh-mnemon to v0.4.1; fixed local ZIP date fields work in timezones behind UTC and keep identical exports byte-stable across timezones |
 | ZIP export reports WAL busy | Wait for Memory Space writes to settle; do not bypass the uncheckpointed-WAL guard |
 | ZIP import checksum/schema failure | The backup is damaged or incompatible; preserve the current root and never unzip over it manually |
 | No Update button | Already current, remote check failed, or the source is link/manual; follow panel guidance |

--- a/docs/en/releases/v0.4.1.md
+++ b/docs/en/releases/v0.4.1.md
@@ -1,0 +1,33 @@
+# v0.4.1: Reliable settings subscriptions and timezone-safe Packs
+
+[简体中文](../../zh-CN/releases/v0.4.1.md) | **English** | [Capability map](../capabilities.md)
+
+v0.4.1 is a focused patch for the Sidebar-only v0.4 series. It fixes DSH settings-store callback binding and Mnemon Pack ZIP timestamps without changing the memory architecture, configuration contract, or data formats.
+
+## Fixes
+
+- **Memory System no longer crashes on this-dependent settings stores.** Both the workspace and Save to memory action wrap `subscribe` and `getSnapshot` with stable callbacks before passing them to React. The real host store keeps its receiver instead of being invoked as an unbound method. [#133](https://github.com/omdsh-dev/dsh-mnemon/pull/133), [#136](https://github.com/omdsh-dev/dsh-mnemon/issues/136)
+- **Pack export works in timezones behind UTC.** ZIP entry date fields are pinned to local 1980-01-01, preventing a UTC epoch from becoming an out-of-range 1979 date. Identical payloads with the same export time now produce identical archive bytes across timezones. [#137](https://github.com/omdsh-dev/dsh-mnemon/pull/137), [#112](https://github.com/omdsh-dev/dsh-mnemon/issues/112)
+- **Regression coverage matches the failure modes.** Settings tests use this-dependent class methods. Pack tests compare complete archives for full, runtime, documents, and memory-spaces exports across UTC, Los Angeles, UTC-12, UTC+14, and Kolkata.
+
+## Upgrade and compatibility
+
+Install `dsh-mnemon@0.4.1` in the owning DSH profile, restart that profile, and reopen Memory System. Users upgrading from v0.3.x must also read the [v0.4.0 Sidebar-only compatibility notes](./v0.4.0.md#upgrade-and-compatibility).
+
+- Runtime, Documents, Memory Space data, Pack manifests and checksums, RPC permissions, storage paths, and Provider credentials are unchanged. Existing Packs remain readable; no migration or deletion is required.
+- Only the fixed ZIP entry timestamp changes. UTC exports retain the prior timestamp fields; other timezones now use the same fields.
+- DSH 0.1.1-rc.2 remains the published dependency baseline. DSH 0.1.2-alpha.1 remains a source-only compatibility target.
+- The Sidebar-only workflow from v0.4.0 is retained. The separately planned v0.5 view-based architecture is not included.
+
+## Rollback
+
+Reinstall `dsh-mnemon@0.4.0` in the same profile and restart it. No data conversion is needed, and existing Packs remain readable, but the settings-store crash and timezone-dependent export behavior return.
+
+## Verification
+
+- On macOS arm64 with Node.js 25.1.0 and pnpm 11.19.0, `TZ=America/Los_Angeles pnpm run verify` passed: 588 tests passed and one Windows-only smoke test was skipped. Deterministic double builds matched 107 files; isolated real Headless activation exposed 35 tools, including 5 representative Mnemon tools. Package-content checks covered 114 files, and all 10 Node-compatible public entries, publint strict, and attw passed.
+- The complete Pack suite passed 16/16 in separately launched UTC, America/Los_Angeles, UTC-12, and UTC+14 processes.
+- The actual v0.4.1 tarball was installed into an isolated npm DSH 0.1.1-rc.2 Web profile with Web UI 0.3.6 and checksum-verified Mnemon 0.2.5. All four memory pages rendered, Save to memory opened and canceled, and Settings reported successful ZIP generation in America/Los_Angeles, with no browser console errors. The browser download-completion event was not captured; downloaded-file persistence was not independently verified. The fixture used synthetic data and a local fixed model response, not a paid model or personal memory.
+- Both implementation PRs passed Linux Node.js 22.19 and 24, Windows Node.js 24, and source-linked DSH 0.1.2-alpha.1 CI before merge.
+
+Previous release: [v0.4.0](./v0.4.0.md).

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -30,7 +30,7 @@
 | 理解 Host、worker、控制面与数据面 | [架构设计](./architecture.md) |
 | 开发 Layer、Adapter、Strategy、Guard 或 MemorySource 插件 | [记忆扩展开发](./extensions.md) |
 | 修改代码、截图、测试或发布 | [开发与验证](./development.md) |
-| 从上一版本升级 | [v0.4.0 发布说明](./releases/v0.4.0.md) |
+| 从上一版本升级 | [v0.4.1 发布说明](./releases/v0.4.1.md) |
 | 查看下一阶段计划 | [Roadmap](./roadmap.md) |
 
 ## 核心术语

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -17,7 +17,7 @@
 
 普通语义任务优先使用名为 `spawn` 的 Provider，并要求 `toolFilter`、`persona` 与 `depthLimit`。Mnemon 会为每次运行提供一个经过 schema 校验的一次性结果工具，不依赖 Provider 的 `outputSchema` 路径。可选的评分后台审查还要求名为 `fork`、且 `inheritsParentContext=true` 的 Provider。缺少 `fork` 不影响确定性页面读取和普通手动操作。
 
-本文流程以 dsh-mnemon v0.4.0、DSH 0.1.1-rc.2 和 Mnemon 0.2.3 作为推荐 registry 基线；部分保持兼容的界面截图拍摄于 dsh-mnemon v0.2.0。DSH rc.2 使用 `Promise.withResolvers` 和 Node Zstd API，因此 Node 20 无法启动完整 profile。源码兼容性也已针对尚未发布到 npm 的 DSH 0.1.2-alpha.1 验证。升级前先备份，并在隔离目录重复本页验证。
+本文流程以 dsh-mnemon v0.4.1、DSH 0.1.1-rc.2 和 Mnemon 0.2.3 作为推荐 registry 基线；部分保持兼容的界面截图拍摄于 dsh-mnemon v0.2.0。DSH rc.2 使用 `Promise.withResolvers` 和 Node Zstd API，因此 Node 20 无法启动完整 profile。源码兼容性也已针对尚未发布到 npm 的 DSH 0.1.2-alpha.1 验证。升级前先备份，并在隔离目录重复本页验证。
 
 安装并核对已验证的 DSH 版本：
 

--- a/docs/zh-CN/operations.md
+++ b/docs/zh-CN/operations.md
@@ -155,6 +155,8 @@ DSH rc.8 首次说明的可选 SQLite 不兼容性在 DSH 0.1.1-rc.2 中仍然�
 | Document source path 被拒绝 | 路径必须在会话工作区内，且不能引用受管 Documents 目录 |
 | CLI timeout | 增大 `timeoutMs`；大 Store 的状态与图谱可能超过 10 秒 |
 | lock timeout | 检查其他写进程，不要删除仍属于活跃进程的 lock |
+| 记忆系统白屏并提示 `refreshSnapshot` 或 settings store 错误 | 将 dsh-mnemon 升级到 v0.4.1 并重启所属 DSH profile；设置回调会保留宿主 store 的 `this` 绑定 |
+| ZIP 导出提示 `date not in range 1980-2099` | 将 dsh-mnemon 升级到 v0.4.1；固定本地 ZIP 日期字段后，UTC 以西时区可以正常导出，相同导出的归档字节也不再因时区变化 |
 | ZIP 导出提示 WAL busy | 等待 Memory Space 写入完成并重试；不要绕过未 checkpoint WAL 检查 |
 | ZIP 导入 checksum / schema 失败 | 备份损坏或格式不兼容；保留当前根，不要手工解压覆盖 |
 | 更新按钮不出现 | 当前已是最新、远程检查失败，或安装来源是 link / 手工模式；按面板提示沿原方式更新 |

--- a/docs/zh-CN/releases/v0.4.1.md
+++ b/docs/zh-CN/releases/v0.4.1.md
@@ -1,0 +1,33 @@
+# v0.4.1：可靠的设置订阅与跨时区 Pack 导出
+
+**简体中文** | [English](../../en/releases/v0.4.1.md) | [能力地图](../capabilities.md)
+
+v0.4.1 是 Sidebar 唯一入口的 v0.4 系列补丁，修复 DSH settings store 回调绑定和 Mnemon Pack ZIP 时间戳，不改变记忆架构、配置契约或数据格式。
+
+## 修复
+
+- **记忆系统不再因依赖 `this` 的 settings store 而崩溃。** 工作台和存入记忆操作都先以稳定回调包装 `subscribe` 与 `getSnapshot`，再传给 React；保留真实宿主 store 的 `this`，避免以未绑定方法调用。[#133](https://github.com/omdsh-dev/dsh-mnemon/pull/133)、[#136](https://github.com/omdsh-dev/dsh-mnemon/issues/136)
+- **UTC 以西时区可以正常导出 Pack。** 将 ZIP 条目的本地日期字段固定为 1980-01-01，避免 UTC 起点在本地落入超出范围的 1979 年；相同数据和导出时间在不同时区生成的归档字节保持一致。[#137](https://github.com/omdsh-dev/dsh-mnemon/pull/137)、[#112](https://github.com/omdsh-dev/dsh-mnemon/issues/112)
+- **回归测试覆盖真实故障形态。** 设置测试使用依赖 `this` 的类方法；Pack 测试覆盖完整包、运行时、档案和记忆体四种导出范围，在 UTC、洛杉矶、UTC-12、UTC+14 和加尔各答比较完整归档字节。
+
+## 升级与兼容性
+
+在所属 DSH profile 中安装 `dsh-mnemon@0.4.1`，重启该 profile，再重新打开记忆系统。从 v0.3.x 升级的用户还需阅读 [v0.4.0 Sidebar-only 兼容性说明](./v0.4.0.md#升级与兼容性)。
+
+- Runtime、Documents、Memory Space 数据、Pack manifest 与 checksum、RPC 权限、存储路径和 Provider 凭据保持不变；已有 Pack 仍可读取，不需要迁移或删除数据。
+- 仅调整 ZIP 条目的固定时间戳。UTC 导出保留原日期字段，其他时区现在也使用相同字段。
+- 已发布依赖基线仍为 DSH 0.1.1-rc.2；DSH 0.1.2-alpha.1 继续作为仅提供源码的兼容性目标。
+- 保留 v0.4.0 的 Sidebar 唯一入口工作流，不包含独立计划的 v0.5 view-based 架构升级。
+
+## 回滚
+
+在同一 profile 中重新安装 `dsh-mnemon@0.4.0` 并重启。无需转换数据，已有 Pack 仍可读取，但 settings store 崩溃和依赖时区的导出行为也会恢复。
+
+## 验证
+
+- 在 macOS arm64 / Node.js 25.1.0 / pnpm 11.19.0 上运行 `TZ=America/Los_Angeles pnpm run verify`：588 项测试通过，跳过一项 Windows 专用冒烟测试。可复现双构建匹配 107 个文件；隔离的真实 Headless 激活暴露 35 个工具，其中包含 5 个代表性 Mnemon 工具。发布包检查覆盖 114 个文件，10 个 Node-compatible 公开入口、publint strict 与 attw 全部通过。
+- 完整 Pack 套件分别在 UTC、洛杉矶、UTC-12 和 UTC+14 的独立进程中通过 16/16。
+- 将实际 v0.4.1 tarball 安装到隔离的 npm DSH 0.1.1-rc.2 Web profile，使用 Web UI 0.3.6 和经 checksum 校验的 Mnemon 0.2.5：四个记忆子页正常渲染，存入记忆弹窗可打开并取消，设置页在洛杉矶时区报告 ZIP 生成成功，浏览器控制台无错误。浏览器下载完成事件未被捕获，因此未独立验证下载文件落盘。夹具仅使用合成数据和本地固定模型回复，不调用付费模型或个人记忆。
+- 两个实现 PR 均在合并前通过 Linux Node.js 22.19 与 24、Windows Node.js 24，以及源码链接 DSH 0.1.2-alpha.1 CI。
+
+上一版：[v0.4.0](./v0.4.0.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mnemon",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Composable three-tier memory control plane for DeepSeek Harness: persistent runtime context, searchable project documents, pluggable long-term memory, guarded strategies, WebUI, and headless tools.",
   "keywords": [
     "deepseek-harness",


### PR DESCRIPTION
> 提交 PR 前请阅读[贡献指南](../CONTRIBUTING.zh-CN.md)、[Contributing Guide](../CONTRIBUTING.md)与[开发和验证指南](../docs/zh-CN/development.md) / [Development and Verification Guide](../docs/en/development.md)。
> Before opening a PR, read the [Contributing Guide](../CONTRIBUTING.md), [贡献指南](../CONTRIBUTING.zh-CN.md), and the [Development and Verification Guide](../docs/en/development.md) / [开发和验证指南](../docs/zh-CN/development.md).
> PR 标题和提交信息必须使用 Conventional Commits（`type(scope): subject`），且不得包含 emoji。 / PR titles and commits must use Conventional Commits (`type(scope): subject`) and must not contain emoji.
> 本仓库接受 Bug 修复、兼容性适配、现有能力增强、性能或体验优化和维护类 PR。全新能力、Provider、持久化格式或安全边界变更必须先提 Issue 并获得维护者确认。 / This repository accepts bug fixes, compatibility work, improvements to existing capabilities, performance or UX optimization, and maintenance. New capabilities, Providers, persistence formats, or security-boundary changes require prior maintainer approval in an Issue.
> 外部贡献者的仅文档类 PR 不直接接受；请先提 Issue 讨论。维护者的发布说明与文档维护不受此限制。 / Documentation-only PRs from external contributors are not accepted directly; open an Issue first. Maintainer release notes and documentation maintenance are exempt.

## 摘要 / Summary

Prepare v0.4.1 after the CI-verified merges of #133 and #137. Bump the root package, publish matching English/Chinese release notes, and refresh release links and troubleshooting guidance.

在 #133 与 #137 均通过 CI 并合并后准备 v0.4.1；更新根包版本、中英文发布说明、发布入口与故障排查。

## 关联 Issue 或背景 / Related Issue or Context

Release follow-up for #136 / #133 (settings-store receiver binding) and #112 / #137 (timezone-safe Pack exports). Both fixes are already merged into main; this PR changes only release metadata and documentation. User-authorized maintainer release maintenance.

## 涉及区域 / Affected Areas

<!-- 至少勾选一项。 / Check at least one item. -->

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [x] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

<!-- 至少勾选一项；仅文档类 PR 的限制见文件顶部说明。 / Check at least one item; see the note above for documentation-only PRs. -->

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [ ] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [x] 维护或重构 / Maintenance or refactor
- [ ] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```sh
git fetch origin main
git merge-base --is-ancestor b95c69fea603315f63999c56e870fc9656cd3441 origin/main
git merge-base --is-ancestor 54e89378cf261b181f093490b2a2344ccc0812b0 origin/main
```

Created the isolated release worktree from main at `8fcf2d6` after both merges.

## AI 编码披露 / AI Coding Disclosure

<!-- 必填。勾选且仅勾选一项；模型和工具字段不得留空。 / Required. Check exactly one option; the model and tool fields must not be blank. -->

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

GPT-5 (Codex)

使用的编码 Agent 工具 / Coding Agent tool used:

Codex desktop; generated and self-reviewed in an isolated release worktree.

## 仓库规范检查 / Repository Rules

<!-- 本仓库硬性规范，请逐项确认。 / Confirm every mandatory repository rule. -->

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

The v0.4.0 Sidebar-only workflow, dependency baseline, memory formats, Pack manifests/checksums, permissions, paths and credentials are unchanged. No data migration or deletion is required. Existing Packs remain readable. Rollback to v0.4.0 needs only reinstall/restart, but restores the two fixed bugs. The separate v0.5 architecture remains out of scope.

保留 v0.4.0 Sidebar 工作流、依赖基线、数据格式与权限边界；已有 Pack 仍可读取，不迁移或删除数据。回滚至 v0.4.0 无需转换数据，但两项问题会恢复。

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm install --frozen-lockfile
TZ=America/Los_Angeles pnpm run verify
TZ=UTC pnpm exec vitest run tests/pack.spec.ts --reporter=dot
TZ=America/Los_Angeles pnpm exec vitest run tests/pack.spec.ts --reporter=dot
TZ=Etc/GMT+12 pnpm exec vitest run tests/pack.spec.ts --reporter=dot
TZ=Etc/GMT-14 pnpm exec vitest run tests/pack.spec.ts --reporter=dot
git diff --check
```

Also packed the actual release tarball, verified 160 relative documentation links, and ran `scripts/serve-web-regression.mjs` with test-owned directories, the tarball, and a checksum-verified Mnemon 0.2.5 binary.

结果摘要 / Result summary:

macOS arm64, Node.js 25.1.0, pnpm 11.19.0, npm DSH 0.1.1-rc.2:

- 588 tests passed; one Windows-only test skipped on macOS.
- 107 deterministic build files matched; real Headless activation exposed 35 tools including 5 representative Mnemon tools.
- Package checks passed for 114 files / 1,688,240 unpacked bytes; all 10 public Node-compatible entry imports, publint strict, and attw passed.
- Pack suite: 16/16 in each of four independent timezone processes.
- Both implementation PRs passed Linux Node 22.19/24, Windows Node 24 and DSH alpha source CI before merge.
- Browser smoke: four memory pages, Save to memory open/cancel, and Settings ZIP-generation success with no console errors. The download-completion event was not captured, so downloaded-file persistence was not independently verified; byte-level export validation is covered by the Pack suite.
- Release tarball SHA-256: `a187509347916b3082f3c534732dc155abc09898f265d79ea039cfa08d72c923`.

## 用户可见变更证据 / Local Feature Evidence

<!--
面向用户的功能或行为变更必填。 / Required for user-facing feature or behavior changes.
附截图或短视频，展示 / Attach screenshots or a short video showing:
- 使用的是本 PR 或最新代码 / the PR or latest code is running
- 功能已启用或配置 / the feature is enabled or configured
- 操作成功并出现可见结果 / the action succeeds with a visible result
- 没有泄露凭据、私有记忆或敏感路径 / no credentials, private memory, or sensitive paths are exposed
纯内部改动可填 N/A 并解释。 / For internal-only changes, enter N/A and explain.
-->

证据 / Evidence:

The tested tarball reports `dsh-mnemon 0.4.1` in the real Web status page. The isolated fixture uses Web UI 0.3.6, Mnemon 0.2.5, synthetic data, and local fixed model replies. No personal profiles, private memory, paid model or Provider credentials were used. Settings reported `mnemon-backup-2026-08-30_18-16-44-849.zip` (1.5 KB) generated successfully with the Host running in America/Los_Angeles. Screenshots and raw test logs are retained locally; the bilingual release notes record the verified scope and limitation.

This release PR has no additional UI layout change and does not relabel historical screenshots.

