### PR TITLE
fix(host): support both DSH session projection contracts

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -12,6 +12,16 @@ Install dependencies:
 pnpm install
 ```
 
+## Session projection compatibility
+
+Mnemon's child-local token-usage projection supports both DSH projection contracts: `schema` / `view` in 0.1.0 and `stateSchema` / `wire` in 0.1.1 and the supported alpha. Both entry points share the same wire schema and view function. The internal state and `stateVersion: 1` remain unchanged, so cached state survives upgrades and rollbacks between these hosts.
+
+```sh
+pnpm exec vitest run tests/subagent-token-usage-host.spec.ts tests/subagent-token-usage.spec.ts tests/client-subagent-token-usage.spec.tsx
+```
+
+The Host tests execute the published 0.1.0-rc.8 registry and the active registry against real DSH sessions, covering live snapshots, detached replay, checkpoint restoration, cross-version state, and change notifications. The legacy npm alias is a test-only development dependency; it does not replace the active Host. Source verification links the active registry to the alpha alongside the other DSH packages.
+
 ## DSH 0.1.2-alpha.1 source verification
 
 The alpha is intentionally not published to npm. Keep the registry dependencies and lockfile on the latest published DSH baseline, then overlay only generated `node_modules` links from a built Harness checkout:

--- a/docs/zh-CN/development.md
+++ b/docs/zh-CN/development.md
@@ -12,6 +12,16 @@
 pnpm install
 ```
 
+## Session projection 兼容性
+
+Mnemon 的 child-local token-usage projection 同时支持两代 DSH 契约：0.1.0 的 `schema` / `view`，以及 0.1.1 和受支持 alpha 的 `stateSchema` / `wire`。两组入口共用同一份 wire schema 和 view 函数。内部状态和 `stateVersion: 1` 保持不变，因此在这些 Host 之间升级或回滚时可以继续使用缓存状态。
+
+```sh
+pnpm exec vitest run tests/subagent-token-usage-host.spec.ts tests/subagent-token-usage.spec.ts tests/client-subagent-token-usage.spec.tsx
+```
+
+Host 测试使用真实 DSH Session，分别运行已发布的 0.1.0-rc.8 registry 和当前激活的 registry，覆盖实时快照、离线重放、checkpoint 恢复、跨版本状态和变更通知。旧版 npm alias 仅用于测试，是开发依赖，不会替换实际 Host。源码验证会把当前 registry 与其他 DSH package 一同链接到 alpha。
+
 ## DSH 0.1.2-alpha.1 源码验证
 
 该 alpha 刻意不发布到 npm。`package.json` 与 lockfile 继续保留最新已发布 DSH 基线，只在构建完成的 Harness 检出上覆盖生成的 `node_modules` 直连：

--- a/package.json
+++ b/package.json
@@ -165,6 +165,8 @@
     "@deepseek-ai/dsh-llm": "0.1.1-rc.2",
     "@deepseek-ai/dsh-session": "0.1.1-rc.2",
     "@deepseek-ai/dsh-session-persistence-jsonl": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-session-projection": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-session-projection-legacy": "npm:@deepseek-ai/dsh-session-projection@0.1.0-rc.8",
     "@deepseek-ai/dsh-session-query": "0.1.1-rc.2",
     "@deepseek-ai/dsh-subagent": "0.1.1-rc.2",
     "@deepseek-ai/dsh-subagent-spawn-in-process": "0.1.1-rc.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,12 @@ importers:
       '@deepseek-ai/dsh-session-persistence-jsonl':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-persistence@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(f6e17e22b8cca0a927c37b0e1bc3a46b))(@deepseek-ai/dsh-timeout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.1-rc.2(f6e17e22b8cca0a927c37b0e1bc3a46b))
+      '@deepseek-ai/dsh-session-projection':
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(f6e17e22b8cca0a927c37b0e1bc3a46b))
+      '@deepseek-ai/dsh-session-projection-legacy':
+        specifier: npm:@deepseek-ai/dsh-session-projection@0.1.0-rc.8
+        version: '@deepseek-ai/dsh-session-projection@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(f6e17e22b8cca0a927c37b0e1bc3a46b))'
       '@deepseek-ai/dsh-session-query':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(590be13e5a2162e67470573dbcdbb0bf)
@@ -1561,6 +1567,13 @@ packages:
       '@deepseek-ai/dsh-session-persistence': ^0.1.1-rc.2
       '@deepseek-ai/dsh-session-projection': ^0.1.1-rc.2
       '@deepseek-ai/dsh-storage-domain': ^0.1.1-rc.2
+
+  '@deepseek-ai/dsh-session-projection@0.1.0-rc.8':
+    resolution: {integrity: sha512-q00B+rl7WAuK0Bgh93SY2+ZpqaH2kJhfJ9n6Jg6R/m4plnH0Ip4oCAHl6u8rBzDgb1mniQGEQDz/7BN5Q3It8Q==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.8
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.8
 
   '@deepseek-ai/dsh-session-projection@0.1.1-rc.2':
     resolution: {integrity: sha512-SNaOrjRS4RMXocna6uL33TeS/uhcQ7jDJtJZ1HyDPL06mXUdAgje2MVt8OZCh6dH95xIiqpQQm+KjzeiQnhYSQ==}
@@ -6835,6 +6848,13 @@ snapshots:
       '@deepseek-ai/dsh-session-projection': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(f6e17e22b8cca0a927c37b0e1bc3a46b))
       '@deepseek-ai/dsh-storage-domain': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-storage@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/schemastery': 3.18.1
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-session-projection@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(f6e17e22b8cca0a927c37b0e1bc3a46b))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(f6e17e22b8cca0a927c37b0e1bc3a46b)
       zod: 4.4.3
 
   '@deepseek-ai/dsh-session-projection@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(f6e17e22b8cca0a927c37b0e1bc3a46b))':

--- a/scripts/link-dsh-source.mjs
+++ b/scripts/link-dsh-source.mjs
@@ -27,6 +27,7 @@ const links = new Map([
   ['@deepseek-ai/dsh-llm', 'packages/llm/llm'],
   ['@deepseek-ai/dsh-session', 'packages/core/session'],
   ['@deepseek-ai/dsh-session-persistence-jsonl', 'packages/session/session-persistence-jsonl'],
+  ['@deepseek-ai/dsh-session-projection', 'packages/session/session-projection'],
   ['@deepseek-ai/dsh-session-query', 'packages/session-query/session-query'],
   ['@deepseek-ai/dsh-subagent', 'packages/subagent/subagent'],
   ['@deepseek-ai/dsh-subagent-spawn-in-process', 'packages/subagent/subagent-spawn-in-process'],

--- a/src/subagent-token-usage.ts
+++ b/src/subagent-token-usage.ts
@@ -8,7 +8,7 @@
  * and resets at every durable descriptor.
  */
 import { z } from 'zod'
-import type { HostContextShape, HostSessionEvent } from './contracts.ts'
+import type { HostContextShape } from './contracts.ts'
 
 export interface MnemonTokenUsageProjection {
   uncachedInputTokens: number
@@ -28,6 +28,11 @@ export interface MnemonSubagentTokenUsageState {
 }
 
 type UsageSample = NonNullable<MnemonSubagentTokenUsageState['last']>
+
+interface ProjectionEvent {
+  type: string
+  data: unknown
+}
 
 interface ProjectionRegistry {
   register(definition: typeof mnemonSubagentTokenUsageProjectionDefinition): unknown
@@ -53,6 +58,12 @@ const tokenUsageStateSchema: z.ZodType<MnemonSubagentTokenUsageState> = z.object
     buckets: tokenUsageSchema,
   }).strict().nullable(),
 }).strict()
+
+const tokenUsageWire = {
+  viewSchema: tokenUsageSchema.nullable(),
+  view: (state: MnemonSubagentTokenUsageState): MnemonTokenUsageProjection | null =>
+    state.descriptorSeen ? state.totals : null,
+}
 
 const emptyTokenUsage = (): MnemonTokenUsageProjection => ({
   uncachedInputTokens: 0,
@@ -88,19 +99,21 @@ function usageBuckets(value: unknown): MnemonTokenUsageProjection | undefined {
   }
 }
 
-function usageSample(event: HostSessionEvent): UsageSample | undefined {
-  const turn = nonnegativeInteger(event.data.turn)
-  const step = nonnegativeInteger(event.data.step)
+function usageSample(event: ProjectionEvent): UsageSample | undefined {
+  if (typeof event.data !== 'object' || event.data === null || Array.isArray(event.data)) return undefined
+  const data = event.data as Record<string, unknown>
+  const turn = nonnegativeInteger(data.turn)
+  const step = nonnegativeInteger(data.step)
   if (turn === undefined || step === undefined) return undefined
   let rawUsage: unknown
   if (event.type === 'assistant/chunk') {
-    const chunk = event.data.chunk
+    const chunk = data.chunk
     if (typeof chunk !== 'object' || chunk === null || Array.isArray(chunk)) return undefined
     const record = chunk as Record<string, unknown>
     if (record.type !== 'usage') return undefined
     rawUsage = record.usage
   } else if (event.type === 'assistant/message') {
-    rawUsage = event.data.usage
+    rawUsage = data.usage
   } else {
     return undefined
   }
@@ -140,12 +153,14 @@ export const mnemonSubagentTokenUsageProjectionDefinition = {
   key: MNEMON_SUBAGENT_TOKEN_USAGE_KEY,
   stateVersion: 1,
   stateSchema: tokenUsageStateSchema,
+  // DSH 0.1.0 consumes schema/view; 0.1.1+ consumes stateSchema/wire.
+  schema: tokenUsageWire.viewSchema,
   init: (): MnemonSubagentTokenUsageState => ({
     descriptorSeen: false,
     totals: emptyTokenUsage(),
     last: null,
   }),
-  apply: (state: MnemonSubagentTokenUsageState, event: HostSessionEvent): MnemonSubagentTokenUsageState => {
+  apply: (state: MnemonSubagentTokenUsageState, event: ProjectionEvent): MnemonSubagentTokenUsageState => {
     if (event.type === 'subagent/descriptor') {
       return { descriptorSeen: true, totals: emptyTokenUsage(), last: null }
     }
@@ -164,11 +179,8 @@ export const mnemonSubagentTokenUsageProjectionDefinition = {
       last: sample,
     }
   },
-  wire: {
-    viewSchema: tokenUsageSchema.nullable(),
-    view: (state: MnemonSubagentTokenUsageState): MnemonTokenUsageProjection | null =>
-      state.descriptorSeen ? state.totals : null,
-  },
+  view: tokenUsageWire.view,
+  wire: tokenUsageWire,
 } as const
 
 /** Register lazily when the optional DSH projection service is present. */

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -91,12 +91,17 @@ function context(options: { connection?: boolean; workspaceRegistry?: boolean } 
 
 describe('dsh-mnemon plugin composition', () => {
   it('keeps the installed DSH prerelease family coherent', () => {
+    const legacyProjection = '@deepseek-ai/dsh-session-projection-legacy'
     const directDshDependencies = Object.entries(manifest.devDependencies)
       .filter(([name]) => name === '@deepseek-ai/dsh' || name.startsWith('@deepseek-ai/dsh-'))
-    const lockedDshVersions = [...lockfile.matchAll(/@deepseek-ai\/dsh(?:-[a-z0-9-]+)?@(\d+\.\d+\.\d+-rc\.\d+)/g)]
-      .map(match => match[1])
+      .filter(([name]) => name !== legacyProjection)
+    const lockedDshVersions = [...lockfile.matchAll(/(@deepseek-ai\/dsh(?:-[a-z0-9-]+)?)@(\d+\.\d+\.\d+-rc\.\d+)/g)]
+      // Only this aliased regression fixture may use the older host contract.
+      .filter(([, name, version]) => name !== '@deepseek-ai/dsh-session-projection' || version !== '0.1.0-rc.8')
+      .map(match => match[2])
 
-    expect(directDshDependencies).toHaveLength(19)
+    expect(manifest.devDependencies[legacyProjection]).toBe('npm:@deepseek-ai/dsh-session-projection@0.1.0-rc.8')
+    expect(directDshDependencies).toHaveLength(20)
     expect(new Set(directDshDependencies.map(([, version]) => version))).toEqual(new Set(['0.1.1-rc.2']))
     expect(manifest.engines.node).toBe('>=20')
     expect(manifest.peerDependencies['@deepseek-ai/dsh-client-ui-primitives']).toContain('^0.1.1-rc.1')

--- a/tests/subagent-token-usage-host.spec.ts
+++ b/tests/subagent-token-usage-host.spec.ts
@@ -1,0 +1,186 @@
+import { Context } from '@deepseek-ai/cordis'
+import SessionStore, { SessionId, type Session } from '@deepseek-ai/dsh-session'
+import SessionProjectionRegistry, { type ProjectionDefinition } from '@deepseek-ai/dsh-session-projection'
+import LegacySessionProjectionRegistry, { type ProjectionDefinition as LegacyProjectionDefinition } from '@deepseek-ai/dsh-session-projection-legacy'
+import { snapshotSubagentDescriptor } from '@deepseek-ai/dsh-subagent'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  MNEMON_SUBAGENT_TOKEN_USAGE_KEY as key,
+  mnemonSubagentTokenUsageProjectionDefinition as projection,
+  type MnemonSubagentTokenUsageState,
+  type MnemonTokenUsageProjection,
+} from '../src/subagent-token-usage.ts'
+
+declare module '@deepseek-ai/dsh-session-projection' {
+  interface SessionProjectionMap {
+    mnemonSubagentTokenUsage: MnemonTokenUsageProjection | null
+  }
+  interface SessionProjectionStateMap {
+    mnemonSubagentTokenUsage: MnemonSubagentTokenUsageState
+  }
+}
+
+declare module '@deepseek-ai/dsh-session-projection-legacy' {
+  interface SessionProjectionMap {
+    mnemonSubagentTokenUsage: MnemonTokenUsageProjection | null
+  }
+}
+
+// Check the published contracts as well as their actual runtime consumers.
+const currentDefinition = projection satisfies ProjectionDefinition<typeof key, MnemonSubagentTokenUsageState>
+const legacyDefinition = projection satisfies LegacyProjectionDefinition<typeof key, MnemonSubagentTokenUsageState>
+
+const generations = [
+  {
+    name: 'DSH 0.1.0-rc.8 (schema/view)',
+    create(ctx: Context) {
+      const registry = new LegacySessionProjectionRegistry(ctx)
+      registry.register(legacyDefinition)
+      return registry
+    },
+  },
+  {
+    name: 'active DSH (stateSchema/wire)',
+    create(ctx: Context) {
+      const registry = new SessionProjectionRegistry(ctx)
+      registry.register(currentDefinition)
+      return registry
+    },
+  },
+] as const
+
+const contexts: Context[] = []
+
+afterEach(async () => {
+  for (const ctx of contexts.splice(0).reverse()) await ctx.fiber.dispose()
+})
+
+function harness(generation: typeof generations[number]) {
+  const ctx = new Context()
+  contexts.push(ctx)
+  const sessions = new SessionStore(ctx)
+  const registry = generation.create(ctx)
+  const session = sessions.create(SessionId('projection-fixture'))
+  return { ctx, registry, session }
+}
+
+function descriptor(session: Session) {
+  return session.append('subagent/descriptor', snapshotSubagentDescriptor({
+    mode: 'one-shot', provider: 'fixture', label: 'Projection regression',
+  }))
+}
+
+function usage(session: Session, step: number, inputTokens: number, outputTokens: number) {
+  return session.append('assistant/chunk', {
+    turn: 1,
+    step,
+    chunk: {
+      type: 'usage',
+      usage: { inputTokens, outputTokens, cacheReadTokens: 3, cacheWriteTokens: 4 },
+    },
+  })
+}
+
+const expectedUsage = {
+  uncachedInputTokens: 19,
+  outputTokens: 6,
+  cacheReadTokens: 6,
+  cacheWriteTokens: 8,
+}
+
+describe.each(generations)('Mnemon projection with $name', (generation) => {
+  it('serves empty and ordinary session history without child usage', () => {
+    const { registry, session } = harness(generation)
+    expect(registry.snapshot(session)).toEqual({ asOfSeq: -1, values: { [key]: null } })
+
+    usage(session, 0, 1_000, 100)
+    expect(registry.snapshot(session)).toEqual({ asOfSeq: 0, values: { [key]: null } })
+    expect(registry.restore({}, session.events, 0).snapshot).toEqual(registry.snapshot(session))
+  })
+
+  it('serves attached and detached child history without counting inherited usage', () => {
+    const { registry, session } = harness(generation)
+    usage(session, 0, 1_000, 100)
+    descriptor(session)
+    usage(session, 0, 100, 10)
+    descriptor(session)
+    usage(session, 0, 10, 2)
+    usage(session, 0, 12, 5)
+    usage(session, 1, 7, 1)
+
+    const expected = { asOfSeq: session.seq - 1, values: { [key]: expectedUsage } }
+    expect(registry.snapshot(session)).toEqual(expected)
+    expect(registry.restore({}, session.events, 0).snapshot).toEqual(expected)
+  })
+
+  it('restores JSON checkpoints and replaces a same-step sample after restart', () => {
+    const { registry, session } = harness(generation)
+    descriptor(session)
+    usage(session, 0, 10, 2)
+    const checkpoint = JSON.parse(JSON.stringify(registry.checkpoint(session)))
+    expect(registry.viewCheckpoint(checkpoint)).toEqual({ [key]: {
+      uncachedInputTokens: 10, outputTokens: 2, cacheReadTokens: 3, cacheWriteTokens: 4,
+    } })
+
+    usage(session, 0, 12, 5)
+    usage(session, 1, 7, 1)
+    const restarted = harness(generation).registry
+    const floor = restarted.restoreFloor(checkpoint)!
+    const restored = restarted.restore(checkpoint, session.events.slice(floor), floor)
+
+    expect(restored.snapshot).toEqual({ asOfSeq: session.seq - 1, values: { [key]: expectedUsage } })
+    expect(restored.checkpoint).toEqual(registry.checkpoint(session))
+    expect(restored.checkpoint[key]?.ver).toBe(1)
+    expect(restored.checkpoint[key]?.val).toMatchObject({
+      descriptorSeen: true, totals: expectedUsage, last: { turn: 1, step: 1 },
+    })
+    expect(registry.viewCheckpoint(checkpoint)[key]?.uncachedInputTokens).toBe(10)
+  })
+
+  it('emits validated child-local changes without duplicate streaming samples', () => {
+    const { registry, session } = harness(generation)
+    const changed = vi.fn()
+    registry.onChanged(changed)
+    usage(session, 0, 1_000, 100)
+    expect(changed).not.toHaveBeenCalled()
+
+    const start = descriptor(session)
+    const sample = usage(session, 0, 10, 2)
+    usage(session, 0, 10, 2)
+    expect(changed.mock.calls.map(([, changedKey, value, seq]) => ({ key: changedKey, value, seq }))).toEqual([
+      { key, value: { uncachedInputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }, seq: start.seq },
+      { key, value: { uncachedInputTokens: 10, outputTokens: 2, cacheReadTokens: 3, cacheWriteTokens: 4 }, seq: sample.seq },
+    ])
+  })
+
+  it('refolds the complete log when a checkpoint version is obsolete', () => {
+    const { registry, session } = harness(generation)
+    descriptor(session)
+    usage(session, 0, 12, 5)
+    usage(session, 1, 7, 1)
+    const checkpoint = { [key]: { ver: 0, seq: session.seq - 1, val: null } }
+
+    expect(registry.restoreFloor(checkpoint)).toBe(0)
+    expect(registry.viewCheckpoint(checkpoint)).toEqual({})
+    expect(registry.restore(checkpoint, session.events, 0).snapshot.values).toEqual({ [key]: expectedUsage })
+  })
+})
+
+describe('Mnemon projection checkpoints across DSH generations', () => {
+  for (const [source, target] of [[generations[0], generations[1]], [generations[1], generations[0]]] as const) {
+    it(`preserves state from ${source.name} to ${target.name}`, () => {
+      const { registry, session } = harness(source)
+      descriptor(session)
+      usage(session, 0, 10, 2)
+      const checkpoint = JSON.parse(JSON.stringify(registry.checkpoint(session)))
+      usage(session, 0, 12, 5)
+      usage(session, 1, 7, 1)
+
+      const targetRegistry = harness(target).registry
+      const floor = targetRegistry.restoreFloor(checkpoint)!
+      const restored = targetRegistry.restore(checkpoint, session.events.slice(floor), floor)
+      expect(restored.snapshot).toEqual({ asOfSeq: session.seq - 1, values: { [key]: expectedUsage } })
+      expect(restored.checkpoint).toEqual(registry.checkpoint(session))
+    })
+  }
+})

--- a/tests/subagent-token-usage-host.spec.ts
+++ b/tests/subagent-token-usage-host.spec.ts
@@ -1,6 +1,10 @@
 import { Context } from '@deepseek-ai/cordis'
 import SessionStore, { SessionId, type Session } from '@deepseek-ai/dsh-session'
-import SessionProjectionRegistry, { type ProjectionDefinition } from '@deepseek-ai/dsh-session-projection'
+import SessionProjectionRegistry, {
+  type ProjectionCheckpoint,
+  type ProjectionDefinition,
+  type ProjectionSnapshot,
+} from '@deepseek-ai/dsh-session-projection'
 import LegacySessionProjectionRegistry, { type ProjectionDefinition as LegacyProjectionDefinition } from '@deepseek-ai/dsh-session-projection-legacy'
 import { snapshotSubagentDescriptor } from '@deepseek-ai/dsh-subagent'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -30,11 +34,34 @@ declare module '@deepseek-ai/dsh-session-projection-legacy' {
 const currentDefinition = projection satisfies ProjectionDefinition<typeof key, MnemonSubagentTokenUsageState>
 const legacyDefinition = projection satisfies LegacyProjectionDefinition<typeof key, MnemonSubagentTokenUsageState>
 
+// The source overlay and npm fixture carry distinct nominal Context/Session
+// types. These registry operations only consume their shared public surface.
+interface TestRegistry {
+  register(definition: typeof projection): () => void
+  snapshot(session: Session): ProjectionSnapshot
+  checkpoint(session: Session): ProjectionCheckpoint
+  restoreFloor(checkpoint: ProjectionCheckpoint): number | undefined
+  viewCheckpoint(checkpoint: ProjectionCheckpoint): ProjectionSnapshot['values']
+  restore(
+    checkpoint: ProjectionCheckpoint,
+    events: Session['events'],
+    baseSeq: number,
+    header: Session['header'],
+  ): { snapshot: ProjectionSnapshot; checkpoint: ProjectionCheckpoint }
+  onChanged(listener: (session: Session, key: string, value: unknown, seq: number) => void): () => void
+}
+
+type TestRegistryConstructor = new (ctx: Context) => TestRegistry
+
+// Alpha needs restore's trailing header; the released implementations ignore it.
+const LegacyRegistry = LegacySessionProjectionRegistry as unknown as TestRegistryConstructor
+const ActiveRegistry = SessionProjectionRegistry as unknown as TestRegistryConstructor
+
 const generations = [
   {
     name: 'DSH 0.1.0-rc.8 (schema/view)',
     create(ctx: Context) {
-      const registry = new LegacySessionProjectionRegistry(ctx)
+      const registry = new LegacyRegistry(ctx)
       registry.register(legacyDefinition)
       return registry
     },
@@ -42,7 +69,7 @@ const generations = [
   {
     name: 'active DSH (stateSchema/wire)',
     create(ctx: Context) {
-      const registry = new SessionProjectionRegistry(ctx)
+      const registry = new ActiveRegistry(ctx)
       registry.register(currentDefinition)
       return registry
     },
@@ -95,7 +122,7 @@ describe.each(generations)('Mnemon projection with $name', (generation) => {
 
     usage(session, 0, 1_000, 100)
     expect(registry.snapshot(session)).toEqual({ asOfSeq: 0, values: { [key]: null } })
-    expect(registry.restore({}, session.events, 0).snapshot).toEqual(registry.snapshot(session))
+    expect(registry.restore({}, session.events, 0, session.header).snapshot).toEqual(registry.snapshot(session))
   })
 
   it('serves attached and detached child history without counting inherited usage', () => {
@@ -110,7 +137,7 @@ describe.each(generations)('Mnemon projection with $name', (generation) => {
 
     const expected = { asOfSeq: session.seq - 1, values: { [key]: expectedUsage } }
     expect(registry.snapshot(session)).toEqual(expected)
-    expect(registry.restore({}, session.events, 0).snapshot).toEqual(expected)
+    expect(registry.restore({}, session.events, 0, session.header).snapshot).toEqual(expected)
   })
 
   it('restores JSON checkpoints and replaces a same-step sample after restart', () => {
@@ -126,7 +153,7 @@ describe.each(generations)('Mnemon projection with $name', (generation) => {
     usage(session, 1, 7, 1)
     const restarted = harness(generation).registry
     const floor = restarted.restoreFloor(checkpoint)!
-    const restored = restarted.restore(checkpoint, session.events.slice(floor), floor)
+    const restored = restarted.restore(checkpoint, session.events.slice(floor), floor, session.header)
 
     expect(restored.snapshot).toEqual({ asOfSeq: session.seq - 1, values: { [key]: expectedUsage } })
     expect(restored.checkpoint).toEqual(registry.checkpoint(session))
@@ -162,7 +189,7 @@ describe.each(generations)('Mnemon projection with $name', (generation) => {
 
     expect(registry.restoreFloor(checkpoint)).toBe(0)
     expect(registry.viewCheckpoint(checkpoint)).toEqual({})
-    expect(registry.restore(checkpoint, session.events, 0).snapshot.values).toEqual({ [key]: expectedUsage })
+    expect(registry.restore(checkpoint, session.events, 0, session.header).snapshot.values).toEqual({ [key]: expectedUsage })
   })
 })
 
@@ -178,7 +205,7 @@ describe('Mnemon projection checkpoints across DSH generations', () => {
 
       const targetRegistry = harness(target).registry
       const floor = targetRegistry.restoreFloor(checkpoint)!
-      const restored = targetRegistry.restore(checkpoint, session.events.slice(floor), floor)
+      const restored = targetRegistry.restore(checkpoint, session.events.slice(floor), floor, session.header)
       expect(restored.snapshot).toEqual({ asOfSeq: session.seq - 1, values: { [key]: expectedUsage } })
       expect(restored.checkpoint).toEqual(registry.checkpoint(session))
     })

--- a/tests/subagent-token-usage.spec.ts
+++ b/tests/subagent-token-usage.spec.ts
@@ -68,4 +68,12 @@ describe('Mnemon subagent token-usage projection', () => {
     expect(inject).toHaveBeenCalledWith(['sessionProjections'], expect.any(Function))
     expect(register).toHaveBeenCalledWith(projection)
   })
+
+  it.each([null, undefined, [], 'invalid', { turn: 1, step: 0, chunk: null }])(
+    'ignores malformed event data without changing child usage: %j',
+    (data) => {
+      const state = projection.apply(projection.init(), event('subagent/descriptor'))
+      expect(projection.apply(state, { type: 'assistant/chunk', data })).toBe(state)
+    },
+  )
 })


### PR DESCRIPTION
> 提交 PR 前请阅读[贡献指南](../CONTRIBUTING.zh-CN.md)、[Contributing Guide](../CONTRIBUTING.md)与[开发和验证指南](../docs/zh-CN/development.md) / [Development and Verification Guide](../docs/en/development.md)。
> Before opening a PR, read the [Contributing Guide](../CONTRIBUTING.md), [贡献指南](../CONTRIBUTING.zh-CN.md), and the [Development and Verification Guide](../docs/en/development.md) / [开发和验证指南](../docs/zh-CN/development.md).
> PR 标题和提交信息必须使用 Conventional Commits（`type(scope): subject`），且不得包含 emoji。 / PR titles and commits must use Conventional Commits (`type(scope): subject`) and must not contain emoji.
> 本仓库接受 Bug 修复、兼容性适配、现有能力增强、性能或体验优化和维护类 PR。全新能力、Provider、持久化格式或安全边界变更必须先提 Issue 并获得维护者确认。 / This repository accepts bug fixes, compatibility work, improvements to existing capabilities, performance or UX optimization, and maintenance. New capabilities, Providers, persistence formats, or security-boundary changes require prior maintainer approval in an Issue.
> 外部贡献者的仅文档类 PR 不直接接受；请先提 Issue 讨论。维护者的发布说明与文档维护不受此限制。 / Documentation-only PRs from external contributors are not accepted directly; open an Issue first. Maintainer release notes and documentation maintenance are exempt.

## 摘要 / Summary

修复旧版 DSH 读取会话历史尾页时因 Mnemon projection 缺少 `schema/view` 而整体失败的问题。共享同一份 schema/view，同时保留新版 `stateSchema/wire`，不改变 token 去重和缓存状态格式。

Restore session-history tail loading on legacy DSH by exposing both projection contracts from one shared view implementation. Keep current hosts, child-local accounting, and persisted checkpoints compatible.

## 关联 Issue 或背景 / Related Issue or Context

Closes #147.

Confirmed against the published `@deepseek-ai/dsh-session-projection@0.1.0-rc.8`: the original code throws `Cannot read properties of undefined (reading 'parse')` in both `snapshot()` and `restore()`. The pinned 0.1.1-rc.2 host uses the newer interface, so replacing its fields would introduce a regression.

## 涉及区域 / Affected Areas

<!-- 至少勾选一项。 / Check at least one item. -->

- [x] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [x] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [ ] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

<!-- 至少勾选一项；仅文档类 PR 的限制见文件顶部说明。 / Check at least one item; see the note above for documentation-only PRs. -->

- [x] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [x] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [x] 兼容性适配 / Compatibility change
- [ ] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```sh
git fetch origin main
git rebase origin/main
```

Base: `aa446cf598ee5928c787d340eb314d3f1803eb4c`; developed in an independent workspace/worktree on `codex/fix-dsh-projection-147`.

## AI 编码披露 / AI Coding Disclosure

<!-- 必填。勾选且仅勾选一项；模型和工具字段不得留空。 / Required. Check exactly one option; the model and tool fields must not be blank. -->

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

GPT-5 (Codex)

使用的编码 Agent 工具 / Coding Agent tool used:

Codex desktop

## 仓库规范检查 / Repository Rules

<!-- 本仓库硬性规范，请逐项确认。 / Confirm every mandatory repository rule. -->

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

同时提供 DSH 0.1.0 的顶层 `schema/view` 与 0.1.1+ 的 `stateSchema/wire`，不探测版本、不替换宿主、不屏蔽投影异常。`stateVersion: 1`、内部缓存结构和 wire DTO 均保持不变；跨版本 checkpoint 恢复和同一步 token 替换已验证。事件输入按 `unknown` 收窄，兼容正式 DSH 事件类型并安全忽略无效 payload。

The old registry is pinned under a development-only npm alias for regression tests; the active host remains 0.1.1-rc.2 (or the existing alpha source overlay). No production dependency, Provider, credential, configuration, storage path, RPC permission, or existing user data changes. No migration is required. Rolling back the patch preserves data but restores the old-host history bug. Generated declarations include both contracts; no generated `lib/` files are committed.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm install --frozen-lockfile
pnpm exec vitest run tests/subagent-token-usage-host.spec.ts tests/subagent-token-usage.spec.ts tests/client-subagent-token-usage.spec.tsx
pnpm run verify
DSH_SOURCE_ROOT=../deepseek-harness-alpha pnpm run dsh:link-source
pnpm_config_verify_deps_before_run=false pnpm run verify
pnpm_config_verify_deps_before_run=false pnpm run dsh:restore-registry
node ../artifacts/run-history-smoke.mjs
```

结果摘要 / Result summary:

最终完整验证通过：macOS arm64、Node.js 24.18.0、pnpm 10.13.1。

- Regression before the fix: 6 failed / 6 passed in the new real-registry suite, including the exact reported TypeError. After the fix: all 12 pass.
- Focused projection/client coverage: 24 tests passed.
- Full suite: 647 tests passed; the existing Windows-only smoke test was skipped on macOS.
- Full verification also passed against a locally built, unmodified `dsh-v0.1.2-alpha.1` checkout: the same 647 passing tests, deterministic build, Headless activation/restart, and package checks. The fixture supplies alpha's trailing session header and uses the shared public registry operations across nominally distinct Cordis/Session types; both published projection definitions remain compile-time checked.
- Deterministic double build: 108 files identical.
- Real isolated Headless activation and restart: 35 tools, including 5 representative Mnemon tools; settings migration/idempotence passed.
- Package validation: 115 files; all 10 Node-compatible public entries imported; publint and Are the Types Wrong passed.
- HTTP comparison: all 32 request expectations passed across old/current ApiProxy and registry implementations, before/after code, ordinary/child sessions, and attached/disk-restored histories.
- A clean pnpm 10 install resolved an initial local mixed-pnpm profile-loader failure; the final `pnpm run verify` exited 0.

## 用户可见变更证据 / Local Feature Evidence

<!--
面向用户的功能或行为变更必填。 / Required for user-facing feature or behavior changes.
附截图或短视频，展示 / Attach screenshots or a short video showing:
- 使用的是本 PR 或最新代码 / the PR or latest code is running
- 功能已启用或配置 / the feature is enabled or configured
- 操作成功并出现可见结果 / the action succeeds with a visible result
- 没有泄露凭据、私有记忆或敏感路径 / no credentials, private memory, or sensitive paths are exposed
纯内部改动可填 N/A 并解释。 / For internal-only changes, enter N/A and explain.
-->

证据 / Evidence:


Host-only compatibility change; the evidence is redacted command/HTTP output rather than a UI screenshot. No DSH source was modified. The local throwaway HTTP harness used published ApiProxy/registry 0.1.0-rc.8 and 0.1.1-rc.2 code with real DSH Session, JSONL persistence, query, and optional-injection services. No external LLM or user data was used.

```text
POST /api/session.history, fixture-child, detached

Before (DSH 0.1.0-rc.8):
  beforeSeq=1 -> ok=true
  tail page   -> ok=false, code=internal
  history unavailable for session "fixture-child":
  TypeError: Cannot read properties of undefined (reading 'parse')

After (same request and host implementation):
  beforeSeq=1 -> ok=true
  tail page   -> ok=true
  projections.asOfSeq=3
  mnemonSubagentTokenUsage={uncachedInputTokens:12, outputTokens:5,
                           cacheReadTokens:3, cacheWriteTokens:4}
  sessionListMetadata={blank:true, lastPromptAt:null}

Old host: ordinary/child, attached/detached histories all recovered.
Current host: all before/after cases retained their expected results.
PASS: 32 real HTTP request expectations.

pnpm run verify (registry + alpha source overlay) -> exit 0 in both runs
Test Files: 54 passed, 1 skipped
Tests: 647 passed, 1 skipped
Verified deterministic output for 108 files.
Verified Headless profile activation and idempotent restart.
Verified package contents and public entries; publint/attw passed.
```
