### PR TITLE
chore(release): prepare v0.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 <p align="center">
   <a href="./docs/en/capabilities.md"><strong>Explore the capability map</strong></a> ·
   <a href="./docs/en/getting-started.md">Start in five minutes</a> ·
-  <a href="./docs/en/releases/v0.4.3.md">Read the v0.4.3 notes</a> ·
+  <a href="./docs/en/releases/v0.4.4.md">Read the v0.4.4 notes</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">Watch the widescreen demo</a>
 </p>
 
@@ -41,6 +41,8 @@ v0.4.1 fixes Memory System and Save to memory rendering with this-dependent DSH 
 v0.4.2 restores optional `displayMode: builtin` as a conversation placement for the same Sidebar-first UI. Legacy `buildin` is accepted and automatically saved as `builtin`; memory data is unchanged. See the [release notes](./docs/en/releases/v0.4.2.md) and [entry placement and scope mapping](./docs/en/configuration.md#entry-placement-displaymode-and-tabenabled).
 
 v0.4.3 aligns the collapsed Memory System icon with neighboring sidebar controls while preserving the expanded appearance. See the [patch release notes](./docs/en/releases/v0.4.3.md).
+
+v0.4.4 fixes session history failures on older DSH hosts by supporting both session projection contracts. Newer hosts and existing projection checkpoints remain compatible. See the [patch release notes](./docs/en/releases/v0.4.4.md).
 
 ## Understand the scope in 30 seconds
 
@@ -216,7 +218,7 @@ See [Operations, security, and troubleshooting](./docs/en/operations.md) for bac
 | Back up, update, or troubleshoot | [Operations](./docs/en/operations.md) |
 | Integrate tools, commands, or RPC | [Interface reference](./docs/en/interfaces.md) |
 | Build a Layer, Adapter, Strategy, Guard, or MemorySource extension | [Extension guide](./docs/en/extensions.md) |
-| Review the release | [v0.4.3 release notes](./docs/en/releases/v0.4.3.md) |
+| Review the release | [v0.4.4 release notes](./docs/en/releases/v0.4.4.md) |
 
 See the [documentation hub](./docs/en/README.md) for the full map.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
 <p align="center">
   <a href="./docs/zh-CN/capabilities.md"><strong>先看能力地图</strong></a> ·
   <a href="./docs/zh-CN/getting-started.md">5 分钟开始</a> ·
-  <a href="./docs/zh-CN/releases/v0.4.3.md">v0.4.3 升级说明</a> ·
+  <a href="./docs/zh-CN/releases/v0.4.4.md">v0.4.4 升级说明</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">观看宽屏实机演示</a>
 </p>
 
@@ -41,6 +41,8 @@ v0.4.1 修复记忆系统和存入记忆在依赖 `this` 的 DSH settings store 
 v0.4.2 恢复可选 `displayMode: builtin`，只将 Sidebar 优先迭代的共用界面放入会话。旧 `buildin` 仍可识别，并自动保存为 `builtin`，不改变记忆数据。详见[发布说明](./docs/zh-CN/releases/v0.4.2.md)与[入口位置与范围映射](./docs/zh-CN/configuration.md#入口位置displaymode-与-tabenabled)。
 
 v0.4.3 让折叠后的记忆系统图标与侧栏相邻控件对齐，并保留原有展开样式。详见[补丁发布说明](./docs/zh-CN/releases/v0.4.3.md)。
+
+v0.4.4 同时支持新旧 DSH 会话投影接口，修复旧版宿主读取会话历史失败的问题，并保持新版宿主和已有投影检查点兼容。详见[补丁发布说明](./docs/zh-CN/releases/v0.4.4.md)。
 
 ## 30 秒理解能力边界
 
@@ -216,7 +218,7 @@ dsh plugin --profile headless add "link:/absolute/path/to/dsh-mnemon"
 | 备份、更新或排障 | [运维指南](./docs/zh-CN/operations.md) |
 | 接入工具、命令或 RPC | [接口参考](./docs/zh-CN/interfaces.md) |
 | 开发 Layer、Adapter、Strategy、Guard 或 MemorySource 扩展 | [扩展开发指南](./docs/zh-CN/extensions.md) |
-| 查看本次升级 | [v0.4.3 发布说明](./docs/zh-CN/releases/v0.4.3.md) |
+| 查看本次升级 | [v0.4.4 发布说明](./docs/zh-CN/releases/v0.4.4.md) |
 
 完整目录见[文档中心](./docs/zh-CN/README.md)。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,9 +3,9 @@
 - [English](./en/README.md)
 - [简体中文](./zh-CN/README.md)
 
-Start with [Getting Started](./en/getting-started.md). Existing users should read the [v0.4.3 release notes](./en/releases/v0.4.3.md); extension authors should continue with [Architecture](./en/architecture.md) and [Building Memory Extensions](./en/extensions.md).
+Start with [Getting Started](./en/getting-started.md). Existing users should read the [v0.4.4 release notes](./en/releases/v0.4.4.md); extension authors should continue with [Architecture](./en/architecture.md) and [Building Memory Extensions](./en/extensions.md).
 
-第一次使用请从[快速开始](./zh-CN/getting-started.md)进入。已有用户先看 [v0.4.3 发布说明](./zh-CN/releases/v0.4.3.md)；扩展作者继续阅读[架构设计](./zh-CN/architecture.md)与[记忆扩展开发](./zh-CN/extensions.md)。
+第一次使用请从[快速开始](./zh-CN/getting-started.md)进入。已有用户先看 [v0.4.4 发布说明](./zh-CN/releases/v0.4.4.md)；扩展作者继续阅读[架构设计](./zh-CN/architecture.md)与[记忆扩展开发](./zh-CN/extensions.md)。
 
 The root README stays focused on orientation and quick start. Architecture, data model, lifecycle, interfaces, operations, and development details live here.
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -30,7 +30,7 @@ This hub is organized by what you need to accomplish. New users should follow Ge
 | Understand Host, workers, control plane, and data plane | [Architecture](./architecture.md) |
 | Build a Layer, Adapter, Strategy, Guard, or MemorySource plugin | [Building Memory Extensions](./extensions.md) |
 | Modify code, screenshots, tests, or releases | [Development and verification](./development.md) |
-| Upgrade from the previous release | [v0.4.3 release notes](./releases/v0.4.3.md) |
+| Upgrade from the previous release | [v0.4.4 release notes](./releases/v0.4.4.md) |
 | See planned work | [Roadmap](./roadmap.md) |
 
 ## Core terms

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -17,7 +17,7 @@ You need:
 
 Regular semantic work prefers a provider named `spawn` with `toolFilter`, `persona`, and `depthLimit`. Mnemon supplies a schema-validated, one-run result tool instead of depending on the Provider's `outputSchema` path. Optional score-based background review additionally requires a provider named `fork` with `inheritsParentContext=true`. Missing `fork` does not block deterministic pages or regular manual actions.
 
-This workflow uses dsh-mnemon v0.4.3, DSH 0.1.1-rc.2, and Mnemon 0.2.3 as the recommended registry baseline. Some compatible UI screenshots were captured on dsh-mnemon v0.2.0. DSH rc.2 uses `Promise.withResolvers` and the Node Zstd API, so Node 20 cannot boot its complete profile. Source compatibility is also verified against DSH 0.1.2-alpha.1, which is not published to npm. Back up and repeat this verification against an isolated root before upgrading.
+This workflow uses dsh-mnemon v0.4.4, DSH 0.1.1-rc.2, and Mnemon 0.2.3 as the recommended registry baseline. Some compatible UI screenshots were captured on dsh-mnemon v0.2.0. DSH rc.2 uses `Promise.withResolvers` and the Node Zstd API, so Node 20 cannot boot its complete profile. Source compatibility is also verified against DSH 0.1.2-alpha.1, which is not published to npm. Back up and repeat this verification against an isolated root before upgrading.
 
 Install and verify the tested DSH release with:
 

--- a/docs/en/releases/v0.4.4.md
+++ b/docs/en/releases/v0.4.4.md
@@ -1,0 +1,33 @@
+# v0.4.4: DSH session projection compatibility
+
+[简体中文](../../zh-CN/releases/v0.4.4.md) | **English**
+
+v0.4.4 fixes session history requests that fail with `Cannot read properties of undefined (reading 'parse')` on older DSH hosts. [Issue #147](https://github.com/omdsh-dev/dsh-mnemon/issues/147), [PR #149](https://github.com/omdsh-dev/dsh-mnemon/pull/149).
+
+## Fixes
+
+- The child-local token-usage projection now exposes both the legacy `schema` / `view` contract and the newer `stateSchema` / `wire` contract, sharing one wire schema and view function.
+- Live sessions, detached history replay, and restored checkpoints keep working across both registry generations. Parent and ancestor usage remains excluded from child totals, and repeated samples for one step replace rather than accumulate.
+- Malformed event payloads are ignored safely. The implementation also remains compatible with the DSH 0.1.2-alpha.1 source contract.
+
+## Upgrade and compatibility
+
+Install `dsh-mnemon@0.4.4` in the owning DSH profile and restart it. DSH 0.1.1-rc.2 remains the registry development baseline; DSH 0.1.2-alpha.1 remains a source compatibility target. Legacy compatibility tests use the published DSH 0.1.0-rc.8 projection registry.
+
+Projection state stays at `stateVersion: 1` with the same stored format. No migration or cache deletion is required. Memory data, storage paths, Pack formats, Provider credentials, RPC authority, settings, and production dependencies are unchanged. The legacy registry alias is only a development test fixture and is not shipped as a runtime dependency.
+
+Sidebar and optional Builtin placement keep the [v0.4.3 behavior](./v0.4.3.md). This patch contains no UI layout changes or v0.5 development work.
+
+## Verification
+
+The compatibility suite runs real legacy and current DSH registries with real sessions, covering empty snapshots, attached and detached replay, duplicate usage samples, checkpoint restoration, cross-generation checkpoints, change notifications, and obsolete-state refolding. See the [development guide](../development.md#session-projection-compatibility) for reproducible commands.
+
+- The release candidate passed complete `pnpm run verify` on Node 24.18.0 with pnpm 10.13.1: 647 tests passed and one Windows-only test was skipped on macOS. All 108 deterministic build files, Headless activation with 35 tools and five representative Mnemon tools, settings migration and restart, ten Node-compatible public entries, publint, and attw passed.
+- A real HTTP comparison made 32 requests through the published legacy/current ApiProxy and projection registries. The unmodified v0.4.3 source reproduced the legacy history-tail failure; v0.4.4 passed ordinary/child sessions, attached/detached histories, and pagination controls while retaining correct projections on newer hosts.
+- The 115-file tarball was installed in two isolated DSH 0.1.1-rc.2 Web profiles, native and with Web UI 0.3.9, using official Mnemon CLI 0.2.6. Both installations matched every packed file and imported all ten Node entries. Version 0.4.4, all four pages in Chinese and English, and Task Board round trips passed. A synthetic native conversation survived a browser reload with its history intact. No browser errors were observed; the Web UI's existing Host `session/list` warning remains. Tests used temporary data and a local model stub, without personal memory or paid model calls.
+
+## Rollback
+
+Reinstall `dsh-mnemon@0.4.3` in the same profile and restart it. No data conversion is needed, but older DSH hosts can encounter the session history failure again.
+
+Previous release: [v0.4.3](./v0.4.3.md).

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -30,7 +30,7 @@
 | 理解 Host、worker、控制面与数据面 | [架构设计](./architecture.md) |
 | 开发 Layer、Adapter、Strategy、Guard 或 MemorySource 插件 | [记忆扩展开发](./extensions.md) |
 | 修改代码、截图、测试或发布 | [开发与验证](./development.md) |
-| 从上一版本升级 | [v0.4.3 发布说明](./releases/v0.4.3.md) |
+| 从上一版本升级 | [v0.4.4 发布说明](./releases/v0.4.4.md) |
 | 查看下一阶段计划 | [Roadmap](./roadmap.md) |
 
 ## 核心术语

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -17,7 +17,7 @@
 
 普通语义任务优先使用名为 `spawn` 的 Provider，并要求 `toolFilter`、`persona` 与 `depthLimit`。Mnemon 会为每次运行提供一个经过 schema 校验的一次性结果工具，不依赖 Provider 的 `outputSchema` 路径。可选的评分后台审查还要求名为 `fork`、且 `inheritsParentContext=true` 的 Provider。缺少 `fork` 不影响确定性页面读取和普通手动操作。
 
-本文流程以 dsh-mnemon v0.4.3、DSH 0.1.1-rc.2 和 Mnemon 0.2.3 作为推荐 registry 基线；部分保持兼容的界面截图拍摄于 dsh-mnemon v0.2.0。DSH rc.2 使用 `Promise.withResolvers` 和 Node Zstd API，因此 Node 20 无法启动完整 profile。源码兼容性也已针对尚未发布到 npm 的 DSH 0.1.2-alpha.1 验证。升级前先备份，并在隔离目录重复本页验证。
+本文流程以 dsh-mnemon v0.4.4、DSH 0.1.1-rc.2 和 Mnemon 0.2.3 作为推荐 registry 基线；部分保持兼容的界面截图拍摄于 dsh-mnemon v0.2.0。DSH rc.2 使用 `Promise.withResolvers` 和 Node Zstd API，因此 Node 20 无法启动完整 profile。源码兼容性也已针对尚未发布到 npm 的 DSH 0.1.2-alpha.1 验证。升级前先备份，并在隔离目录重复本页验证。
 
 安装并核对已验证的 DSH 版本：
 

--- a/docs/zh-CN/releases/v0.4.4.md
+++ b/docs/zh-CN/releases/v0.4.4.md
@@ -1,0 +1,33 @@
+# v0.4.4：DSH 会话投影接口兼容
+
+**简体中文** | [English](../../en/releases/v0.4.4.md)
+
+v0.4.4 修复旧版 DSH 宿主读取会话历史时出现的 `Cannot read properties of undefined (reading 'parse')` 错误。[Issue #147](https://github.com/omdsh-dev/dsh-mnemon/issues/147)、[PR #149](https://github.com/omdsh-dev/dsh-mnemon/pull/149)。
+
+## 修复
+
+- 子 Agent 本地 token 用量投影同时提供旧版 `schema` / `view` 和新版 `stateSchema` / `wire` 接口，共用同一个 wire schema 和 view 函数。
+- 两代 registry 均支持活跃会话、脱离会话后的历史回放和检查点恢复。子 Agent 总量仍排除父级与祖先用量，同一步骤的重复样本继续替换而非累加。
+- 安全忽略格式错误的事件载荷，同时保持与 DSH 0.1.2-alpha.1 源码接口兼容。
+
+## 升级与兼容性
+
+在所属 DSH profile 中安装 `dsh-mnemon@0.4.4`，然后重启。DSH 0.1.1-rc.2 仍为 registry 开发基线；DSH 0.1.2-alpha.1 仍为源码兼容性目标。旧版兼容性测试使用已发布的 DSH 0.1.0-rc.8 投影 registry。
+
+投影状态仍为 `stateVersion: 1`，存储格式不变，无需迁移或删除缓存。记忆数据、存储路径、Pack 格式、Provider 凭据、RPC 权限、设置和生产依赖均不变。旧版 registry 别名仅为开发测试夹具，不作为运行时依赖发布。
+
+Sidebar 与可选 Builtin 入口保持 [v0.4.3 的行为](./v0.4.3.md)。本补丁不包含 UI 布局改动或 v0.5 开发内容。
+
+## 验证
+
+兼容性测试以真实会话运行新旧 DSH registry，覆盖空快照、活跃与脱离会话回放、重复用量样本、检查点恢复、跨代检查点、变更通知和过期状态重算。可复现命令见[开发指南](../development.md#session-projection-兼容性)。
+
+- 发布候选在 Node 24.18.0 与 pnpm 10.13.1 下通过完整 `pnpm run verify`：647 项测试通过，1 项 Windows 专用测试在 macOS 跳过。108 个构建文件的确定性检查、包含 35 个工具与 5 个代表性 Mnemon 工具的 Headless 激活、设置迁移与重启、10 个 Node 兼容公开入口、publint 和 attw 均通过。
+- 使用已发布的新旧 ApiProxy 和投影 registry 完成 32 次真实 HTTP 对照请求。未修改的 v0.4.3 源码复现了旧版历史尾部请求失败；v0.4.4 通过普通与子 Agent 会话、活跃与脱离会话历史、分页对照，并保持新版宿主的投影结果正确。
+- 将包含 115 个文件的 tarball 安装到两个隔离的 DSH 0.1.1-rc.2 Web profile，分别使用原生界面和 Web UI 0.3.9，并搭配官方 Mnemon CLI 0.2.6。两次安装的全部文件均与打包产物一致，10 个 Node 入口均可导入。版本 0.4.4、中英文四个主页面、任务看板往返均通过；原生界面的合成会话在浏览器重载后仍能完整读取历史。未观察到浏览器错误；Web UI 既有的 Host `session/list` 警告仍存在。测试仅使用临时数据和本地模型桩，没有访问个人记忆或调用付费模型。
+
+## 回滚
+
+在同一 profile 中重新安装 `dsh-mnemon@0.4.3` 并重启，无需转换数据，但旧版 DSH 宿主可能再次遇到会话历史读取失败。
+
+上一版：[v0.4.3](./v0.4.3.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mnemon",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Composable three-tier memory control plane for DeepSeek Harness: persistent runtime context, searchable project documents, pluggable long-term memory, guarded strategies, WebUI, and headless tools.",
   "keywords": [
     "deepseek-harness",


### PR DESCRIPTION
> 提交 PR 前请阅读[贡献指南](../CONTRIBUTING.zh-CN.md)、[Contributing Guide](../CONTRIBUTING.md)与[开发和验证指南](../docs/zh-CN/development.md) / [Development and Verification Guide](../docs/en/development.md)。
> Before opening a PR, read the [Contributing Guide](../CONTRIBUTING.md), [贡献指南](../CONTRIBUTING.zh-CN.md), and the [Development and Verification Guide](../docs/en/development.md) / [开发和验证指南](../docs/zh-CN/development.md).
> PR 标题和提交信息必须使用 Conventional Commits（`type(scope): subject`），且不得包含 emoji。 / PR titles and commits must use Conventional Commits (`type(scope): subject`) and must not contain emoji.
> 本仓库接受 Bug 修复、兼容性适配、现有能力增强、性能或体验优化和维护类 PR。全新能力、Provider、持久化格式或安全边界变更必须先提 Issue 并获得维护者确认。 / This repository accepts bug fixes, compatibility work, improvements to existing capabilities, performance or UX optimization, and maintenance. New capabilities, Providers, persistence formats, or security-boundary changes require prior maintainer approval in an Issue.
> 外部贡献者的仅文档类 PR 不直接接受；请先提 Issue 讨论。维护者的发布说明与文档维护不受此限制。 / Documentation-only PRs from external contributors are not accepted directly; open an Issue first. Maintainer release notes and documentation maintenance are exempt.

## 摘要 / Summary

Prepare `dsh-mnemon@0.4.4` so the DSH session-history compatibility fix from #149 reaches npm users. This PR bumps the root package version, adds matching Chinese/English release notes, and updates current-release links and installation baselines; it adds no runtime changes.

<!-- 用一两句话说明改了什么、为什么改，以及用户或系统行为如何变化。 / In one or two sentences, explain what changed, why, and how user or system behavior changes. -->

## 关联 Issue 或背景 / Related Issue or Context

Maintainer-requested v0.4.x patch release after merging #149, which closed #147. The npm/GitHub baseline is v0.4.3; this release contains the dual-generation session projection fix and its existing tests, with no unrelated v0.5 work.

<!-- 优先使用 Closes #123 或 Fixes #123。没有 Issue 时填写 N/A 并解释为什么可以直接提交。 / Prefer Closes #123 or Fixes #123. If there is no Issue, enter N/A and explain why a direct PR is appropriate. -->

## 涉及区域 / Affected Areas

<!-- 至少勾选一项。 / Check at least one item. -->

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [x] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

<!-- 至少勾选一项；仅文档类 PR 的限制见文件顶部说明。 / Check at least one item; see the note above for documentation-only PRs. -->

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [ ] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [x] 维护或重构 / Maintenance or refactor
- [ ] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin main --tags
git worktree add -b codex/release-v0.4.4 <isolated-worktree> origin/main
```

Base: `688b1e107387a42eeb1c58e25050b06564cbfca4` (merged #149). The original development workspace was not modified.

## AI 编码披露 / AI Coding Disclosure

<!-- 必填。勾选且仅勾选一项；模型和工具字段不得留空。 / Required. Check exactly one option; the model and tool fields must not be blank. -->

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

GPT-5 (Codex).

使用的编码 Agent 工具 / Coding Agent tool used:

Codex desktop, isolated Git worktree, and in-app Browser for local release verification.

## 仓库规范检查 / Repository Rules

<!-- 本仓库硬性规范，请逐项确认。 / Confirm every mandatory repository rule. -->

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

The release metadata and documentation do not change data or runtime behavior beyond merged #149. The fix supports both legacy `schema` / `view` and current `stateSchema` / `wire`, retaining `stateVersion: 1` and checkpoint layout. No migration, cache deletion, settings, storage paths, Pack formats, Provider credentials, RPC authority, or production dependency changes. DSH 0.1.1-rc.2 is the registry baseline; 0.1.2-alpha.1 stays covered by source CI. Reinstall 0.4.3 to roll back without converting data; the legacy history error can return. Test profiles use synthetic data, an official Mnemon 0.2.6 CLI, and a loopback model stub.

<!-- 必填。说明对 DSH、Mnemon、Provider、配置、存储格式、升级或回滚和现有数据的影响。没有影响时填 N/A 并说明理由。 / Required. Explain effects on DSH, Mnemon, Providers, configuration, storage formats, upgrades or rollback, and existing data. Enter N/A with a reason when there is no impact. -->

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm install --frozen-lockfile
pnpm run verify
npm pack --ignore-scripts --pack-destination <artifacts> --json
node <artifacts>/run-history-smoke.mjs
node scripts/serve-web-regression.mjs --package <artifacts>/dsh-mnemon-0.4.4.tgz --cli <test-cli>/mnemon --web-ui none
node scripts/serve-web-regression.mjs --package <artifacts>/dsh-mnemon-0.4.4.tgz --cli <test-cli>/mnemon --web-ui @linxin666/dsh-web-all@0.3.9
node <artifacts>/verify-installed.mjs <native-profile> 0.4.4
node <artifacts>/verify-installed.mjs <web-ui-profile> 0.4.4
git diff --check
```

结果摘要 / Result summary:

- Node 24.18.0 / pnpm 10.13.1: full verification passed, with **647 tests passed and one existing Windows-only test skipped on macOS**.
- All **108** deterministic build files, Headless activation with **35 tools / five representative Mnemon tools**, migration/idempotent restart, all **ten** Node-compatible entries, publint and attw passed.
- **32 real HTTP requests** through the published legacy/current ApiProxy and projection registries passed their expectations: v0.4.3 reproduces the legacy failure, v0.4.4 fixes it, and newer hosts remain correct.
- The inspected tarball has **115 files**. Both real Web profile installations match every file byte-for-byte and import all ten Node entries.
- Native DSH and Web UI 0.3.9 show **0.4.4**, pass all four pages in Chinese/English, and report no browser errors. Task Board round trips retain the memory page. A native synthetic conversation survives reload with its history intact.
- Existing upstream source-map and Web UI Host `session/list` warnings remain; no new failure or real model call occurred.
- All bilingual release links resolve, and the ten-file diff contains no source code, generated output, secrets, personal memory, or raw fixture logs. CI also exercises Linux Node 22.19/24, Windows Node 24, Node 20 public imports, and DSH alpha source compatibility.

## 用户可见变更证据 / Local Feature Evidence

<!--
面向用户的功能或行为变更必填。 / Required for user-facing feature or behavior changes.
附截图或短视频，展示 / Attach screenshots or a short video showing:
- 使用的是本 PR 或最新代码 / the PR or latest code is running
- 功能已启用或配置 / the feature is enabled or configured
- 操作成功并出现可见结果 / the action succeeds with a visible result
- 没有泄露凭据、私有记忆或敏感路径 / no credentials, private memory, or sensitive paths are exposed
纯内部改动可填 N/A 并解释。 / For internal-only changes, enter N/A and explain.
-->

证据 / Evidence:

Release-only metadata/documentation; the implemented Host fix and its reproduction evidence are in #149. Redacted candidate results:

```text
package: dsh-mnemon@0.4.4
Tests: 647 passed | 1 Windows-only skip on macOS
HTTP comparison: 32/32 expected outcomes
legacy v0.4.3 tail: TypeError reading undefined.parse
legacy v0.4.4 tail: ok=true
current v0.4.4 tail: ok=true
child usage: input=12 output=5 cacheRead=3 cacheWrite=4
native + Web UI 0.3.9: version=0.4.4, zh/en pages=pass
installed package contents: 115/115 files match in each profile
installed Node exports: 10/10 in each profile
native history after reload: preserved
browser errors: 0
```

Release notes: `docs/en/releases/v0.4.4.md` and `docs/zh-CN/releases/v0.4.4.md`. Raw logs and fixtures remain outside the repository.
