### PR TITLE
chore(release): prepare v0.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 <p align="center">
   <a href="./docs/en/capabilities.md"><strong>Explore the capability map</strong></a> ·
   <a href="./docs/en/getting-started.md">Start in five minutes</a> ·
-  <a href="./docs/en/releases/v0.4.4.md">Read the v0.4.4 notes</a> ·
+  <a href="./docs/en/releases/v0.4.5.md">Read the v0.4.5 notes</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">Watch the widescreen demo</a>
 </p>
 
@@ -43,6 +43,8 @@ v0.4.2 restores optional `displayMode: builtin` as a conversation placement for 
 v0.4.3 aligns the collapsed Memory System icon with neighboring sidebar controls while preserving the expanded appearance. See the [patch release notes](./docs/en/releases/v0.4.3.md).
 
 v0.4.4 fixes session history failures on older DSH hosts by supporting both session projection contracts. Newer hosts and existing projection checkpoints remain compatible. See the [patch release notes](./docs/en/releases/v0.4.4.md).
+
+v0.4.5 registers Memory System with an installed Better Sidebar while keeping the normal DSH Sidebar entry and both client activation orders working. See the [patch release notes](./docs/en/releases/v0.4.5.md).
 
 ## Understand the scope in 30 seconds
 
@@ -218,7 +220,7 @@ See [Operations, security, and troubleshooting](./docs/en/operations.md) for bac
 | Back up, update, or troubleshoot | [Operations](./docs/en/operations.md) |
 | Integrate tools, commands, or RPC | [Interface reference](./docs/en/interfaces.md) |
 | Build a Layer, Adapter, Strategy, Guard, or MemorySource extension | [Extension guide](./docs/en/extensions.md) |
-| Review the release | [v0.4.4 release notes](./docs/en/releases/v0.4.4.md) |
+| Review the release | [v0.4.5 release notes](./docs/en/releases/v0.4.5.md) |
 
 See the [documentation hub](./docs/en/README.md) for the full map.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
 <p align="center">
   <a href="./docs/zh-CN/capabilities.md"><strong>先看能力地图</strong></a> ·
   <a href="./docs/zh-CN/getting-started.md">5 分钟开始</a> ·
-  <a href="./docs/zh-CN/releases/v0.4.4.md">v0.4.4 升级说明</a> ·
+  <a href="./docs/zh-CN/releases/v0.4.5.md">v0.4.5 升级说明</a> ·
   <a href="https://github.com/omdsh-dev/dsh-mnemon/blob/e6ca446e45bdd17991f3c7c98560456de465282b/docs/assets/media/dsh-mnemon-memory-system-demo.mp4">观看宽屏实机演示</a>
 </p>
 
@@ -43,6 +43,8 @@ v0.4.2 恢复可选 `displayMode: builtin`，只将 Sidebar 优先迭代的共�
 v0.4.3 让折叠后的记忆系统图标与侧栏相邻控件对齐，并保留原有展开样式。详见[补丁发布说明](./docs/zh-CN/releases/v0.4.3.md)。
 
 v0.4.4 同时支持新旧 DSH 会话投影接口，修复旧版宿主读取会话历史失败的问题，并保持新版宿主和已有投影检查点兼容。详见[补丁发布说明](./docs/zh-CN/releases/v0.4.4.md)。
+
+v0.4.5 在已安装 Better Sidebar 时向其注册记忆系统，同时保留 DSH 普通 Sidebar 入口，并兼容两种客户端加载顺序。详见[补丁发布说明](./docs/zh-CN/releases/v0.4.5.md)。
 
 ## 30 秒理解能力边界
 
@@ -218,7 +220,7 @@ dsh plugin --profile headless add "link:/absolute/path/to/dsh-mnemon"
 | 备份、更新或排障 | [运维指南](./docs/zh-CN/operations.md) |
 | 接入工具、命令或 RPC | [接口参考](./docs/zh-CN/interfaces.md) |
 | 开发 Layer、Adapter、Strategy、Guard 或 MemorySource 扩展 | [扩展开发指南](./docs/zh-CN/extensions.md) |
-| 查看本次升级 | [v0.4.4 发布说明](./docs/zh-CN/releases/v0.4.4.md) |
+| 查看本次升级 | [v0.4.5 发布说明](./docs/zh-CN/releases/v0.4.5.md) |
 
 完整目录见[文档中心](./docs/zh-CN/README.md)。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,9 +3,9 @@
 - [English](./en/README.md)
 - [简体中文](./zh-CN/README.md)
 
-Start with [Getting Started](./en/getting-started.md). Existing users should read the [v0.4.4 release notes](./en/releases/v0.4.4.md); extension authors should continue with [Architecture](./en/architecture.md) and [Building Memory Extensions](./en/extensions.md).
+Start with [Getting Started](./en/getting-started.md). Existing users should read the [v0.4.5 release notes](./en/releases/v0.4.5.md); extension authors should continue with [Architecture](./en/architecture.md) and [Building Memory Extensions](./en/extensions.md).
 
-第一次使用请从[快速开始](./zh-CN/getting-started.md)进入。已有用户先看 [v0.4.4 发布说明](./zh-CN/releases/v0.4.4.md)；扩展作者继续阅读[架构设计](./zh-CN/architecture.md)与[记忆扩展开发](./zh-CN/extensions.md)。
+第一次使用请从[快速开始](./zh-CN/getting-started.md)进入。已有用户先看 [v0.4.5 发布说明](./zh-CN/releases/v0.4.5.md)；扩展作者继续阅读[架构设计](./zh-CN/architecture.md)与[记忆扩展开发](./zh-CN/extensions.md)。
 
 The root README stays focused on orientation and quick start. Architecture, data model, lifecycle, interfaces, operations, and development details live here.
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -30,7 +30,7 @@ This hub is organized by what you need to accomplish. New users should follow Ge
 | Understand Host, workers, control plane, and data plane | [Architecture](./architecture.md) |
 | Build a Layer, Adapter, Strategy, Guard, or MemorySource plugin | [Building Memory Extensions](./extensions.md) |
 | Modify code, screenshots, tests, or releases | [Development and verification](./development.md) |
-| Upgrade from the previous release | [v0.4.4 release notes](./releases/v0.4.4.md) |
+| Upgrade from the previous release | [v0.4.5 release notes](./releases/v0.4.5.md) |
 | See planned work | [Roadmap](./roadmap.md) |
 
 ## Core terms

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -17,7 +17,7 @@ You need:
 
 Regular semantic work prefers a provider named `spawn` with `toolFilter`, `persona`, and `depthLimit`. Mnemon supplies a schema-validated, one-run result tool instead of depending on the Provider's `outputSchema` path. Optional score-based background review additionally requires a provider named `fork` with `inheritsParentContext=true`. Missing `fork` does not block deterministic pages or regular manual actions.
 
-This workflow uses dsh-mnemon v0.4.4, DSH 0.1.1-rc.2, and Mnemon 0.2.3 as the recommended registry baseline. Some compatible UI screenshots were captured on dsh-mnemon v0.2.0. DSH rc.2 uses `Promise.withResolvers` and the Node Zstd API, so Node 20 cannot boot its complete profile. Source compatibility is also verified against DSH 0.1.2-alpha.1, which is not published to npm. Back up and repeat this verification against an isolated root before upgrading.
+This workflow uses dsh-mnemon v0.4.5, DSH 0.1.1-rc.2, and Mnemon 0.2.3 as the recommended registry baseline. Some compatible UI screenshots were captured on dsh-mnemon v0.2.0. DSH rc.2 uses `Promise.withResolvers` and the Node Zstd API, so Node 20 cannot boot its complete profile. Source compatibility is also verified against DSH 0.1.2-alpha.1, which is not published to npm. Back up and repeat this verification against an isolated root before upgrading.
 
 Install and verify the tested DSH release with:
 

--- a/docs/en/releases/v0.4.5.md
+++ b/docs/en/releases/v0.4.5.md
@@ -1,0 +1,29 @@
+# v0.4.5: Better Sidebar compatibility
+
+[简体中文](../../zh-CN/releases/v0.4.5.md) | **English**
+
+v0.4.5 makes Memory System available inside an installed `dsh-better-sidebar` without replacing its normal DSH Sidebar entry. [Issue #153](https://github.com/omdsh-dev/dsh-mnemon/issues/153), [PR #157](https://github.com/omdsh-dev/dsh-mnemon/pull/157).
+
+## Fixes
+
+- In the default `displayMode: sidebar`, Mnemon now uses Better Sidebar's documented optional `registerTab` service. The single-instance tab has the stable id `dsh-mnemon:memory` and reuses the same Memory System view as the normal DSH Sidebar entry.
+- Registration is activation-order independent: Better Sidebar can load before or after Mnemon, and service replacement, unload, or hot reload disposes and restores registration without duplicates.
+- A Better Sidebar tab uses the session and workspace scope supplied for that tab rather than leaking the globally active session. Setting `tabEnabled: false` or `displayMode: builtin` continues to suppress this registration.
+
+## Upgrade and compatibility
+
+Install `dsh-mnemon@0.4.5` in the owning DSH profile and restart it. Better Sidebar remains optional and no new runtime dependency is added. The compatibility target tested here is `dsh-better-sidebar@0.18.1-alpha.0`; profiles without that service retain the existing standalone Sidebar behavior.
+
+Memory data, storage paths, Pack formats, Provider credentials, RPC authority, settings, production dependencies, and session projection state are unchanged. No migration or cache deletion is required. The [v0.4.4 session projection compatibility](./v0.4.4.md) remains intact, and this patch contains no unrelated v0.5 development work.
+
+## Verification
+
+The implementation and release candidate passed complete `pnpm run verify` on Node 24.18.0 with pnpm 10.13.1: 649 tests passed and one Windows-only test was skipped on macOS. All 109 deterministic build files, Headless activation with 35 tools and five representative Mnemon tools, settings migration and restart, ten Node-compatible public entries, the 116-file package contents, publint, and attw passed. PR #157 also passed the Linux Node 22.19/24, Windows Node 24, and DSH alpha source CI jobs.
+
+Two isolated real WebUI profiles covered both client activation orders. DSH 0.1.1-rc.2 with `@linxin666/dsh-web-all@0.3.6` loaded Better Sidebar before Mnemon; DSH 0.1.2-alpha.3 loaded Mnemon first. In both cases the normal Sidebar kept exactly one Memory System row, Better Sidebar exposed exactly one menu item, the scoped view rendered, and a fresh browser tab reported zero console errors and zero warnings. Reload restoration also passed in the reported-version profile. See the [environment record and screenshots](../../pr-assets/better-sidebar-153/README.md).
+
+## Rollback
+
+Reinstall `dsh-mnemon@0.4.4` in the same profile and restart it. No data conversion is needed. Better Sidebar can retain an already opened `dsh-mnemon:memory` tab in its own persisted layout; after rollback that tab can temporarily appear orphaned and may be closed. The normal DSH Sidebar entry remains available.
+
+Previous release: [v0.4.4](./v0.4.4.md).

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -30,7 +30,7 @@
 | 理解 Host、worker、控制面与数据面 | [架构设计](./architecture.md) |
 | 开发 Layer、Adapter、Strategy、Guard 或 MemorySource 插件 | [记忆扩展开发](./extensions.md) |
 | 修改代码、截图、测试或发布 | [开发与验证](./development.md) |
-| 从上一版本升级 | [v0.4.4 发布说明](./releases/v0.4.4.md) |
+| 从上一版本升级 | [v0.4.5 发布说明](./releases/v0.4.5.md) |
 | 查看下一阶段计划 | [Roadmap](./roadmap.md) |
 
 ## 核心术语

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -17,7 +17,7 @@
 
 普通语义任务优先使用名为 `spawn` 的 Provider，并要求 `toolFilter`、`persona` 与 `depthLimit`。Mnemon 会为每次运行提供一个经过 schema 校验的一次性结果工具，不依赖 Provider 的 `outputSchema` 路径。可选的评分后台审查还要求名为 `fork`、且 `inheritsParentContext=true` 的 Provider。缺少 `fork` 不影响确定性页面读取和普通手动操作。
 
-本文流程以 dsh-mnemon v0.4.4、DSH 0.1.1-rc.2 和 Mnemon 0.2.3 作为推荐 registry 基线；部分保持兼容的界面截图拍摄于 dsh-mnemon v0.2.0。DSH rc.2 使用 `Promise.withResolvers` 和 Node Zstd API，因此 Node 20 无法启动完整 profile。源码兼容性也已针对尚未发布到 npm 的 DSH 0.1.2-alpha.1 验证。升级前先备份，并在隔离目录重复本页验证。
+本文流程以 dsh-mnemon v0.4.5、DSH 0.1.1-rc.2 和 Mnemon 0.2.3 作为推荐 registry 基线；部分保持兼容的界面截图拍摄于 dsh-mnemon v0.2.0。DSH rc.2 使用 `Promise.withResolvers` 和 Node Zstd API，因此 Node 20 无法启动完整 profile。源码兼容性也已针对尚未发布到 npm 的 DSH 0.1.2-alpha.1 验证。升级前先备份，并在隔离目录重复本页验证。
 
 安装并核对已验证的 DSH 版本：
 

--- a/docs/zh-CN/releases/v0.4.5.md
+++ b/docs/zh-CN/releases/v0.4.5.md
@@ -1,0 +1,29 @@
+# v0.4.5：Better Sidebar 兼容性
+
+**简体中文** | [English](../../en/releases/v0.4.5.md)
+
+v0.4.5 让已安装 `dsh-better-sidebar` 的用户可以在其中打开记忆系统，同时保留原有的 DSH 普通 Sidebar 入口。[Issue #153](https://github.com/omdsh-dev/dsh-mnemon/issues/153)、[PR #157](https://github.com/omdsh-dev/dsh-mnemon/pull/157)。
+
+## 修复
+
+- 默认 `displayMode: sidebar` 下，Mnemon 现在使用 Better Sidebar 文档化的可选 `registerTab` 服务。单实例 Tab 使用稳定 id `dsh-mnemon:memory`，并与 DSH 普通 Sidebar 入口复用同一个记忆系统视图。
+- 注册不依赖激活顺序：Better Sidebar 可以先于或晚于 Mnemon 加载；服务替换、卸载或热重载时也会正确注销并恢复，不产生重复入口。
+- Better Sidebar Tab 使用该 Tab 传入的会话和工作区作用域，不会错误沿用全局当前会话。设置 `tabEnabled: false` 或 `displayMode: builtin` 时仍不会注册此 Tab。
+
+## 升级与兼容性
+
+在所属 DSH profile 中安装 `dsh-mnemon@0.4.5`，然后重启。Better Sidebar 仍为可选组件，不新增运行时依赖。本次验证的兼容目标为 `dsh-better-sidebar@0.18.1-alpha.0`；未提供该服务的 profile 继续保留原有独立 Sidebar 行为。
+
+记忆数据、存储路径、Pack 格式、Provider 凭据、RPC 权限、设置、生产依赖和会话投影状态均不变，无需迁移或删除缓存。[v0.4.4 的会话投影兼容性](./v0.4.4.md)保持不变；本补丁不包含无关的 v0.5 开发内容。
+
+## 验证
+
+实现与发布候选在 Node 24.18.0 与 pnpm 10.13.1 下通过完整 `pnpm run verify`：649 项测试通过，1 项 Windows 专用测试在 macOS 跳过。109 个构建文件的确定性检查、包含 35 个工具与 5 个代表性 Mnemon 工具的 Headless 激活、设置迁移与重启、10 个 Node 兼容公开入口、116 个文件的包内容、publint 和 attw 均通过。PR #157 的 Linux Node 22.19/24、Windows Node 24 和 DSH alpha 源码 CI 任务也全部通过。
+
+两个真实隔离 WebUI profile 覆盖了两种客户端激活顺序。DSH 0.1.1-rc.2 与 `@linxin666/dsh-web-all@0.3.6` 环境先加载 Better Sidebar、后加载 Mnemon；DSH 0.1.2-alpha.3 环境先加载 Mnemon。两者都保留且仅保留 1 个普通 Sidebar 记忆系统行，Better Sidebar 菜单也仅出现 1 个入口；作用域视图正常渲染，新浏览器标签页均为 0 个控制台 error、0 个 warning。报告版本环境还通过了刷新恢复验证。详见[环境记录与截图](../../pr-assets/better-sidebar-153/README.md)。
+
+## 回滚
+
+在同一 profile 中重新安装 `dsh-mnemon@0.4.4` 并重启，无需转换数据。Better Sidebar 可能在自身持久化布局中保留已打开的 `dsh-mnemon:memory` Tab；回滚后它可能暂时显示为 orphaned tab，可直接关闭，原有 DSH 普通 Sidebar 入口仍可使用。
+
+上一版：[v0.4.4](./v0.4.4.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mnemon",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Composable three-tier memory control plane for DeepSeek Harness: persistent runtime context, searchable project documents, pluggable long-term memory, guarded strategies, WebUI, and headless tools.",
   "keywords": [
     "deepseek-harness",


### PR DESCRIPTION
## 摘要 / Summary

Prepare `dsh-mnemon@0.4.5` so the Better Sidebar compatibility fix from #157 reaches npm users. This PR bumps the root package version, adds matching Chinese and English release notes, and updates current-release links and installation baselines; it adds no runtime changes beyond the already merged fix.

## 关联 Issue 或背景 / Related Issue or Context

Maintainer-requested v0.4.x patch release after merging #157, which resolves #153. The npm and GitHub baseline is v0.4.4; this release contains only the optional Better Sidebar integration and its existing tests and WebUI evidence, with no unrelated v0.5 work.

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [x] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [ ] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [x] 维护或重构 / Maintenance or refactor
- [ ] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin main --tags
git worktree add -b codex/release-v0.4.5 <isolated-worktree> origin/main
```

Base: `c69c63a926cd32f84c0e5c2fe39102381b43ea34` (merged #157). The original development workspace was not modified.

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

GPT-5.6 Sol (Codex).

使用的编码 Agent 工具 / Coding Agent tool used:

Codex desktop and an isolated Git worktree. The merged #157 acceptance work also used the in-app Browser against isolated WebUI profiles.

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

The release metadata and documentation do not add runtime behavior beyond merged #157. Better Sidebar remains an optional soft dependency; profiles without it retain the normal DSH Sidebar entry. Registration is limited to `displayMode: sidebar`, respects `tabEnabled`, follows service replacement and both activation orders, and passes the target tab's session/workspace scope. No memory data, storage paths, Pack formats, Provider credentials, RPC authority, settings, production dependencies, or projection state change. No migration or cache deletion is needed. Reinstall 0.4.4 to roll back; an already persisted `dsh-mnemon:memory` Better Sidebar tab may appear orphaned and can be closed. All WebUI checks used isolated synthetic profiles and data roots.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
npx --yes --package=node@24.18.0 --package=pnpm@10.13.1 -- pnpm install --frozen-lockfile
npx --yes --package=node@24.18.0 --package=pnpm@10.13.1 -- pnpm run verify
npx --yes --package=node@24.18.0 --package=pnpm@10.13.1 -- npm pack --dry-run --ignore-scripts --json
git diff --check
```

结果摘要 / Result summary:

- Node 24.18.0 / pnpm 10.13.1: complete verification passed with 649 tests passed and one existing Windows-only test skipped on macOS.
- All 109 deterministic build files, Headless activation with 35 tools and five representative Mnemon tools, migration/idempotent restart, all ten Node-compatible entries, publint, and attw passed.
- The dry-run npm package identifies itself as `dsh-mnemon@0.4.5` and contains 116 files, 382,771 packed bytes, and 1,703,206 unpacked bytes.
- The known missing sourcemap notice from upstream `@deepseek-ai/dsh-client-ui-primitives@0.1.1-rc.2` remains non-blocking; no new test or package warning was introduced.
- PR #157 already passed Linux Node 22.19/24, Windows Node 24, DSH alpha source CI, and both independent WebUI activation-order scenarios with zero browser errors and warnings.
- The ten-file release diff contains no runtime source, generated output, credentials, private memory, or raw fixture logs.

## 用户可见变更证据 / Local Feature Evidence

Release-only metadata and documentation; the implemented compatibility fix and screenshots are in merged PR #157. The preserved evidence shows the normal DSH Sidebar entry and Better Sidebar menu item together, and the Memory System Runtime page rendered inside Better Sidebar:

- [Environment and acceptance record](https://github.com/omdsh-dev/dsh-mnemon/blob/c69c63a926cd32f84c0e5c2fe39102381b43ea34/docs/pr-assets/better-sidebar-153/README.md)
- [Tab menu screenshot](https://github.com/omdsh-dev/dsh-mnemon/blob/c69c63a926cd32f84c0e5c2fe39102381b43ea34/docs/pr-assets/better-sidebar-153/after-tab-menu.jpg?raw=1)
- [Memory tab screenshot](https://github.com/omdsh-dev/dsh-mnemon/blob/c69c63a926cd32f84c0e5c2fe39102381b43ea34/docs/pr-assets/better-sidebar-153/after-memory-tab.jpg?raw=1)

Release notes: `docs/en/releases/v0.4.5.md` and `docs/zh-CN/releases/v0.4.5.md`.
