### PR TITLE
docs(operations): document cloud WebUI access

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ dsh plugin --profile web add dsh-mnemon
 dsh --profile web
 ```
 
+When the Web profile is published under a cloud hostname, stable DSH 0.1.1-rc.2 needs an authenticated HTTPS reverse proxy, an explicit trusted authority, and a local Mnemon management override. Follow the [cloud-hosted WebUI procedure](./docs/en/operations.md#cloud-hosted-webui); do not expose the loopback service directly.
+
 DSH profiles have independent plugin rosters. Install the same package separately for one-shot Headless tasks:
 
 ```sh

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,6 +134,8 @@ dsh plugin --profile web add dsh-mnemon
 dsh --profile web
 ```
 
+将 Web profile 发布到云端域名时，稳定版 DSH 0.1.1-rc.2 需要带身份认证的 HTTPS 反向代理、显式可信 authority，以及本机 Mnemon 管理权限覆盖。请按[云端 WebUI 操作步骤](./docs/zh-CN/operations.md#cloud-hosted-webui)配置，不要把回环服务直接暴露到公网。
+
 DSH 各 profile 的插件清单彼此独立。一次性 Headless 任务需要单独安装：
 
 ```sh

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -25,6 +25,7 @@ This hub is organized by what you need to accomplish. New users should follow Ge
 | Understand workspace inspection versus the Agent's effective directory | [UI guide: Workspace mode](./ui-guide.md#workspace-mode-separating-inspection-from-execution) |
 | Check or update Mnemon and dsh-mnemon | [Operations: Version checks and updates](./operations.md#version-checks-and-updates) |
 | Back up, restore, or migrate the complete memory root | [Operations: Backup and recovery](./operations.md#backup-and-recovery) |
+| Publish the WebUI behind a cloud hostname | [Operations: Cloud-hosted WebUI](./operations.md#cloud-hosted-webui) |
 | Troubleshoot empty recall, misalignment, CLI, or provider errors | [Operations and troubleshooting](./operations.md#troubleshooting) |
 | Use model tools, `/mnemon` commands, or internal RPC | [Interface reference](./interfaces.md) |
 | Understand Host, workers, control plane, and data plane | [Architecture](./architecture.md) |

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -170,6 +170,8 @@ On DSH 0.1.1-rc.2, `remoteAccess` remains a real startup security boundary and c
 
 DSH 0.1.2-alpha.5 removes those method-specific privilege tiers and authenticates every Mnemon RPC through the browser session established by its one-time launch token and signed cookie. It ignores `remoteAccess`, which remains accepted solely so the same plugin configuration can roll back to rc.2 safely. `writeEnabled=false` is a product-level read-only mode in both versions; it is not a substitute for transport authentication.
 
+For the complete proxy, profile-patch, trusted-authority, restart, and verification workflow, see [Cloud-hosted WebUI on stable DSH rc.2](./operations.md#cloud-hosted-webui).
+
 ## Storage Scopes
 
 ### `global`
@@ -356,6 +358,8 @@ If the old value comes only from a composition profile, migration saves a canoni
 ## Profile Patch Overrides
 
 The bundled `cordis.patch.yml` provides the default config row. A DSH profile configuration with the same ID may replace that row as a whole. Do not add only `cliPath` to a final profile patch: use `MNEMON_CLI_PATH` or the `mnemon.cliPath` user setting instead. When a profile patch must be customized for another reason, retain every key that must remain enabled instead of assuming a deep merge.
+
+The cloud rc.2 `remoteAccess` override is one such whole-row customization. Use the complete, upgrade-aware example in the [cloud-hosted WebUI procedure](./operations.md#cloud-hosted-webui), not a standalone `config: { remoteAccess: trusted-host }` fragment.
 
 ## Common Configurations
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -113,6 +113,8 @@ Then start or restart the profile:
 dsh --profile web
 ```
 
+If the Web profile is reached through a cloud hostname, do not publish port 3080 directly. Stable DSH 0.1.1-rc.2 keeps Mnemon management channels loopback-only by default, so a remote page can be visible while the Memory System cannot load settings or perform writes. Configure the authenticated reverse proxy, `remoteAccess` override, and trusted authority together by following [Cloud-hosted WebUI on stable DSH rc.2](./operations.md#cloud-hosted-webui). The same section explains the different launch-token flow on DSH 0.1.2-alpha.5.
+
 Upgrade and uninstall:
 
 ```sh

--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -102,6 +102,58 @@ Recommended migration: export from the old scope → switch and confirm the new 
 
 Existing turns and delegated child activations may still use the old runtime. Wait for them to finish or cancel them before moving or retiring its data. Parent completion alone does not release an asynchronous child's delegation; a newly created or cold-resumed activation captures its own authorized generation.
 
+<a id="cloud-hosted-webui"></a>
+
+## Cloud-hosted WebUI on stable DSH 0.1.1-rc.2
+
+Stable DSH 0.1.1-rc.2 is the recommended registry target. Its secure default lets a trusted remote browser use ordinary Mnemon reads and activation, but keeps settings, backups, Provider connections, and broad mutations on loopback. A cloud page may therefore open while the Memory System cannot load its settings or complete writes.
+
+Use the following procedure only when the public entry already has reliable user authentication:
+
+1. Terminate HTTPS and authenticate users at a reverse proxy or access gateway. Proxy the same-origin `/` and `/api` traffic, including streams, to `http://127.0.0.1:3080` while preserving the external `Host` authority. DSH's trusted-host check is a Host/Origin fence, not authentication.
+2. Open the Web profile patch at `~/.dsh/profiles/web/cordis.patch.yml`, or `$DSH_HOME/profiles/web/cordis.patch.yml` when `DSH_HOME` is set. If it already has a top-level `- id: mnemon` entry, edit that entry instead of adding a duplicate. If the initialized file still ends in the empty-array marker `[]`, replace that marker with the complete row below; otherwise append the row to the existing top-level YAML list:
+
+   ```yaml
+   - id: mnemon
+     config:
+       routingGuidance: true
+       lifecycleEnabled: true
+       recallMode: guided
+       writebackMode: guided
+       idleReviewMs: 30000
+       tabEnabled: true
+       writeEnabled: true
+       remoteAccess: trusted-host
+       timeoutMs: 10000
+       defaultRecallLimit: 10
+       embedding:
+         enabled: false
+         endpoint: http://localhost:11434
+         model: nomic-embed-text
+       recallQuality:
+         policy: strict-v1
+         lowScoreThreshold: 0.25
+         highScoreThreshold: 0.6
+         candidateMultiplier: 3
+         maxMediumResults: 4
+         maxUnknownResults: 2
+   ```
+
+   A profile patch replaces the targeted row's complete `config` instead of deep-merging one field. Preserve any existing Mnemon customizations, and compare this row with `dsh web --dump-default-config` after upgrading dsh-mnemon so new bundled defaults are not masked.
+3. Inspect the effective tree with `dsh web --dump-config`. Confirm that the final `mnemon` row contains `remoteAccess: trusted-host` and that stderr reports no unmatched `mnemon` target.
+4. Start the loopback service with the external authority. Use a bare `host[:port]`, not a URL:
+
+   ```sh
+   dsh web --trusted-host memory.example.com --no-open
+   ```
+
+   For a non-default public port, use the exact authority, for example `memory.example.com:8443`. DSH 0.1.1-rc.2 deliberately rejects `--host 0.0.0.0`; keep the service on loopback and let the authenticated proxy or an SSH tunnel reach it.
+5. Restart the Host after changing `remoteAccess` because Mnemon captures this policy at startup. Open the external HTTPS URL, pass the proxy's authentication, then verify that **Status** and **Settings → Memory System** both load and that an intentional small settings save succeeds.
+
+If the browser receives a Host/Origin rejection, check `--trusted-host`, the public port, and whether the proxy preserves `Host`. If reads work but settings or writes remain unavailable, check the effective `mnemon` row and confirm that the Host was restarted.
+
+DSH 0.1.2-alpha.5 is a preview compatibility target with a different security model: it ignores `remoteAccess` and authenticates every RPC and stream through the browser session created by its one-time launch token and signed cookie. Keep the row above for safe rollback to rc.2, but after every alpha Host restart or public-authority change, open the launch URL printed by DSH to establish a fresh cookie. HTTPS and deployment access controls remain recommended.
+
 ## Security boundaries
 
 ### Process

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -25,6 +25,7 @@
 | 理解工作区“查看目录”与 Agent“实际生效目录” | [UI 指南：工作区模式](./ui-guide.md#工作区模式查看与执行分离) |
 | 检查或更新 Mnemon 与 dsh-mnemon | [运维指南：版本检查与更新](./operations.md#版本检查与更新) |
 | 备份、恢复或迁移完整记忆目录 | [运维指南：备份与恢复](./operations.md#备份与恢复) |
+| 通过云端域名发布 WebUI | [运维指南：云端 WebUI](./operations.md#cloud-hosted-webui) |
 | 排查召回为空、目录未对齐、CLI 或 Provider 问题 | [运维、安全与故障排查](./operations.md#故障排查) |
 | 使用模型工具、`/mnemon` 命令或内部 RPC | [接口参考](./interfaces.md) |
 | 理解 Host、worker、控制面与数据面 | [架构设计](./architecture.md) |

--- a/docs/zh-CN/configuration.md
+++ b/docs/zh-CN/configuration.md
@@ -170,6 +170,8 @@ WebUI 从 `memory-system` 描述符读取真实 Layer，因此扩展插件新增
 
 DSH 0.1.2-alpha.5 已移除逐方法权限层，所有 Mnemon RPC 统一经过一次性启动 token 与签名 Cookie 建立的浏览器会话。它会忽略 `remoteAccess`；该设置仅为同一插件配置安全回滚到 rc.2 而保留。两个版本中的 `writeEnabled=false` 都只是产品级只读模式，不能替代 transport 身份认证。
 
+完整的代理、profile patch、可信 authority、重启与验证流程见[稳定版 DSH rc.2 的云端 WebUI](./operations.md#cloud-hosted-webui)。
+
 ## 存储范围
 
 ### `global`
@@ -356,6 +358,8 @@ Builtin 隐藏页眉中的存储模式标记、工作区选择和对齐控件。
 ## Profile patch 覆盖
 
 包内 `cordis.patch.yml` 提供默认 config 行。DSH profile 的同 ID 配置可能整体覆盖这行。不要在 profile 的最终 patch 中只增加 `cliPath`；请改用 `MNEMON_CLI_PATH` 或用户设置 `mnemon.cliPath`。确因其他原因需要自定义 profile patch 时，应保留仍需启用的全部键，而不是假设深合并。
+
+云端 rc.2 的 `remoteAccess` 覆盖就属于这种整行自定义。请使用[云端 WebUI 操作步骤](./operations.md#cloud-hosted-webui)中的完整、可随升级核对的示例，不要只写 `config: { remoteAccess: trusted-host }` 片段。
 
 ## 常见配置
 

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -113,6 +113,8 @@ dsh plugin --profile web add "link:/absolute/path/to/dsh-mnemon"
 dsh --profile web
 ```
 
+如果需要通过云端域名访问 Web profile，不要直接发布 3080 端口。稳定版 DSH 0.1.1-rc.2 默认只允许回环地址使用 Mnemon 管理通道，因此远程页面可能可以打开，但“记忆系统”无法加载设置或执行写入。请按[稳定版 DSH rc.2 的云端 WebUI](./operations.md#cloud-hosted-webui)同时配置带认证的反向代理、`remoteAccess` 覆盖和可信 authority；同一节也说明了 DSH 0.1.2-alpha.5 不同的启动 token 流程。
+
 升级与卸载：
 
 ```sh

--- a/docs/zh-CN/operations.md
+++ b/docs/zh-CN/operations.md
@@ -102,6 +102,58 @@ DSH rc.8 首次说明的可选 SQLite 不兼容性在 DSH 0.1.1-rc.2 中仍然�
 
 现有回合和已委托的子 Agent activation 可能仍使用旧运行图。迁移或停用其数据前，应等待它们结束或取消这些任务。父回合结束本身不会释放异步子任务的委托；新创建或冷恢复的 activation 会捕获自己获准使用的 generation。
 
+<a id="cloud-hosted-webui"></a>
+
+## 稳定版 DSH 0.1.1-rc.2 的云端 WebUI
+
+稳定版 DSH 0.1.1-rc.2 是推荐的 registry 安装目标。其安全默认值允许受信任的远程浏览器执行普通 Mnemon 读取和激活，但设置、备份、Provider 连接与宽泛 mutation 仍限于回环地址。因此云端页面可能可以打开，“记忆系统”却无法加载设置或完成写入。
+
+仅当公网入口已经具备可靠的用户身份认证时，才执行以下步骤：
+
+1. 在反向代理或访问网关终止 HTTPS 并认证用户。把同源的 `/` 与 `/api` 流量（包括 stream）代理到 `http://127.0.0.1:3080`，同时保留外部 `Host` authority。DSH 的 trusted-host 检查只是 Host/Origin 防线，不是身份认证。
+2. 打开 Web profile 的 `~/.dsh/profiles/web/cordis.patch.yml`；如果设置了 `DSH_HOME`，则路径为 `$DSH_HOME/profiles/web/cordis.patch.yml`。如果文件里已经有顶层 `- id: mnemon`，请直接修改该项，不要再添加重复项。如果初始化后的文件仍以空数组标记 `[]` 结尾，请用下面的完整配置行替换这个标记；否则把该行追加到现有顶层 YAML 列表：
+
+   ```yaml
+   - id: mnemon
+     config:
+       routingGuidance: true
+       lifecycleEnabled: true
+       recallMode: guided
+       writebackMode: guided
+       idleReviewMs: 30000
+       tabEnabled: true
+       writeEnabled: true
+       remoteAccess: trusted-host
+       timeoutMs: 10000
+       defaultRecallLimit: 10
+       embedding:
+         enabled: false
+         endpoint: http://localhost:11434
+         model: nomic-embed-text
+       recallQuality:
+         policy: strict-v1
+         lowScoreThreshold: 0.25
+         highScoreThreshold: 0.6
+         candidateMultiplier: 3
+         maxMediumResults: 4
+         maxUnknownResults: 2
+   ```
+
+   Profile patch 会替换目标行的完整 `config`，不会只深度合并一个字段。请保留已有 Mnemon 自定义项；升级 dsh-mnemon 后用 `dsh web --dump-default-config` 对照这行，避免遮蔽新增的包内默认值。
+3. 运行 `dsh web --dump-config` 检查最终配置树。确认最后的 `mnemon` 行包含 `remoteAccess: trusted-host`，并且 stderr 没有报告无法匹配 `mnemon` 目标。
+4. 使用外部 authority 启动回环服务。参数应为裸 `host[:port]`，不是 URL：
+
+   ```sh
+   dsh web --trusted-host memory.example.com --no-open
+   ```
+
+   公网入口使用非默认端口时，应传入准确 authority，例如 `memory.example.com:8443`。DSH 0.1.1-rc.2 会刻意拒绝 `--host 0.0.0.0`；请让服务保持在回环地址，只由带认证的代理或 SSH tunnel 访问。
+5. 修改 `remoteAccess` 后必须重启 Host，因为 Mnemon 只在启动时捕获该策略。打开外部 HTTPS 地址，通过代理认证，然后确认“状态”和“设置 → 记忆系统”都能加载，并用一次有意的小范围设置保存验证写通道。
+
+如果浏览器提示 Host/Origin 被拒绝，请检查 `--trusted-host`、公网端口，以及代理是否保留 `Host`。如果读取正常但设置或写入仍不可用，请检查最终 `mnemon` 行，并确认 Host 已经重启。
+
+DSH 0.1.2-alpha.5 是安全模型不同的预览兼容目标：它会忽略 `remoteAccess`，并通过一次性启动 token 与签名 Cookie 建立的浏览器会话认证全部 RPC 和 stream。保留上面的配置有利于安全回滚到 rc.2；但每次 alpha Host 重启或公网 authority 变化后，都应打开 DSH 输出的启动 URL 以建立新 Cookie。仍建议使用 HTTPS 与部署层访问控制。
+
 ## 安全边界
 
 ### 进程


### PR DESCRIPTION
## 摘要 / Summary

补充稳定版 DSH 0.1.1-rc.2 云端 WebUI 的完整配置流程，覆盖带认证的 HTTPS 反向代理、完整 Mnemon profile patch、`--trusted-host`、重启与诊断，并说明 DSH 0.1.2-alpha.5 的启动 token / Cookie 差异。
Add a discoverable, bilingual cloud-WebUI procedure for stable DSH 0.1.1-rc.2, including authenticated proxying, the complete Mnemon profile override, trusted authority, restart/diagnostics, and the distinct alpha.5 session flow.

## 关联 Issue 或背景 / Related Issue or Context

Closes #152

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [x] 设置、存储或安全 / Settings, storage, or security
- [x] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [x] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [ ] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [x] 兼容性适配 / Compatibility change
- [x] 维护或重构 / Maintenance or refactor
- [ ] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin main
git rev-parse HEAD
git rev-parse origin/main
```

提交前两者均为 `b2b589ee95ab6987af08a4630f4e95c0c3f6f537`。

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

OpenAI GPT-5

使用的编码 Agent 工具 / Coding Agent tool used:

Codex

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

本 PR 只修改文档，不改变运行时代码、RPC authority、持久化格式或已有数据。流程明确把 DSH 0.1.1-rc.2 作为稳定 registry 基线：`remoteAccess: trusted-host` 仅能在已有可靠身份认证的入口启用，DSH trusted-host 只是 Host/Origin 防线，服务继续绑定回环地址。文档同时说明 profile patch 会整行替换配置，以及升级时必须对照包内默认值。

DSH 0.1.2-alpha.5 会忽略 `remoteAccess`，所有 RPC 由一次性启动 token 与签名 Cookie 保护；保留配置可安全回滚到 rc.2。要回滚 rc.2 的远程管理授权，可将 `remoteAccess` 恢复为 `read-only` 或移除覆盖并重启 Host。没有数据迁移要求。

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
npx --yes --package=node@24.18.0 --package=pnpm@10.13.1 -- pnpm install --frozen-lockfile
npx --yes --package=node@24.18.0 --package=pnpm@10.13.1 -- pnpm run verify

# Isolated published-package smoke
DSH_HOME=<temporary-dsh-home> pnpm exec dsh plugin --profile web add dsh-mnemon@0.4.6
DSH_HOME=<temporary-dsh-home> pnpm exec dsh web --dump-config
DSH_HOME=<temporary-dsh-home> pnpm exec dsh web --trusted-host memory.example.com --port 0 --no-open
```

结果摘要 / Result summary:

- `pnpm run verify` passed: typecheck, 654 tests passed with one Windows-only skip, deterministic output for 110 files, isolated Headless activation, and package validation for 117 files.
- The bilingual cloud patch examples are identical; every new internal link resolves to the explicit `cloud-hosted-webui` anchor.
- A clean isolated DSH 0.1.1-rc.2 profile composed the documented row as `remoteAccess: trusted-host` without an unmatched-target warning.
- The isolated Web service started on loopback with the documented trusted authority. A trusted Host request returned HTTP 200, while an untrusted `/api` request returned HTTP 403.

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence:

N/A for screenshots: this is a documentation-only change and does not alter the rendered product UI. The isolated command evidence above validates both the accepted rc.2 configuration path and the trusted/untrusted Host behavior without using personal configuration, credentials, or memory data.
