### PR TITLE
fix(release): verify npm publications as a cohort

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -131,7 +131,7 @@ function missingRegistryVersion(error) {
 
 export async function inspectRegistryArtifact(name, version, registry = defaultRegistry, run = npm) {
   try {
-    const output = await run(['view', `${name}@${version}`, 'version', 'dist.integrity', '--json', '--registry', registry], root)
+    const output = await run(['view', `${name}@${version}`, 'version', 'dist.integrity', '--json', '--prefer-online', '--registry', registry], root)
     const value = JSON.parse(output)
     return { version: value.version, integrity: value['dist.integrity'] }
   } catch (error) {
@@ -140,17 +140,33 @@ export async function inspectRegistryArtifact(name, version, registry = defaultR
   }
 }
 
-export async function waitForRegistryArtifact(expected, registry, run, inspect, attempts = 30, retryDelayMs = 3_000) {
+export async function waitForRegistryArtifacts(expectedArtifacts, registry, run, inspect, attempts = 90, retryDelayMs = 5_000) {
+  assert(expectedArtifacts.length > 0, 'Expected at least one Registry artifact')
+  const pending = new Map(expectedArtifacts.map(expected => [expected.name, expected]))
+  assert.equal(pending.size, expectedArtifacts.length, 'Registry artifact names must be unique')
+  const published = new Map()
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const published = await inspect(expected.name, expected.version, registry, run)
-    if (published !== null) {
-      assert.equal(published.version, expected.version, `${expected.name}: unexpected Registry version`)
-      assert.equal(published.integrity, expected.integrity, `${expected.name}: Registry bytes differ from the frozen tarball`)
-      return published
+    const inspections = await Promise.all([...pending.values()].map(async expected => ({
+      expected,
+      actual: await inspect(expected.name, expected.version, registry, run),
+    })))
+    for (const { expected, actual } of inspections) {
+      if (actual === null) continue
+      assert.equal(actual.version, expected.version, `${expected.name}: unexpected Registry version`)
+      assert.equal(actual.integrity, expected.integrity, `${expected.name}: Registry bytes differ from the frozen tarball`)
+      pending.delete(expected.name)
+      published.set(expected.name, actual)
     }
+    if (pending.size === 0) return expectedArtifacts.map(expected => published.get(expected.name))
     if (attempt < attempts) await new Promise(resolveDelay => setTimeout(resolveDelay, retryDelayMs))
   }
-  throw new Error(`${expected.name}@${expected.version} did not become readable from ${registry}`)
+  const missing = [...pending.values()].map(expected => `${expected.name}@${expected.version}`).join(', ')
+  throw new Error(`${missing} did not become readable from ${registry}`)
+}
+
+export async function waitForRegistryArtifact(expected, registry, run, inspect, attempts = 90, retryDelayMs = 5_000) {
+  const [published] = await waitForRegistryArtifacts([expected], registry, run, inspect, attempts, retryDelayMs)
+  return published
 }
 
 export async function publishRelease(plan, artifacts, run = npm, {
@@ -161,18 +177,29 @@ export async function publishRelease(plan, artifacts, run = npm, {
 } = {}) {
   assert.deepEqual(artifacts.map(item => item.name), plan.packages.map(item => item.manifest.name), 'Pack the entire release before publishing')
   assert(['all', 'plugins', 'starter'].includes(scope), 'Unknown publication scope')
-  const selected = scope === 'plugins' ? artifacts.slice(0, -1) : scope === 'starter' ? artifacts.slice(-1) : artifacts
-  for (const artifact of selected) {
-    const expected = { ...artifact, version: plan.version }
-    const published = await inspect(artifact.name, plan.version, registry, run)
-    if (published !== null) {
-      assert.equal(published.integrity, artifact.integrity, `${artifact.name}: refusing to reuse a different Registry artifact at the frozen version`)
-      console.log(`Verified existing ${artifact.name}@${plan.version} on ${plan.distTag}`)
-      continue
+  const groups = scope === 'plugins'
+    ? [artifacts.slice(0, -1)]
+    : scope === 'starter'
+      ? [artifacts.slice(-1)]
+      : [artifacts.slice(0, -1), artifacts.slice(-1)]
+  for (const group of groups) {
+    const awaitingRegistry = []
+    for (const artifact of group) {
+      const expected = { ...artifact, version: plan.version }
+      const published = await inspect(artifact.name, plan.version, registry, run)
+      if (published !== null) {
+        assert.equal(published.integrity, artifact.integrity, `${artifact.name}: refusing to reuse a different Registry artifact at the frozen version`)
+        console.log(`Verified existing ${artifact.name}@${plan.version} on ${plan.distTag}`)
+        continue
+      }
+      await run(['publish', artifact.filename, '--access', 'public', '--ignore-scripts', '--tag', plan.distTag, '--registry', registry, ...(provenance ? ['--provenance'] : [])], root)
+      awaitingRegistry.push(expected)
+      console.log(`Submitted ${artifact.name}@${plan.version} to ${plan.distTag}`)
     }
-    await run(['publish', artifact.filename, '--access', 'public', '--ignore-scripts', '--tag', plan.distTag, '--registry', registry, ...(provenance ? ['--provenance'] : [])], root)
-    await waitForRegistryArtifact(expected, registry, run, inspect)
-    console.log(`Published ${artifact.name}@${plan.version} to ${plan.distTag}`)
+    if (awaitingRegistry.length > 0) {
+      await waitForRegistryArtifacts(awaitingRegistry, registry, run, inspect)
+      for (const expected of awaitingRegistry) console.log(`Published ${expected.name}@${plan.version} to ${plan.distTag}`)
+    }
   }
 }
 

--- a/tests/release.spec.mjs
+++ b/tests/release.spec.mjs
@@ -151,6 +151,43 @@ describe('complete, channel-safe official release', () => {
     expect(inspect).toHaveBeenCalledTimes(14)
   })
 
+  it('submits a plugin cohort before waiting for Registry propagation and still exposes the Starter last', async () => {
+    const packages = fixture()
+    const strategy = {
+      directory: '/strategy',
+      manifest: { name: 'dsh-mnemon-strategy-example', version: '0.5.0', publishConfig: { access: 'public', tag: 'latest' } },
+    }
+    packages[0].manifest.devDependencies = { [strategy.manifest.name]: strategy.manifest.version }
+    const plan = createReleasePlan([...packages, strategy])
+    const artifacts = plan.packages.map(item => ({
+      name: item.manifest.name,
+      filename: item.manifest.name + '.tgz',
+      integrity: `sha512-${item.manifest.name}`,
+    }))
+    const submitted = new Set()
+    const events = []
+    const run = vi.fn(async args => {
+      if (args[0] !== 'publish') return ''
+      const artifact = artifacts.find(item => item.filename === args[1])
+      submitted.add(artifact.name)
+      events.push(`submit:${artifact.name}`)
+      return ''
+    })
+    const inspect = vi.fn(async name => {
+      const pluginCohortReady = plan.plugins.every(item => submitted.has(item.manifest.name))
+      const visible = submitted.has(name) && (name === plan.starter.manifest.name || pluginCohortReady)
+      if (!visible) return null
+      events.push(`visible:${name}`)
+      return { version: plan.version, integrity: `sha512-${name}` }
+    })
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    try { await publishRelease(plan, artifacts, run, { inspect }) } finally { log.mockRestore() }
+    const lastPluginSubmit = Math.max(...plan.plugins.map(item => events.indexOf(`submit:${item.manifest.name}`)))
+    const firstPluginVisible = Math.min(...plan.plugins.map(item => events.indexOf(`visible:${item.manifest.name}`)))
+    expect(lastPluginSubmit).toBeLessThan(firstPluginVisible)
+    expect(firstPluginVisible).toBeLessThan(events.indexOf(`submit:${plan.starter.manifest.name}`))
+  })
+
   it('installs the frozen Starter and verifies every Registry plugin manifest', async () => {
     const plan = createReleasePlan(fixture())
     const artifacts = plan.packages.map(item => ({


### PR DESCRIPTION
## 摘要 / Summary

将 npm 发布从逐包短等待改为插件 cohort 提交后统一并行回读，最长容忍约 7.5 分钟 Registry 传播，并强制元数据检查优先联网。Starter 仍在全部插件可读且 integrity 与冻结 tarball 一致后才发布。

## 关联 Issue 或背景 / Related Issue or Context

Fixes the recoverable release failures in [workflow run 33827258739](https://github.com/omdsh-dev/dsh-mnemon/actions/runs/33827258739) and [workflow run 33828513795](https://github.com/omdsh-dev/dsh-mnemon/actions/runs/33828513795). Both npm publish calls succeeded; Registry metadata became readable only after the bounded per-package window. No product Issue is needed for this maintainer release hotfix.

## 涉及区域 / Affected Areas

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆体或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [x] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [x] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [ ] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

`git switch -c codex/fix-stable-registry-cohort-wait main`

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

OpenAI GPT-5 (Codex)

使用的编码 Agent 工具 / Coding Agent tool used:

Codex

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-visible copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

不改变运行时、配置、RPC、存储格式或包内容。所有版本依然不可变：恢复时只复用与冻结 tarball integrity 完全相同的已存在版本，否则立即拒绝。插件作为 cohort 验明后才允许发布 Starter，因此默认安装入口不会引用未验证的插件集合。

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm exec vitest run tests/release.spec.mjs tests/version-updates.spec.ts
pnpm typecheck
RELEASE_TAG=v0.5.0 RELEASE_PRERELEASE=false pnpm release:check
git diff --check
```

结果摘要 / Result summary:

全部通过。34 个定向测试通过；新增用例证明同组插件全部提交后才等待传播，且 Starter 必须等插件 cohort 可见后才提交。根类型检查、17 包 stable release plan 与 diff 检查通过。

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence:

N/A。仅修改发布事务的 Registry 传播处理，不改变产品或 WebUI。合并后会以新的冻结 main revision 重跑完整验证、独立插件 E2E、Registry 安装和真实 v0.4.7 升级 smoke。