### PR TITLE
fix(ci): validate consumed release changesets

### DIFF
--- a/scripts/check-release-intent.mjs
+++ b/scripts/check-release-intent.mjs
@@ -1,17 +1,19 @@
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
 import { createRequire } from 'node:module'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import {
+  assertVersionedPublicationChanges,
   createReleasePlan,
   devOnlyManifestChanges,
   publicationInputsChanged,
   readChangedPaths,
   readReleasePackages,
+  readReleaseVersionsAtRevision,
 } from './release.mjs'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -31,6 +33,13 @@ export function assertReleaseIntentCoverage(changedPackages, releases) {
   return covered
 }
 
+export function assertVersionedReleaseIntent(plan, paths, options, pendingChangesets) {
+  assert(plan.selectionComputed && plan.releasePackages.length > 0, 'Expected a versioned release plan')
+  assert.equal(pendingChangesets.length, 0, `Release pull request still contains pending changesets: ${pendingChangesets.join(', ')}`)
+  assertVersionedPublicationChanges(plan, paths, options)
+  return new Set(plan.releasePackages.map(item => item.manifest.name))
+}
+
 async function readChangesetStatusSince(baseRevision) {
   const directory = await mkdtemp(join(tmpdir(), 'mnemon-changeset-status-'))
   const output = join(directory, 'status.json')
@@ -46,22 +55,36 @@ async function readChangesetStatusSince(baseRevision) {
   }
 }
 
+async function readPendingChangesets() {
+  return (await readdir(join(root, '.changeset')))
+    .filter(name => name.endsWith('.md') && name !== 'README.md')
+    .sort()
+}
+
 async function main() {
   const revision = process.env.CHANGESET_REVISION?.trim() || await git(['rev-parse', 'HEAD'])
   const baseRevision = process.env.CHANGESET_BASE_REVISION?.trim() || await git(['merge-base', revision, 'origin/main'])
   for (const value of [baseRevision, revision]) assert.match(value, /^[0-9a-f]{40}$/u, 'Changeset validation requires full Git revisions')
 
   const packages = await readReleasePackages()
-  const plan = createReleasePlan(packages)
+  const baseVersions = await readReleaseVersionsAtRevision(packages, baseRevision)
+  const plan = createReleasePlan(packages, { baseVersions })
   const paths = await readChangedPaths(baseRevision, revision)
   const ignoredPackageJson = await devOnlyManifestChanges(plan, paths, baseRevision, revision)
   const changedPackages = publicationInputsChanged(plan, paths, { ignoredPackageJson })
+  if (plan.releasePackages.length > 0) {
+    const covered = assertVersionedReleaseIntent(plan, paths, { ignoredPackageJson }, await readPendingChangesets())
+    console.log(`Verified consumed changesets and version coverage for release packages: ${[...covered].sort().join(', ')}.`)
+    return
+  }
+  if (changedPackages.size === 0) {
+    console.log('No published package inputs changed; no release intent is required.')
+    return
+  }
   const status = await readChangesetStatusSince(baseRevision)
   assertReleaseIntentCoverage(changedPackages, status.releases)
 
-  console.log(changedPackages.size === 0
-    ? 'No published package inputs changed; no release intent is required.'
-    : `Verified changeset coverage for ${[...changedPackages].sort().join(', ')}.`)
+  console.log(`Verified changeset coverage for ${[...changedPackages].sort().join(', ')}.`)
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) await main()

--- a/tests/changesets.spec.mjs
+++ b/tests/changesets.spec.mjs
@@ -6,6 +6,8 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import { describe, expect, it } from 'vitest'
+import { assertVersionedReleaseIntent } from '../scripts/check-release-intent.mjs'
+import { createReleasePlan } from '../scripts/release.mjs'
 
 const execute = promisify(execFile)
 const require = createRequire(import.meta.url)
@@ -72,5 +74,38 @@ describe('independent package versioning', () => {
     } finally {
       await rm(directory, { recursive: true, force: true })
     }
+  })
+
+  it('accepts a release PR that consumed its changesets and rejects incomplete version coverage', () => {
+    const pluginName = 'dsh-mnemon-source-example'
+    const packages = [
+      {
+        directory: `/fixture/plugins/${pluginName}`,
+        manifest: published(pluginName, '0.5.2', { peerDependencies: { 'dsh-mnemon': '^0.5.1' } }),
+      },
+      {
+        directory: '/fixture',
+        manifest: published('dsh-mnemon', '0.5.2', { dependencies: { [pluginName]: '0.5.2' } }),
+      },
+    ]
+    const plan = createReleasePlan(packages, { baseVersions: new Map([
+      ['dsh-mnemon', '0.5.1'],
+      [pluginName, '0.5.1'],
+    ]) })
+    const paths = ['package.json', `plugins/${pluginName}/package.json`]
+
+    expect(() => assertVersionedReleaseIntent(plan, paths, { ignoredPackageJson: new Set() }, [])).not.toThrow()
+    expect(() => assertVersionedReleaseIntent(plan, paths, { ignoredPackageJson: new Set() }, ['pending.md']))
+      .toThrow(/still contains pending changesets/u)
+
+    const incompletePackages = packages.map(item => item.manifest.name === pluginName
+      ? { ...item, manifest: { ...item.manifest, version: '0.5.1' } }
+      : { ...item, manifest: { ...item.manifest, dependencies: { [pluginName]: '0.5.1' } } })
+    const incompletePlan = createReleasePlan(incompletePackages, { baseVersions: new Map([
+      ['dsh-mnemon', '0.5.1'],
+      [pluginName, '0.5.1'],
+    ]) })
+    expect(() => assertVersionedReleaseIntent(incompletePlan, paths, { ignoredPackageJson: new Set() }, []))
+      .toThrow(/without a version bump: dsh-mnemon-source-example/u)
   })
 })


### PR DESCRIPTION
## 摘要 / Summary

修正发布意图校验：发布 PR 在版本更新并消费 changeset 后，不再被 `changeset status --since` 误判为缺少 changeset。校验现在分别处理纯 CI/测试改动、普通源码 PR 和已版本化发布 PR，并继续阻止漏升版本或残留 changeset 的发布。

## 关联 Issue 或背景 / Related Issue or Context

N/A。准备 v0.5.2 发布 PR 时发现的 CI 边界问题；该修复按约定作为独立 CI PR 提交，是后续发布 PR 的前置条件。

## 涉及区域 / Affected Areas

- [x] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation

## PR 类型 / PR Type

- [x] Bug 修复 / Bug fix
- [x] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

`git fetch origin && git rebase origin/main`

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

OpenAI GPT-5.6

使用的编码 Agent 工具 / Coding Agent tool used:

Codex

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以 `src/shared/contracts.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses `src/shared/contracts.ts` as the single source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 会改变发布制品或其元数据的 PR 已添加 changeset；仅测试、CI 或站点文档变更可不添加。 / A PR that changes a published artifact or its metadata includes a changeset; test-only, CI-only, and site-documentation-only changes may omit one.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

仅修改 CI 发布意图判定与回归测试，不改变 DSH、Mnemon、Provider、配置、存储格式或用户数据。普通源码 PR 仍需 changeset；发布 PR 还会验证所有发布输入都有对应版本提升，并拒绝残留 changeset。

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
npx --yes pnpm@10.13.1 exec vitest run tests/changesets.spec.mjs tests/release.spec.mjs
npx --yes pnpm@10.13.1 run test:root
CHANGESET_BASE_REVISION=77624df9428e52b48f216f320b713bee3c1ad304 CHANGESET_REVISION=91c9c6293b31fde0a0e223dcacb36a55d7d46473 npx --yes pnpm@10.13.1 run release:intent
git diff --check
```

结果摘要 / Result summary:

聚焦回归 20/20 通过；根测试 68 个文件、730/730 测试通过；CI-only 分支的发布意图集成校验通过；diff 检查通过。测试输出仅包含上游 `@deepseek-ai/dsh-client-ui-primitives` 缺失 source map 的既有非阻断警告。

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence:

N/A。该 PR 仅修正内部 CI 发布校验，不改变用户界面或运行时行为。
