### PR TITLE
fix(rpc): route paired remote calls through API gateway

### DIFF
--- a/.changeset/quiet-rivers-route.md
+++ b/.changeset/quiet-rivers-route.md
@@ -1,0 +1,5 @@
+---
+"dsh-mnemon": patch
+---
+
+Route paired browser RPCs through DSH's authenticated API Gateway while retaining legacy channels and requiring the existing trusted-host grant for management operations.

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6 || ^0.1.1-rc.1 || ^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6 || ^0.1.1-rc.1 || ^0.1.2-alpha.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -171,6 +172,7 @@
     "@deepseek-ai/dsh": "0.1.2-rc.1",
     "@deepseek-ai/dsh-agent": "0.1.2-rc.1",
     "@deepseek-ai/dsh-agent-loop": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-api-gateway": "0.1.2-rc.1",
     "@deepseek-ai/dsh-client-connection": "0.1.2-rc.1",
     "@deepseek-ai/dsh-client-locale": "0.1.2-rc.1",
     "@deepseek-ai/dsh-client-store": "0.1.2-rc.1",
@@ -192,6 +194,8 @@
     "@deepseek-ai/dsh-subagent-spawn-in-process": "0.1.2-rc.1",
     "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1",
     "@deepseek-ai/dsh-tools": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-typert-protocol": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-typert-registry": "0.1.2-rc.1",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@deepseek-ai/dsh-agent-loop':
         specifier: 0.1.2-rc.1
         version: 0.1.2-rc.1(b439f35cbe316bcb469bc5c5afd8b06f)
+      '@deepseek-ai/dsh-api-gateway':
+        specifier: 0.1.2-rc.1
+        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-client-connection':
         specifier: 0.1.2-rc.1
         version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
@@ -147,6 +150,12 @@ importers:
       '@deepseek-ai/dsh-tools':
         specifier: 0.1.2-rc.1
         version: 0.1.2-rc.1(de5e1ff2d608fbe22667925341ad1dfc)
+      '@deepseek-ai/dsh-typert-protocol':
+        specifier: 0.1.2-rc.1
+        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-typert-registry':
+        specifier: 0.1.2-rc.1
+        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -28,6 +28,7 @@ import {
   type VersionStatus,
   type VersionUpdateResult,
 } from "../host/protocol.ts"
+import { callMnemonRpc } from './remote-rpc.ts'
 
 interface TurnActivityCacheEntry {
   cursor: number
@@ -55,7 +56,7 @@ async function loadTurnActivities(connection: ClientConnectionHandle, sessionId:
     return snapshot.cursor >= requiredCursor ? snapshot : loadTurnActivities(connection, sessionId, requiredCursor)
   }
 
-  const request = connection.rpc.call(MNEMON_READ_CHANNEL, 'turn-activities', sessionId === undefined ? {} : { sessionId })
+  const request = callMnemonRpc(connection, MNEMON_READ_CHANNEL, 'turn-activities', sessionId === undefined ? {} : { sessionId })
     .then(response => {
       if (!response.ok) throw new Error(response.error.message)
       const snapshot = response.value as TurnMemoryActivitySnapshot
@@ -72,7 +73,7 @@ export class MnemonClient {
   constructor(private readonly connection: ClientConnectionHandle, private readonly sessionId?: string, private readonly workspaceId?: string) {}
 
   private async call<T>(channel: string, endpoint: string, payload: unknown): Promise<T> {
-    const response = await this.connection.rpc.call(channel, endpoint, payload)
+    const response = await callMnemonRpc(this.connection, channel, endpoint, payload)
     if (!response.ok) throw new Error(response.error.message)
     return response.value as T
   }

--- a/src/client/remote-rpc.ts
+++ b/src/client/remote-rpc.ts
@@ -1,0 +1,75 @@
+import {
+  MNEMON_ACTIVATION_CHANNEL,
+  MNEMON_PACK_CHANNEL,
+  MNEMON_READ_CHANNEL,
+  MNEMON_REMOTE_ACTIVATION_ENDPOINT,
+  MNEMON_REMOTE_CHANNEL,
+  MNEMON_REMOTE_PACK_ENDPOINT,
+  MNEMON_REMOTE_READ_ENDPOINT,
+  MNEMON_REMOTE_SETTINGS_ENDPOINT,
+  MNEMON_REMOTE_VIEW_ENDPOINT,
+  MNEMON_REMOTE_VIEW_WRITE_ENDPOINT,
+  MNEMON_REMOTE_WRITE_ENDPOINT,
+  MNEMON_SETTINGS_CHANNEL,
+  MNEMON_VIEW_CHANNEL,
+  MNEMON_VIEW_WRITE_CHANNEL,
+  MNEMON_WRITE_CHANNEL,
+  type ClientConnectionHandle,
+} from '../host/protocol.ts'
+
+type ClientRpcResult = Awaited<ReturnType<ClientConnectionHandle['rpc']['call']>>
+
+const REMOTE_ENDPOINT = new Map<string, string>([
+  [MNEMON_READ_CHANNEL, MNEMON_REMOTE_READ_ENDPOINT],
+  [MNEMON_ACTIVATION_CHANNEL, MNEMON_REMOTE_ACTIVATION_ENDPOINT],
+  [MNEMON_WRITE_CHANNEL, MNEMON_REMOTE_WRITE_ENDPOINT],
+  [MNEMON_PACK_CHANNEL, MNEMON_REMOTE_PACK_ENDPOINT],
+  [MNEMON_SETTINGS_CHANNEL, MNEMON_REMOTE_SETTINGS_ENDPOINT],
+  [MNEMON_VIEW_CHANNEL, MNEMON_REMOTE_VIEW_ENDPOINT],
+  [MNEMON_VIEW_WRITE_CHANNEL, MNEMON_REMOTE_VIEW_WRITE_ENDPOINT],
+])
+
+function isClientRpcResult(value: unknown): value is ClientRpcResult {
+  if (typeof value !== 'object' || value === null || !Object.hasOwn(value, 'ok')) return false
+  const candidate = value as { ok?: unknown; value?: unknown; error?: unknown }
+  if (candidate.ok === true) return Object.hasOwn(candidate, 'value')
+  if (candidate.ok !== false || typeof candidate.error !== 'object' || candidate.error === null) return false
+  return typeof (candidate.error as { message?: unknown }).message === 'string'
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  if (hostname === 'localhost' || hostname === '[::1]') return true
+  const parts = hostname.split('.')
+  return parts.length === 4
+    && parts[0] === '127'
+    && parts.every(part => /^\d{1,3}$/.test(part) && Number(part) <= 255)
+}
+
+function isRemoteConnection(connection: ClientConnectionHandle): boolean {
+  const hostname = globalThis.location?.hostname
+  const remotePage = typeof hostname === 'string' && hostname !== '' && !isLoopbackHostname(hostname)
+  return remotePage || connection.isLoopback === false
+}
+
+/** Route only paired remote pages through API Gateway; local clients retain legacy channels. */
+export async function callMnemonRpc(
+  connection: ClientConnectionHandle,
+  channel: string,
+  endpoint: string,
+  payload: unknown,
+  signal?: AbortSignal,
+): Promise<ClientRpcResult> {
+  const remoteEndpoint = REMOTE_ENDPOINT.get(channel)
+  if (!isRemoteConnection(connection) || remoteEndpoint === undefined) {
+    return signal === undefined
+      ? connection.rpc.call(channel, endpoint, payload)
+      : connection.rpc.call(channel, endpoint, payload, signal)
+  }
+  const remotePayload = { args: { endpoint, payload } }
+  const response = await (signal === undefined
+    ? connection.rpc.call(MNEMON_REMOTE_CHANNEL, remoteEndpoint, remotePayload)
+    : connection.rpc.call(MNEMON_REMOTE_CHANNEL, remoteEndpoint, remotePayload, signal))
+  if (!response.ok) return response
+  if (!isClientRpcResult(response.value)) throw new Error('DSH API Gateway returned an invalid Mnemon response')
+  return response.value
+}

--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -6,6 +6,7 @@ import {
   type ClientSettingsSnapshot,
   type SettingsOperation,
 } from "../host/protocol.ts"
+import { callMnemonRpc } from './remote-rpc.ts'
 
 export class MnemonSettingsScope<T extends object> implements ClientSettingsScope<T> {
   private snapshot: ClientSettingsSnapshot<T> = { status: 'loading', writable: false, mode: 'host' }
@@ -83,7 +84,7 @@ export class MnemonSettingsScope<T extends object> implements ClientSettingsScop
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), Math.max(1, this.requestTimeoutMs))
     try {
-      return await this.connection.rpc.call(MNEMON_SETTINGS_CHANNEL, endpoint, payload, controller.signal)
+      return await callMnemonRpc(this.connection, MNEMON_SETTINGS_CHANNEL, endpoint, payload, controller.signal)
     } catch (error) {
       if (controller.signal.aborted) throw new Error('Mnemon settings request timed out')
       throw error

--- a/src/host/plugin.ts
+++ b/src/host/plugin.ts
@@ -1,3 +1,4 @@
+import { Context } from '@deepseek-ai/cordis'
 import { Config, InteractionConfig, resolveConfig, resolveInteractionConfig, type Config as MnemonConfig } from './config.ts'
 import { registerCommands } from './commands.ts'
 import type { HostContextShape, HostWorkspaceRegistry } from './dsh.ts'
@@ -13,6 +14,7 @@ import { provideMemoryRuntime } from '../core/runtime.ts'
 import { MemoryPluginManagement } from './plugin-management.ts'
 import { registerViewRpc } from './view-rpc.ts'
 import { MemoryPluginInstallation } from './plugin-installation.ts'
+import { MnemonRemoteService } from './remote-rpc.ts'
 
 export const name = 'dsh-mnemon'
 export const provide = ['mnemonMemory']
@@ -121,8 +123,17 @@ export function apply(rawContext: unknown, config: MnemonConfig = {}): void {
     // rc.2 enforces this legacy channel authority, while 0.1.2-alpha.1 ignores
     // the extra JavaScript argument and authenticates every Host API uniformly.
     const managementAuthority = resolved.remoteAccess === 'trusted-host' ? 'trusted-host' : 'loopback'
-    registerRpc(webContext.connection, runtime, lifecycle, undefined, managementAuthority)
-    registerSettingsRpc(webContext.connection, ctx.settings, managementAuthority)
-    registerViewRpc(webContext.connection, runtime, extensions, memoryPlugins, lifecycle, managementAuthority, pluginInstallation)
+    const rpc = registerRpc(webContext.connection, runtime, lifecycle, undefined, managementAuthority)
+    const settings = registerSettingsRpc(webContext.connection, ctx.settings, managementAuthority)
+    const view = registerViewRpc(webContext.connection, runtime, extensions, memoryPlugins, lifecycle, managementAuthority, pluginInstallation)
+    if (Context.is(webContext)) {
+      new MnemonRemoteService(webContext, {
+        ...rpc,
+        settings,
+        view: view.read,
+        viewWrite: view.write,
+        management: managementAuthority === 'trusted-host',
+      })
+    }
   })
 }

--- a/src/host/protocol.ts
+++ b/src/host/protocol.ts
@@ -29,6 +29,16 @@ export const MNEMON_ACTIVATION_CHANNEL = '/dsh-mnemon-activation'
 export const MNEMON_WRITE_CHANNEL = '/dsh-mnemon-write'
 export const MNEMON_PACK_CHANNEL = '/dsh-mnemon-pack'
 export const MNEMON_SETTINGS_CHANNEL = '/dsh-mnemon-settings'
+/** DSH API Gateway endpoints used by paired remote Web clients. */
+export const MNEMON_REMOTE_CHANNEL = '/api'
+export const MNEMON_REMOTE_NAMESPACE = 'dshMnemon'
+export const MNEMON_REMOTE_READ_ENDPOINT = `${MNEMON_REMOTE_NAMESPACE}/read`
+export const MNEMON_REMOTE_ACTIVATION_ENDPOINT = `${MNEMON_REMOTE_NAMESPACE}/activation`
+export const MNEMON_REMOTE_WRITE_ENDPOINT = `${MNEMON_REMOTE_NAMESPACE}/write`
+export const MNEMON_REMOTE_PACK_ENDPOINT = `${MNEMON_REMOTE_NAMESPACE}/pack`
+export const MNEMON_REMOTE_SETTINGS_ENDPOINT = `${MNEMON_REMOTE_NAMESPACE}/settings`
+export const MNEMON_REMOTE_VIEW_ENDPOINT = `${MNEMON_REMOTE_NAMESPACE}/view`
+export const MNEMON_REMOTE_VIEW_WRITE_ENDPOINT = `${MNEMON_REMOTE_NAMESPACE}/viewWrite`
 export const MNEMON_SETTINGS_NAMESPACE = 'mnemon'
 export const MNEMON_UI_SETTINGS_NAMESPACE = 'mnemon-ui'
 export * from './view-protocol.ts'

--- a/src/host/remote-rpc.ts
+++ b/src/host/remote-rpc.ts
@@ -1,0 +1,90 @@
+import type { Context } from '@deepseek-ai/cordis'
+import { Remote, TypertRemoteService } from '@deepseek-ai/dsh-typert-protocol'
+import type { HostRpcHandler, RpcResult } from './dsh.ts'
+import { MNEMON_REMOTE_NAMESPACE } from './protocol.ts'
+
+export interface MnemonRemoteHandlers {
+  readonly read: HostRpcHandler
+  readonly activation: HostRpcHandler
+  readonly write: HostRpcHandler
+  readonly pack: HostRpcHandler
+  readonly settings: HostRpcHandler
+  readonly view: HostRpcHandler
+  readonly viewWrite: HostRpcHandler
+  readonly management: boolean
+}
+
+function denied(): RpcResult<unknown> {
+  return {
+    ok: false,
+    error: {
+      code: 'bad-request',
+      message: 'remote Mnemon management requires remoteAccess: trusted-host',
+      details: { issues: [] },
+    },
+  }
+}
+
+function unknownSettingsEndpoint(endpoint: string): RpcResult<unknown> {
+  return {
+    ok: false,
+    error: {
+      code: 'bad-request',
+      message: `unknown remote Mnemon settings endpoint: ${endpoint}`,
+      details: { issues: [] },
+    },
+  }
+}
+
+/**
+ * Project Mnemon's existing handlers through DSH API Gateway. The Gateway owns
+ * `/api`, Host/Origin validation, browser pairing, and response envelopes;
+ * this Service retains Mnemon's narrower management grant.
+ */
+export class MnemonRemoteService extends TypertRemoteService {
+  constructor(ctx: Context, private readonly handlers: MnemonRemoteHandlers) {
+    super(ctx, 'mnemonRemote', { namespace: MNEMON_REMOTE_NAMESPACE })
+  }
+
+  @Remote('read')
+  read(endpoint: string, payload: unknown, signal: AbortSignal): Promise<RpcResult<unknown>> {
+    return this.handlers.read(endpoint, payload, signal)
+  }
+
+  @Remote('activation')
+  activation(endpoint: string, payload: unknown, signal: AbortSignal): Promise<RpcResult<unknown>> {
+    return this.handlers.activation(endpoint, payload, signal)
+  }
+
+  @Remote('write')
+  write(endpoint: string, payload: unknown, signal: AbortSignal): Promise<RpcResult<unknown>> {
+    if (!this.handlers.management) return Promise.resolve(denied())
+    return this.handlers.write(endpoint, payload, signal)
+  }
+
+  @Remote('pack')
+  pack(endpoint: string, payload: unknown, signal: AbortSignal): Promise<RpcResult<unknown>> {
+    if (!this.handlers.management) return Promise.resolve(denied())
+    return this.handlers.pack(endpoint, payload, signal)
+  }
+
+  @Remote('settings')
+  async settings(endpoint: string, payload: unknown, signal: AbortSignal): Promise<RpcResult<unknown>> {
+    if (endpoint === 'mutate' && !this.handlers.management) return denied()
+    if (endpoint !== 'get' && endpoint !== 'mutate') return unknownSettingsEndpoint(endpoint)
+    const response = await this.handlers.settings(endpoint, payload, signal)
+    if (endpoint !== 'get' || this.handlers.management || !response.ok || typeof response.value !== 'object' || response.value === null || Array.isArray(response.value)) return response
+    return { ...response, value: { ...(response.value as Record<string, unknown>), writable: false } }
+  }
+
+  @Remote('view')
+  view(endpoint: string, payload: unknown, signal: AbortSignal): Promise<RpcResult<unknown>> {
+    return this.handlers.view(endpoint, payload, signal)
+  }
+
+  @Remote('viewWrite')
+  viewWrite(endpoint: string, payload: unknown, signal: AbortSignal): Promise<RpcResult<unknown>> {
+    if (!this.handlers.management) return Promise.resolve(denied())
+    return this.handlers.viewWrite(endpoint, payload, signal)
+  }
+}

--- a/src/host/rpc.ts
+++ b/src/host/rpc.ts
@@ -353,10 +353,20 @@ export function createPackHandler(input: LiveMnemonRuntime): HostRpcHandler {
   }
 }
 
-export function registerRpc(connection: HostConnectionHandle, input: LiveMnemonRuntime, lifecycle?: MnemonLifecycle, versions?: VersionUpdateManager, managementAuthority: HostRpcAuthority = 'loopback'): void {
+export function registerRpc(connection: HostConnectionHandle, input: LiveMnemonRuntime, lifecycle?: MnemonLifecycle, versions?: VersionUpdateManager, managementAuthority: HostRpcAuthority = 'loopback'): {
+  read: HostRpcHandler
+  activation: HostRpcHandler
+  write: HostRpcHandler
+  pack: HostRpcHandler
+} {
   const versionManager = versions ?? new VersionUpdateManager({ mnemonCliPath: () => input.config.cliPath })
-  connection.rpc.handle(MNEMON_READ_CHANNEL, createReadHandler(input, lifecycle, versionManager), { authority: 'trusted-host' })
-  connection.rpc.handle(MNEMON_ACTIVATION_CHANNEL, createActivationHandler(input), { authority: 'trusted-host' })
-  connection.rpc.handle(MNEMON_WRITE_CHANNEL, createWriteHandler(input, lifecycle, versionManager), { authority: managementAuthority })
-  connection.rpc.handle(MNEMON_PACK_CHANNEL, createPackHandler(input), { authority: managementAuthority })
+  const readHandler = createReadHandler(input, lifecycle, versionManager)
+  const activationHandler = createActivationHandler(input)
+  const writeHandler = createWriteHandler(input, lifecycle, versionManager)
+  const packHandler = createPackHandler(input)
+  connection.rpc.handle(MNEMON_READ_CHANNEL, readHandler, { authority: 'trusted-host' })
+  connection.rpc.handle(MNEMON_ACTIVATION_CHANNEL, activationHandler, { authority: 'trusted-host' })
+  connection.rpc.handle(MNEMON_WRITE_CHANNEL, writeHandler, { authority: managementAuthority })
+  connection.rpc.handle(MNEMON_PACK_CHANNEL, packHandler, { authority: managementAuthority })
+  return { read: readHandler, activation: activationHandler, write: writeHandler, pack: packHandler }
 }

--- a/src/host/settings.ts
+++ b/src/host/settings.ts
@@ -137,6 +137,8 @@ export function createSettingsHandler(settings: HostSettingsService): HostRpcHan
   }
 }
 
-export function registerSettingsRpc(connection: HostConnectionHandle, settings: HostSettingsService, authority: HostRpcAuthority = 'loopback'): void {
-  connection.rpc.handle(MNEMON_SETTINGS_CHANNEL, createSettingsHandler(settings), { authority })
+export function registerSettingsRpc(connection: HostConnectionHandle, settings: HostSettingsService, authority: HostRpcAuthority = 'loopback'): HostRpcHandler {
+  const handler = createSettingsHandler(settings)
+  connection.rpc.handle(MNEMON_SETTINGS_CHANNEL, handler, { authority })
+  return handler
 }

--- a/src/host/view-rpc.ts
+++ b/src/host/view-rpc.ts
@@ -74,7 +74,13 @@ export function createViewHandler(runtime: LiveMnemonRuntime, engine: MemoryRunt
   }
 }
 
-export function registerViewRpc(connection: HostConnectionHandle, runtime: LiveMnemonRuntime, engine: MemoryRuntime, management: MemoryPluginManagement, lifecycle: MnemonLifecycle, authority: HostRpcAuthority, installation?: MemoryPluginInstallation): void {
-  connection.rpc.handle(MNEMON_VIEW_CHANNEL, createViewHandler(runtime, engine, management, 'read', lifecycle, installation), { authority: 'trusted-host' })
-  connection.rpc.handle(MNEMON_VIEW_WRITE_CHANNEL, createViewHandler(runtime, engine, management, 'write', lifecycle, installation), { authority })
+export function registerViewRpc(connection: HostConnectionHandle, runtime: LiveMnemonRuntime, engine: MemoryRuntime, management: MemoryPluginManagement, lifecycle: MnemonLifecycle, authority: HostRpcAuthority, installation?: MemoryPluginInstallation): {
+  read: HostRpcHandler
+  write: HostRpcHandler
+} {
+  const readHandler = createViewHandler(runtime, engine, management, 'read', lifecycle, installation)
+  const writeHandler = createViewHandler(runtime, engine, management, 'write', lifecycle, installation)
+  connection.rpc.handle(MNEMON_VIEW_CHANNEL, readHandler, { authority: 'trusted-host' })
+  connection.rpc.handle(MNEMON_VIEW_WRITE_CHANNEL, writeHandler, { authority })
+  return { read: readHandler, write: writeHandler }
 }

--- a/tests/client-api.spec.ts
+++ b/tests/client-api.spec.ts
@@ -27,6 +27,66 @@ describe('MnemonClient product transport', () => {
     }]])
   })
 
+  it('routes a paired remote client through namespaced shared endpoints', async () => {
+    const call = vi.fn(async (_channel: string, _endpoint: string, _payload: unknown) => ({
+      ok: true as const,
+      value: { ok: true as const, value: {} },
+    }))
+    const client = new MnemonClient({ isLoopback: false, rpc: { call } } as ClientConnectionHandle, 'session-1')
+    await client.statusSummary()
+    await client.mutateSourceManagement('source:spaces', 'body-update', {}, 'r1', true)
+    await client.assistSource('source:spaces', 'activation', { memoryBodyId: 'project', active: true }, 'r1', true)
+    await client.packTarget()
+    await client.applyView({ expectedRevision: 'view-1', strategyTypeId: 'default-three-tier', entries: {} })
+
+    expect(call.mock.calls.map(([channel, endpoint, payload]) => [channel, endpoint, (payload as { args: { endpoint: string } }).args.endpoint])).toEqual([
+      ['/api', 'dshMnemon/read', 'status-summary'],
+      ['/api', 'dshMnemon/write', 'source-management-mutate'],
+      ['/api', 'dshMnemon/activation', 'source-assistance'],
+      ['/api', 'dshMnemon/pack', 'target'],
+      ['/api', 'dshMnemon/viewWrite', 'apply'],
+    ])
+    expect(call.mock.calls[0]?.[2]).toEqual({ args: { endpoint: 'status-summary', payload: { sessionId: 'session-1' } } })
+  })
+
+  it('detects a paired remote page when an older Connection omits isLoopback', async () => {
+    vi.stubGlobal('location', { hostname: 'rsi.example' })
+    try {
+      const call = vi.fn(async () => ({
+        ok: true as const,
+        value: { ok: true as const, value: { healthy: true } },
+      }))
+      const client = new MnemonClient({ rpc: { call } } as ClientConnectionHandle, 'session-1')
+
+      await client.statusSummary()
+
+      expect(call).toHaveBeenCalledWith('/api', 'dshMnemon/read', {
+        args: { endpoint: 'status-summary', payload: { sessionId: 'session-1' } },
+      })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('uses the page origin when a remote desktop reports host ownership as loopback', async () => {
+    vi.stubGlobal('location', { hostname: 'rsi.example' })
+    try {
+      const call = vi.fn(async () => ({
+        ok: true as const,
+        value: { ok: true as const, value: { healthy: true } },
+      }))
+      const client = new MnemonClient({ isLoopback: true, rpc: { call } } as ClientConnectionHandle)
+
+      await client.statusSummary()
+
+      expect(call).toHaveBeenCalledWith('/api', 'dshMnemon/read', {
+        args: { endpoint: 'status-summary', payload: {} },
+      })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('shares one bulk projection across all turn tails until the durable cursor advances', async () => {
     let cursor = 7
     const call = vi.fn(async (_channel: string, endpoint: string) => {

--- a/tests/client-interaction-surfaces.spec.tsx
+++ b/tests/client-interaction-surfaces.spec.tsx
@@ -48,6 +48,18 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
+function remoteRpc(domain: (endpoint: string, payload: Record<string, unknown>) => unknown | Promise<unknown>) {
+  return vi.fn(async (channel: string, remoteEndpoint: string, rawArgs: unknown) => {
+    if (channel !== '/api' || !remoteEndpoint.startsWith('dshMnemon/')) throw new Error(`unexpected remote endpoint: ${channel} ${remoteEndpoint}`)
+    const args = (rawArgs as { args: { endpoint: string; payload: Record<string, unknown> } }).args
+    return { ok: true as const, value: await domain(args.endpoint, args.payload) }
+  })
+}
+
+function calledRemote(call: ReturnType<typeof remoteRpc>, endpoint: string): boolean {
+  return call.mock.calls.some(([, , rawArgs]) => (rawArgs as { args?: { endpoint?: string } }).args?.endpoint === endpoint)
+}
+
 describe('conversation interaction surfaces', () => {
   it('consumes a delivered anchor instead of replaying it after remount', () => {
     const received: string[] = []
@@ -146,7 +158,7 @@ describe('conversation interaction surfaces', () => {
   })
 
   it('keeps supervised message writes read-only when Host settings are not writable', async () => {
-    const rpcCall = vi.fn(async (_channel: string, endpoint: string) => {
+    const rpcCall = remoteRpc(async (endpoint: string) => {
       if (endpoint === 'status') return { ok: true as const, value: { writeEnabled: true } }
       if (endpoint === 'assistant-message') return { ok: true as const, value: { messageId: 'message-1', text: 'A durable project decision.' } }
       throw new Error(`unexpected endpoint: ${endpoint}`)
@@ -160,11 +172,11 @@ describe('conversation interaction surfaces', () => {
     await waitFor(() => expect(screen.getByRole('status').textContent).toBe('saveAction.readOnly'))
     expect(submit.disabled).toBe(true)
     fireEvent.click(submit)
-    expect(rpcCall.mock.calls.some(([, endpoint]) => endpoint === 'supervise')).toBe(false)
+    expect(calledRemote(rpcCall, 'supervise')).toBe(false)
   })
 
   it('allows supervised message writes when authenticated Host settings are writable', async () => {
-    const rpcCall = vi.fn(async (_channel: string, endpoint: string) => {
+    const rpcCall = remoteRpc(async (endpoint: string) => {
       if (endpoint === 'status') return { ok: true as const, value: { writeEnabled: true } }
       if (endpoint === 'assistant-message') return { ok: true as const, value: { messageId: 'message-1', text: 'A durable project decision.' } }
       if (endpoint === 'supervise') return { ok: true as const, value: { summary: 'stored', action: 'remember' } }
@@ -178,7 +190,7 @@ describe('conversation interaction surfaces', () => {
     const submit = await screen.findByRole('button', { name: 'saveAction.submit' }) as HTMLButtonElement
     await waitFor(() => expect(submit.disabled).toBe(false))
     fireEvent.click(submit)
-    await waitFor(() => expect(rpcCall.mock.calls.some(([, endpoint]) => endpoint === 'supervise')).toBe(true))
+    await waitFor(() => expect(calledRemote(rpcCall, 'supervise')).toBe(true))
   })
 
   it('updates the save action on locale changes without remounting an edited candidate', async () => {

--- a/tests/client-settings-scope.spec.ts
+++ b/tests/client-settings-scope.spec.ts
@@ -17,8 +17,42 @@ describe('MnemonSettingsScope', () => {
 
     expect(laterListener).toHaveBeenCalledOnce()
     expect(call).toHaveBeenCalledOnce()
+    expect(call).toHaveBeenCalledWith('/dsh-mnemon-settings', 'get', { namespace: 'mnemon-ui' }, expect.any(AbortSignal))
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('keeping the published Host snapshot'), expect.any(Error))
     warn.mockRestore()
+  })
+
+  it('uses the shared API carrier for a writable paired remote client', async () => {
+    const call = vi.fn(async (_channel: string, _endpoint: string, args: unknown) => {
+      const endpoint = (args as { args: { endpoint: string } }).args.endpoint
+      return {
+        ok: true as const,
+        value: {
+          ok: true as const,
+          value: {
+            status: 'ready' as const,
+            value: { turnBar: endpoint === 'mutate' },
+            revision: endpoint === 'mutate' ? 2 : 1,
+            writable: true,
+            mode: 'host' as const,
+          },
+        },
+      }
+    })
+    const connection = { isLoopback: false, rpc: { call } } as ClientConnectionHandle
+    const scope = new MnemonSettingsScope<InteractionConfig>(connection, 'mnemon-ui')
+    await vi.waitFor(() => expect(scope.getSnapshot().revision).toBe(1))
+    await scope.set('turnBar', true)
+
+    expect(call).toHaveBeenNthCalledWith(1, '/api', 'dshMnemon/settings', {
+      args: { endpoint: 'get', payload: { namespace: 'mnemon-ui' } },
+    }, expect.any(AbortSignal))
+    expect(call).toHaveBeenNthCalledWith(2, '/api', 'dshMnemon/settings', {
+      args: {
+        endpoint: 'mutate',
+        payload: { namespace: 'mnemon-ui', expectedRevision: 1, ops: [{ op: 'set', path: ['turnBar'], value: true }] },
+      },
+    }, expect.any(AbortSignal))
   })
 
   it('commits a multi-field edit through one namespaced revision fence', async () => {

--- a/tests/client-settings.spec.tsx
+++ b/tests/client-settings.spec.tsx
@@ -234,29 +234,32 @@ describe('MnemonSettingsCard', () => {
       subscribe() { return () => {} },
       set: vi.fn(async () => {}), unset: vi.fn(async () => {}), setPath: vi.fn(async () => {}), unsetPath: vi.fn(async () => {}), mutate: vi.fn(async () => {}),
     } satisfies ClientSettingsScope<Config> & { snapshot: typeof snapshot }
-    const call = vi.fn(async (channel: string, endpoint: string) => {
-      if (channel === '/dsh-mnemon-read' && endpoint === 'task-agent-models') return {
+    const call = vi.fn(async (channel: string, remoteEndpoint: string, rawArgs: unknown) => {
+      const endpoint = (rawArgs as { args: { endpoint: string } }).args.endpoint
+      if (channel === '/api' && remoteEndpoint === 'dshMnemon/read' && endpoint === 'task-agent-models') return {
         ok: true as const,
-        value: { effective: { provider: 'deepseek', model: 'deepseek-chat', source: 'dsh-default' as const }, groups: [], failures: [] },
+        value: { ok: true as const, value: { effective: { provider: 'deepseek', model: 'deepseek-chat', source: 'dsh-default' as const }, groups: [], failures: [] } },
       }
-      if (channel === '/dsh-mnemon-read' && endpoint === 'provider-services') return {
-        ok: true as const, value: { providers: [], items: [], generatedAt: '' },
+      if (channel === '/api' && remoteEndpoint === 'dshMnemon/read' && endpoint === 'provider-services') return {
+        ok: true as const, value: { ok: true as const, value: { providers: [], items: [], generatedAt: '' } },
       }
-      if (channel === '/dsh-mnemon-pack' && endpoint === 'target') return {
-        ok: true as const, value: { root: '/root/.mnemon', scope: 'global' as const },
+      if (channel === '/api' && remoteEndpoint === 'dshMnemon/pack' && endpoint === 'target') return {
+        ok: true as const, value: { ok: true as const, value: { root: '/root/.mnemon', scope: 'global' as const } },
       }
-      throw new Error(`unexpected ${channel} ${endpoint}`)
+      throw new Error(`unexpected ${channel} ${remoteEndpoint}/${endpoint}`)
     })
     const connection = { rpc: { call }, isLoopback: false } as ClientConnectionHandle
 
     render(<MnemonSettingsCard scope={scope} connection={connection} />)
 
-    await waitFor(() => expect(call).toHaveBeenCalledWith('/dsh-mnemon-read', 'task-agent-models', { includeCatalog: false }))
+    await waitFor(() => expect(call).toHaveBeenCalledWith('/api', 'dshMnemon/read', {
+      args: { endpoint: 'task-agent-models', payload: { includeCatalog: false } },
+    }))
     expect((screen.getByRole('radio', { name: '工作区' }) as HTMLInputElement).disabled).toBe(false)
     expect((screen.getByRole('radio', { name: '跟随主链路' }) as HTMLInputElement).disabled).toBe(false)
     expect(screen.queryByText('当前部署的插件设置为只读。')).toBeNull()
-    await waitFor(() => expect(call.mock.calls.some(([, endpoint]) => endpoint === 'provider-services')).toBe(true))
-    expect(call.mock.calls.some(([, endpoint]) => endpoint === 'target')).toBe(true)
+    await waitFor(() => expect(call.mock.calls.some(([, remoteEndpoint, args]) => remoteEndpoint === 'dshMnemon/read' && (args as { args: { endpoint: string } }).args.endpoint === 'provider-services')).toBe(true))
+    expect(call.mock.calls.some(([, remoteEndpoint, args]) => remoteEndpoint === 'dshMnemon/pack' && (args as { args: { endpoint: string } }).args.endpoint === 'target')).toBe(true)
   })
 
   it('shows an actionable error instead of a blank settings page when both scopes are unavailable', () => {

--- a/tests/client.spec.tsx
+++ b/tests/client.spec.tsx
@@ -540,13 +540,13 @@ describe('MnemonWorkbench', () => {
     expect((screen.getByRole('button', { name: '删除项目记忆空间' }) as HTMLButtonElement).disabled).toBe(true)
 
     fireEvent.click(await screen.findByRole('article', { name: '重新连接项目记忆空间' }))
-    await waitFor(() => expect(call).toHaveBeenCalledWith('/dsh-mnemon-read', 'body-reconnect', { memoryBodyId: 'project', sessionId: 'session-1' }))
+    await waitFor(() => expect(call).toHaveBeenCalledWith('/api', 'body-reconnect', { memoryBodyId: 'project', sessionId: 'session-1' }))
 
     const toggle = screen.getByRole('switch', { name: '偏好记忆空间读取开关' }) as HTMLButtonElement
     expect(toggle.disabled).toBe(false)
     fireEvent.click(toggle)
     await waitFor(() => expect(toggle.getAttribute('aria-checked')).toBe('true'))
-    expect(call).toHaveBeenCalledWith('/dsh-mnemon-activation', 'body', { memoryBodyId: 'preferences', active: true, sessionId: 'session-1' })
+    expect(call).toHaveBeenCalledWith('/api', 'body', { memoryBodyId: 'preferences', active: true, sessionId: 'session-1' })
     expect(call.mock.calls.some(([channel]) => channel === '/dsh-mnemon-write')).toBe(false)
   })
 

--- a/tests/dsh-connection-compat.spec.ts
+++ b/tests/dsh-connection-compat.spec.ts
@@ -1,6 +1,8 @@
 import { Context } from '@deepseek-ai/cordis'
+import { TypertGatewayService } from '@deepseek-ai/dsh-api-gateway'
 import { HostConnectionService } from '@deepseek-ai/dsh-client-connection'
-import { describe, expect, it } from 'vitest'
+import { TypertRegistry } from '@deepseek-ai/dsh-typert-registry'
+import { describe, expect, it, vi } from 'vitest'
 import type {
   HostConnectionHandle,
   HostRpcHandler,
@@ -9,6 +11,7 @@ import type {
 } from "../src/host/dsh.ts"
 import { registerSettingsRpc } from "../src/host/settings.ts"
 import { MNEMON_SETTINGS_CHANNEL } from "../src/host/protocol.ts"
+import { MnemonRemoteService } from '../src/host/remote-rpc.ts'
 
 interface RegisteredRoute {
   path: string
@@ -57,5 +60,52 @@ describe('released and source DSH Connection compatibility', () => {
     )
 
     expect(routes.map(route => route.path)).toEqual([MNEMON_SETTINGS_CHANNEL])
+  })
+
+  it('dispatches a namespaced Mnemon read through the released shared API contract', async () => {
+    const context = new Context()
+    context.provide('webServer', { register: () => () => {}, registerUpgrade: () => () => {} } as never)
+    new TypertRegistry(context)
+    const Connection = HostConnectionService as unknown as BranchFreeConnectionConstructor
+    const connection = new Connection(context, [], {
+      isAuthenticated: () => true,
+      authorizeIndex: () => true,
+      authenticatedUrl: value => value,
+    }) as unknown as HostConnectionService
+    new TypertGatewayService(context, { websocketHeartbeatIntervalMs: 2_000 })
+    const read = vi.fn(async endpoint => ({ ok: true as const, value: { endpoint, healthy: true } }))
+    const unavailable: HostRpcHandler = vi.fn(async () => ({ ok: false as const, error: { code: 'internal' as const, message: 'unused', details: {} } }))
+    new MnemonRemoteService(context, {
+      read,
+      activation: unavailable,
+      write: unavailable,
+      pack: unavailable,
+      settings: unavailable,
+      view: unavailable,
+      viewWrite: unavailable,
+      management: false,
+    })
+    for (const runtime of context.registry.values()) {
+      for (const fiber of runtime.fibers) await fiber.await()
+    }
+
+    const endpoint = 'dshMnemon/read'
+    const response = await connection.createSharedFetchHandler('/api').fetch(new Request(`http://127.0.0.1/api/${endpoint}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        type: 'client-request', rpcId: 'compat-rpc', method: endpoint,
+        payload: { args: { endpoint: 'status-summary', payload: {} } },
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual({
+      type: 'server-response',
+      rpcId: 'compat-rpc',
+      result: { ok: true, value: { ok: true, value: { endpoint: 'status-summary', healthy: true } } },
+    })
+    expect(read).toHaveBeenCalledWith('status-summary', {}, expect.any(AbortSignal))
   })
 })

--- a/tests/fixtures/client.tsx
+++ b/tests/fixtures/client.tsx
@@ -52,9 +52,14 @@ export const sourceCatalog: MemorySourceManagementCatalog = {
 
 /** Domain fixtures remain independent of the Source transport envelope. */
 export function sourceTransport(domain: (channel: string, endpoint: string, payload?: Record<string, unknown>) => Promise<any>) {
-  return async (channel: string, endpoint: string, payload?: Record<string, unknown>) => {
-    if (endpoint === 'source-management-catalog') return { ok: true, value: sourceCatalog }
-    if (!['source-management-read', 'source-management-mutate', 'source-assistance'].includes(endpoint)) return domain(channel, endpoint, payload)
+  return async (channel: string, transportEndpoint: string, transportPayload?: Record<string, unknown>) => {
+    const gateway = channel === '/api' && transportEndpoint.startsWith('dshMnemon/')
+    const gatewayArgs = gateway ? transportPayload?.args as Record<string, unknown> | undefined : undefined
+    const endpoint = gateway ? String(gatewayArgs?.endpoint) : transportEndpoint
+    const payload = gateway ? gatewayArgs?.payload as Record<string, unknown> | undefined : transportPayload
+    const wrap = (response: unknown): unknown => gateway ? { ok: true, value: response } : response
+    if (endpoint === 'source-management-catalog') return wrap({ ok: true, value: sourceCatalog })
+    if (!['source-management-read', 'source-management-mutate', 'source-assistance'].includes(endpoint)) return wrap(await domain(channel, endpoint, payload))
     const key = String(payload?.sourceInstanceKey)
     if (!sourceCatalog.sources.some(source => source.sourceInstanceKey === key)) throw new Error('Unregistered test Source: ' + key)
     const type = key.slice('source:mnemon-source-'.length)
@@ -72,6 +77,6 @@ export function sourceTransport(domain: (channel: string, endpoint: string, payl
     if (operation === 'activation') logical = 'body'
     if (input.oldText !== undefined) { input.old_text = input.oldText; delete input.oldText }
     const response = await domain(channel, logical, input)
-    return !response.ok ? response : { ok: true, value: { revision: 'r1', value: response.value } }
+    return wrap(!response.ok ? response : { ok: true, value: { revision: 'r1', value: response.value } })
   }
 }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -130,11 +130,13 @@ describe('dsh-mnemon plugin composition', () => {
     const releaseAgeExclusions = [...workspaceConfig.matchAll(/^  - '(@deepseek-ai\/dsh(?:-[a-z0-9-]+)?@0\.1\.2-rc\.1)'$/gm)]
       .map(match => match[1])
 
-    expect(directDshDependencies).toHaveLength(23)
+    expect(directDshDependencies).toHaveLength(26)
     expect(new Set(directDshDependencies.map(([, version]) => version))).toEqual(new Set(['0.1.2-rc.1']))
     expect(manifest.engines.node).toBe('>=20')
     expect(manifest.peerDependencies['@deepseek-ai/dsh-client-ui-primitives']).toContain('^0.1.1-rc.1')
     expect(manifest.peerDependencies['@deepseek-ai/dsh-client-ui-primitives']).toContain('^0.1.2-alpha.1')
+    expect(manifest.peerDependencies['@deepseek-ai/dsh-typert-protocol']).toContain('^0.1.0-rc.6')
+    expect(manifest.peerDependencies['@deepseek-ai/dsh-typert-protocol']).toContain('^0.1.2-alpha.1')
     expect(lockedDshVersions.length).toBeGreaterThan(100)
     expect(new Set(lockedDshVersions)).toEqual(new Set(['0.1.2-rc.1']))
     expect(new Set(releaseAgeExclusions)).toEqual(new Set(lockedRcReleases))

--- a/tests/remote-rpc.spec.ts
+++ b/tests/remote-rpc.spec.ts
@@ -1,0 +1,49 @@
+import { Context } from '@deepseek-ai/cordis'
+import { describe, expect, it, vi } from 'vitest'
+import type { HostRpcHandler } from '../src/host/dsh.ts'
+import { MnemonRemoteService } from '../src/host/remote-rpc.ts'
+
+function handler(value: string): HostRpcHandler {
+  return vi.fn(async endpoint => ({ ok: true as const, value: `${value}:${endpoint}` }))
+}
+
+describe('Mnemon API Gateway service', () => {
+  function fixture(management: boolean) {
+    const handlers = {
+      read: handler('read'), activation: handler('activation'), write: handler('write'), pack: handler('pack'),
+      settings: handler('settings'), view: handler('view'), viewWrite: handler('view-write'), management,
+    }
+    const service = new MnemonRemoteService(new Context(), handlers)
+    return { service, handlers, signal: new AbortController().signal }
+  }
+
+  it('delegates reads and narrow activation without widening management authority', async () => {
+    const { service, handlers, signal } = fixture(false)
+    await expect(service.read('status-summary', { workspaceId: 'workspace' }, signal)).resolves.toEqual({ ok: true, value: 'read:status-summary' })
+    await expect(service.view('dashboard', {}, signal)).resolves.toEqual({ ok: true, value: 'view:dashboard' })
+    await expect(service.activation('body', { active: true }, signal)).resolves.toEqual({ ok: true, value: 'activation:body' })
+    vi.mocked(handlers.settings).mockResolvedValueOnce({ ok: true, value: { status: 'ready', writable: true } })
+    await expect(service.settings('get', { namespace: 'mnemon' }, signal)).resolves.toEqual({ ok: true, value: { status: 'ready', writable: false } })
+    await expect(service.settings('mutate', {}, signal)).resolves.toMatchObject({ ok: false, error: { code: 'bad-request' } })
+    await expect(service.write('remember', {}, signal)).resolves.toMatchObject({ ok: false, error: { code: 'bad-request' } })
+    await expect(service.pack('export', {}, signal)).resolves.toMatchObject({ ok: false, error: { code: 'bad-request' } })
+    await expect(service.viewWrite('apply', {}, signal)).resolves.toMatchObject({ ok: false, error: { code: 'bad-request' } })
+    expect(handlers.read).toHaveBeenCalledWith('status-summary', { workspaceId: 'workspace' }, signal)
+    expect(handlers.view).toHaveBeenCalledWith('dashboard', {}, signal)
+    expect(handlers.activation).toHaveBeenCalledWith('body', { active: true }, signal)
+    expect(handlers.settings).toHaveBeenCalledWith('get', { namespace: 'mnemon' }, signal)
+    expect(handlers.write).not.toHaveBeenCalled()
+  })
+
+  it('delegates management only after the explicit trusted-host grant', async () => {
+    const { service, handlers, signal } = fixture(true)
+    await expect(service.write('remember', {}, signal)).resolves.toEqual({ ok: true, value: 'write:remember' })
+    await expect(service.pack('export', {}, signal)).resolves.toEqual({ ok: true, value: 'pack:export' })
+    await expect(service.viewWrite('apply', {}, signal)).resolves.toEqual({ ok: true, value: 'view-write:apply' })
+    await expect(service.settings('mutate', {}, signal)).resolves.toEqual({ ok: true, value: 'settings:mutate' })
+    expect(handlers.write).toHaveBeenCalledWith('remember', {}, signal)
+    expect(handlers.pack).toHaveBeenCalledWith('export', {}, signal)
+    expect(handlers.viewWrite).toHaveBeenCalledWith('apply', {}, signal)
+    expect(handlers.settings).toHaveBeenCalledWith('mutate', {}, signal)
+  })
+})

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,6 +3,7 @@ import { dirname, relative, resolve as resolvePath } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { UserConfig, TsdownPlugin } from 'tsdown'
 import { transform } from 'lightningcss'
+import ts from 'typescript'
 
 const PLUGIN_ID = 'dsh-mnemon'
 const PROJECT_ROOT = dirname(fileURLToPath(import.meta.url))
@@ -29,6 +30,7 @@ const host: UserConfig = {
   dts: false,
   clean: true,
   deps: { neverBundle: true },
+  plugins: [standardDecoratorsPlugin()],
 }
 
 const client: UserConfig = {
@@ -94,6 +96,25 @@ export function clientCssPlugin(injectStyles = true): TsdownPlugin {
         '}',
         `export default ${JSON.stringify(classMap)};`,
       ].join('\n')
+    },
+  }
+}
+
+/** Lower standard decorators because Rolldown currently preserves their syntax. */
+function standardDecoratorsPlugin(): TsdownPlugin {
+  return {
+    name: 'dsh-mnemon-standard-decorators',
+    transform(code: string, id: string) {
+      if (!id.replaceAll('\\', '/').endsWith('/src/host/remote-rpc.ts')) return null
+      const output = ts.transpileModule(code, {
+        fileName: id,
+        compilerOptions: {
+          target: ts.ScriptTarget.ES2022,
+          module: ts.ModuleKind.ESNext,
+          verbatimModuleSyntax: true,
+        },
+      })
+      return { code: output.outputText, map: null }
     },
   }
 }


### PR DESCRIPTION
## 摘要 / Summary

Route paired remote-browser Mnemon RPCs through DSH's namespaced Typert API Gateway while retaining the legacy standalone channels for loopback clients. This fixes authenticated remote pages receiving HTTP 403 for status, Source catalog, settings, and management calls, including remote-desktop runtimes that report host ownership through `connection.isLoopback`.

## 关联 Issue 或背景 / Related Issue or Context

N/A — this is a compatibility bug fix using published DSH Connection and Typert Gateway contracts. It adds no new capability or authority boundary and preserves the existing `remoteAccess` grant.

## 涉及区域 / Affected Areas

- [x] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆空间或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [x] Web UI 或对话交互 / Web UI or conversation interaction
- [x] 设置、存储或安全 / Settings, storage, or security
- [x] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [ ] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [ ] 其他（请说明）/ Other (explain below)

## PR 类型 / PR Type

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [x] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [x] 兼容性适配 / Compatibility change
- [ ] 维护或重构 / Maintenance or refactor
- [ ] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin && git rebase origin/main
```

## AI 编码披露 / AI Coding Disclosure

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

GPT-5

使用的编码 Agent 工具 / Coding Agent tool used:

Codex

## 仓库规范检查 / Repository Rules

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以浏览器安全的 `src/host/protocol.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses browser-safe `src/host/protocol.ts` as the source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 会改变发布制品或其元数据的 PR 已添加 changeset；仅测试、CI 或站点文档变更可不添加。 / A PR that changes a published artifact or its metadata includes a changeset; test-only, CI-only, and site-documentation-only changes may omit one.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

- Local loopback clients keep the existing `/dsh-mnemon-*` RPC channels; paired non-loopback pages use `/api/dshMnemon/*` through DSH's Host/Origin and pairing fences.
- Read, View, and narrow activation calls retain their existing remote availability. Write, pack, View mutation, and settings mutation remain rejected unless `remoteAccess: trusted-host` is configured; settings snapshots are forced to `writable: false` without that grant.
- The implementation depends only on published DSH rc/alpha-compatible Typert contracts and retains the supported Connection fallback for runtimes without `isLoopback`.
- Provider behavior, configuration schemas, storage paths, persistence formats, and existing data are unchanged. No migration is required.
- Rollback is the previous npm package version or artifact; stored data and settings remain valid and are retained.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
npx --yes pnpm@10.13.1 run verify
```

结果摘要 / Result summary:

- Passed documentation checks, type checking, deterministic double builds, all independent plugin builds/tests, Headless activation, package-content checks, `publint --strict`, and `attw`.
- Root suite: 74 test files and 790 tests passed. Two opt-in platform/integration tests remained skipped by their existing conditions.
- Targeted Gateway, Connection compatibility, settings authority, and Client routing tests passed for local, paired remote, denied management, and trusted management paths.
- A redacted live paired-HTTPS smoke test loaded the built PR client bundle, emitted only `/remote/api/dshMnemon/*` UI requests, returned HTTP 200 for status, Source catalog, and settings, and showed neither the previous transport failure nor the not-ready state.
- The smoke profile used stock `@linxin666/dsh-web-all@0.3.16` with no active package patch.

## 用户可见变更证据 / Local Feature Evidence

证据 / Evidence:

N/A — this is an internal transport compatibility correction rather than a new user-facing feature. The redacted live paired-browser results above exercise the affected UI and both authorization outcomes without exposing a pairing token, device identifier, private path, or workspace data.
