### PR TITLE
fix(ci): make issue template checks advisory

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,13 +1,19 @@
 name: Bug 报告 / Bug report
-description: 提交可复现的 Bug，并附验证证据、代码引用与补丁草案。 / Report a reproducible bug with verification evidence, code references, and a patch proposal.
+description: 报告异常现象、复现步骤和环境；日志及修复建议可选。 / Describe the problem, reproduction steps and environment; logs and fixes are optional.
 title: "[Bug]: "
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        请保持本模板完整并填写所有必填部分。缺少复现信息、证据、冒烟测试、代码引用或补丁草案的 Bug 报告将被自动关闭。
-        Keep this template intact and complete every required field. Bug reports missing reproduction details, evidence, smoke tests, code references, or a patch proposal will be closed automatically.
+        请填写现象、预期结果、复现步骤和环境。信息不足时机器人会提示补充，模板检查不会自动关闭 Issue。
+        Describe the problem, expected outcome, reproduction steps and environment. Missing information prompts a request for details; template checks do not close issues.
+
+        日志、截图和对照结果可直接放在复现步骤中。下方的证据、冒烟测试、代码引用和补丁草案均为选填，无需重复内容或先提供修复方案。
+        Logs, screenshots and control results may go directly in the reproduction steps. Separate evidence, smoke tests, code references and patch proposals are optional; no duplication or fix is required.
+
+        通过 CLI/API 提交时可使用相同段落标题组织正文。类型填写为“Bug 报告 / Bug report”时，机器人会补齐 `bug` 标签，无需提交者拥有标签权限。
+        CLI/API reports may use the same section headings. The bot adds the `bug` label when the type is “Bug 报告 / Bug report”; reporters do not need label permissions.
 
         提交前请先搜索确认没有重复 / Search for existing reports before submitting: [Issues](https://github.com/omdsh-dev/dsh-mnemon/issues?q=is%3Aissue)
 
@@ -69,7 +75,7 @@ body:
     id: details-reproduction
     attributes:
       label: 详情或复现步骤 / Details or reproduction steps
-      description: 提供从干净或已说明状态开始的最小复现步骤。 / Provide the smallest reproduction starting from a clean or clearly described state.
+      description: 提供最小复现步骤和实际结果；报错和日志（包括 JSON 或普通文本）可直接写在这里。 / Include minimal steps and observed results; errors and logs, including JSON or plain text, may go here.
       placeholder: |
         1. 配置 / Configure ...
         2. 启动 / Start ...
@@ -95,37 +101,37 @@ body:
     id: bug-evidence
     attributes:
       label: Bug 证据 / Bug evidence
-      description: UI 问题请上传截图或视频；Host、CLI、Headless 问题请附脱敏日志或错误输出。 / Upload screenshots or video for UI problems, or redacted logs and error output for Host, CLI, or Headless problems.
-      placeholder: 将截图拖到此处，或粘贴脱敏日志代码块或 GitHub 附件链接。 / Drop evidence here, or paste a redacted log block or GitHub attachment link.
+      description: 选填。复现步骤已有证据时无需重复；支持普通文本、任意语言代码块、图片或附件。 / Optional. Do not repeat evidence already in the steps; plain text, any code-block language, images or attachments are accepted.
+      placeholder: 可粘贴脱敏报错、日志、截图或附件，也可留空。 / Add redacted errors, logs, screenshots or attachments, or leave blank.
     validations:
-      required: true
+      required: false
   - type: textarea
     id: smoke-test
     attributes:
       label: 冒烟测试 / Smoke test
-      description: 说明实际执行的验证、观察结果和对照实验；未执行的推测不算验证。 / Describe the checks you actually ran, observed results, and controls; speculation is not verification.
+      description: 选填。补充实际执行的验证、观察结果或对照实验；未执行可留空。 / Optional. Add checks you actually ran, observed results or controls; leave blank if none were run.
       placeholder: |
         - 测试环境 / Test environment:
         - 执行命令或操作 / Commands or actions:
         - 实际结果 / Observed result:
         - 对照版本或配置 / Control version or configuration:
     validations:
-      required: true
+      required: false
   - type: textarea
     id: code-reference
     attributes:
       label: 引用代码 / Code references
-      description: 指向仓库内相关代码的精确位置，可附固定 commit 的 GitHub 链接。 / Point to exact repository paths, functions, or lines, optionally using links pinned to a commit.
+      description: 选填。知道相关代码位置时，可提供路径、函数或固定 commit 链接。 / Optional. If you know the relevant code, add paths, functions or links pinned to a commit.
       placeholder: |
-        src/subagent.ts:870
+        src/host/subagent.ts:870
         tests/subagent.spec.ts
     validations:
-      required: true
+      required: false
   - type: textarea
     id: patch
     attributes:
       label: 补丁草案 / Patch proposal
-      description: 提供建议修复的 diff、代码片段或足够具体的实现草案，即使尚不完整。 / Provide a suggested diff, code snippet, or concrete implementation proposal, even if incomplete.
+      description: 选填。已有修复思路时可以补充；无需为提交 Bug 先编写补丁。 / Optional. Share a fix if you have one; a patch is not required to report a bug.
       placeholder: |
         ```diff
         --- a/src/example.ts
@@ -133,7 +139,7 @@ body:
         @@ ... @@
         ```
     validations:
-      required: true
+      required: false
   - type: textarea
     id: additional-context
     attributes:

--- a/.github/ISSUE_TEMPLATE/standard_issue.yml
+++ b/.github/ISSUE_TEMPLATE/standard_issue.yml
@@ -5,8 +5,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        请保持本模板完整并填写所有必填部分。删除必填部分的 Issue 将被自动关闭。可复现的 Bug 请使用“Bug 报告 / Bug report”表单。
-        Keep this template intact and complete every required field. Issues with required sections removed will be closed automatically. Use the “Bug 报告 / Bug report” form for reproducible bugs.
+        请填写请求、预期结果、使用场景和相关环境。信息不足时机器人会提示补充，模板检查不会自动关闭 Issue。Bug 请使用“Bug 报告 / Bug report”表单。
+        Describe the request, expected outcome, use case and relevant environment. Missing information prompts a request for details; template checks do not close issues. Use the “Bug 报告 / Bug report” form for bugs.
+
+        通过 CLI/API 提交时可使用相同段落标题组织正文；补充信息可直接编辑原 Issue，机器人会更新已有提示。
+        CLI/API reports may use the same section headings. Edit the original issue to add information; the bot updates its existing reminder.
 
         提交前请先搜索确认没有重复 / Search for existing issues before submitting: [Issues](https://github.com/omdsh-dev/dsh-mnemon/issues?q=is%3Aissue)
 

--- a/.github/workflows/issue-template-enforcer.yml
+++ b/.github/workflows/issue-template-enforcer.yml
@@ -1,8 +1,12 @@
-name: Issue 模板校验 / Enforce Issue Template
+name: Issue 信息检查 / Check Issue Information
 
 on:
   issues:
-    types: [opened, reopened]
+    types: [opened, reopened, edited]
+
+concurrency:
+  group: issue-template-check-${{ github.event.issue.number }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -10,7 +14,7 @@ permissions:
 
 jobs:
   enforce:
-    name: 关闭未遵循模板的 Issue / Close issues that skip the template
+    name: 提示缺失的 Issue 信息 / Request missing issue information
     runs-on: ubuntu-latest
 
     steps:
@@ -41,13 +45,6 @@ jobs:
               return normalized === '' || normalized === 'no response' || normalized === '_no response_';
             };
             const hasCheckedBox = (value) => /^-\s*\[[xX]\]\s+\S+/m.test(value);
-            const hasBugEvidence = (value) => {
-              const imageOrAttachment = /!\[[^\]]*]\([^)]+\)/i.test(value)
-                || /https?:\/\/\S*(?:github\.com\/user-attachments\/assets\/|github\.com\/[^)\s]+\/assets\/|githubusercontent\.com\/|gist\.github\.com\/|[./][^)\s]+\.(?:png|jpe?g|gif|webp|mp4|mov|webm))(?:[?#]\S*)?/i.test(value);
-              const fencedLog = /```(?:text|log|console|shell|sh|bash|powershell|pwsh)?\s*\n[\s\S]{20,}?```/i.test(value);
-              return imageOrAttachment || fencedLog;
-            };
-
             const labels = {
               duplicate: '提交前查重 / Duplicate check',
               area: '涉及区域 / Affected area',
@@ -56,12 +53,8 @@ jobs:
               expected: '预期结果 / Expected outcome',
               details: '详情或复现步骤 / Details or reproduction steps',
               environment: '环境信息 / Environment',
-              evidence: 'Bug 证据 / Bug evidence',
-              smoke: '冒烟测试 / Smoke test',
-              code: '引用代码 / Code references',
-              patch: '补丁草案 / Patch proposal',
             };
-            const baseRequiredSections = [
+            const requiredSections = [
               labels.duplicate,
               labels.area,
               labels.type,
@@ -72,24 +65,12 @@ jobs:
             ];
             const validateIssue = (issue) => {
               const section = (label) => readSection(issue.body || '', label);
-              const issueType = section(labels.type).trim().toLowerCase();
-              const hasBugLabel = (issue.labels || []).some((label) => String(label.name || '').toLowerCase() === 'bug');
-              const isBug = issueType === 'bug 报告 / bug report' || hasBugLabel;
-              const requiredSections = isBug
-                ? [...baseRequiredSections, labels.evidence, labels.smoke, labels.code, labels.patch]
-                : baseRequiredSections;
-
+              // Evidence is assessed by maintainers across the whole report.
+              // Its section, code-block language and formatting are not gates.
               const missingSections = requiredSections.filter((label) => isBlank(section(label)));
               const invalidSections = [];
               if (!isBlank(section(labels.duplicate)) && !hasCheckedBox(section(labels.duplicate))) {
-                invalidSections.push('必须确认已经搜索过 open/closed Issue。 / You must confirm that you searched open and closed issues.');
-              }
-              if (isBug && !hasBugLabel) {
-                invalidSections.push('Bug 报告必须通过“Bug 报告 / Bug report”表单提交并带有 `bug` 标签。 / Bug reports must use the “Bug 报告 / Bug report” form and include the `bug` label.');
-              }
-              const bugEvidence = section(labels.evidence);
-              if (isBug && !isBlank(bugEvidence) && !hasBugEvidence(bugEvidence)) {
-                invalidSections.push('Bug 证据必须包含截图、视频、GitHub 附件、Gist 或至少 20 个字符的 fenced 日志代码块。 / Bug evidence must include an image, video, GitHub attachment, Gist, or a fenced log block containing at least 20 characters.');
+                invalidSections.push('请确认已经搜索过 open/closed Issue。 / Please confirm that you searched open and closed issues.');
               }
 
               return [
@@ -98,39 +79,62 @@ jobs:
               ];
             };
 
-            // The event payload is a snapshot; labels and body may have changed
-            // while this run was queued, especially after an issue was reopened.
+            // The event payload is a snapshot. Read current state before acting,
+            // including after comment lookup or adding a label.
             const { data: initialIssue } = await github.rest.issues.get(issueParams);
-            if (initialIssue.state !== 'open' || validateIssue(initialIssue).length === 0) {
-              return;
+            if (initialIssue.state !== 'open') return;
+
+            const marker = '<!-- dsh-mnemon:issue-template-check -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...issueParams,
+              per_page: 100,
+            });
+            const previousComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.user?.type === 'Bot' &&
+              comment.body?.startsWith(marker),
+            );
+
+            let { data: currentIssue } = await github.rest.issues.get(issueParams);
+            if (currentIssue.state !== 'open') return;
+
+            const issueType = readSection(currentIssue.body || '', labels.type).trim().toLowerCase();
+            const hasBugLabel = (currentIssue.labels || []).some((label) => String(label.name || '').toLowerCase() === 'bug');
+            if (issueType === 'bug 报告 / bug report' && !hasBugLabel) {
+              // API/CLI reporters may not have permission to classify an issue.
+              await github.rest.issues.addLabels({ ...issueParams, labels: ['bug'] });
+              currentIssue = (await github.rest.issues.get(issueParams)).data;
+              if (currentIssue.state !== 'open') return;
             }
 
-            // Recheck immediately before closing so corrections made during
-            // validation are honored, and already closed issues are left alone.
-            const { data: currentIssue } = await github.rest.issues.get(issueParams);
-            if (currentIssue.state !== 'open') return;
             const details = validateIssue(currentIssue);
-            if (details.length === 0) return;
+            if (details.length === 0 && !previousComment) return;
 
-            const comment = [
-              '该 Issue 因未满足仓库 Issue 规范而被自动关闭。',
-              'This issue was automatically closed because it does not meet the repository issue requirements.',
-              '',
-              '请通过仓库的 Issue Forms 重新提交，并保持模板完整：',
-              'Please submit again through the repository Issue Forms and keep the template intact:',
+            const comment = details.length > 0 ? [
+              marker,
+              '此 Issue 保持打开。为便于排查，请补充以下基础信息：',
+              'The issue remains open. Please add the following basic information to help triage:',
               '',
               ...details.map((detail) => `- ${detail}`),
               '',
-              '补充完整后可以在评论区请求维护者重开。不要在公开 Issue 中粘贴凭据、私有记忆或未脱敏日志。',
-              'After providing the missing information, you may ask a maintainer to reopen the issue. Do not post credentials, private memory, or unredacted logs publicly.',
+              '在正文中补充即可，本提示会在编辑后更新。证据可以是普通文本、JSON 或其他代码块，也可以直接放在复现步骤中。',
+              'Update the issue body and this reminder will refresh. Evidence may be plain text, JSON or other code blocks, including content in the reproduction steps.',
+            ].join('\n') : [
+              marker,
+              '基础信息已补齐，后续由维护者排查和处理。',
+              'Required report information is present. Maintainers will review the report.',
             ].join('\n');
 
-            await github.rest.issues.update({
-              ...issueParams,
-              state: 'closed',
-              state_reason: 'not_planned',
-            });
-            await github.rest.issues.createComment({
-              ...issueParams,
-              body: comment,
-            });
+            // Update only this check's own reminder. Never change issue state.
+            if (previousComment) {
+              if (previousComment.body !== comment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: previousComment.id,
+                  body: comment,
+                });
+              }
+            } else {
+              await github.rest.issues.createComment({ ...issueParams, body: comment });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,10 @@ Code, comments, documentation, commit messages, and PR titles must not contain e
 ## Issue rules
 
 - Search open and closed Issues before submitting;
-- use the bilingual [Bug report form](.github/ISSUE_TEMPLATE/bug_report.yml) for bugs, including reproduction, environment, evidence, smoke tests, code references, and a patch proposal;
+- use the bilingual [Bug report form](.github/ISSUE_TEMPLATE/bug_report.yml) for bugs, describing the symptom, expected outcome, reproduction steps and environment. Evidence may be plain text, JSON or another code block anywhere in the report; separate evidence, smoke tests, code references and patch proposals are optional;
 - use the bilingual [standard Issue form](.github/ISSUE_TEMPLATE/standard_issue.yml) for features, enhancements, documentation, and questions;
-- Issues with missing required information are closed automatically; contributors may request reopening after completing the template;
+- CLI/API submissions may use the same section headings; the bot adds `bug` when the report type is “Bug 报告 / Bug report”, so reporters do not need label permissions;
+- template checks request missing basic information without closing the Issue. Edit the original body to supply details; the bot updates its existing reminder. Maintainers decide whether further investigation or closure is appropriate;
 - see [Issue Triage](./ISSUE_TRIAGE.md) or [Issue 分类标准](./ISSUE_TRIAGE.zh-CN.md) for labels, classification, and closure criteria;
 - report security vulnerabilities privately through [SECURITY.md](./SECURITY.md), not in a public Issue.
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -73,9 +73,10 @@ fix(client): honor trusted remote management grant
 ## Issue 规则
 
 - 提交前搜索 open 和 closed Issue，确认没有重复；
-- Bug 使用双语[Bug 报告表单](.github/ISSUE_TEMPLATE/bug_report.yml)，必须包含复现、环境、证据、冒烟测试、代码引用和补丁草案；
+- Bug 使用双语[Bug 报告表单](.github/ISSUE_TEMPLATE/bug_report.yml)，描述现象、预期结果、复现步骤和环境。证据可用普通文本、JSON 或其他代码块，放在正文任意位置；单独的证据、冒烟测试、代码引用和补丁草案均为选填；
 - 功能、增强、文档和问题使用双语[标准 Issue 表单](.github/ISSUE_TEMPLATE/standard_issue.yml)；
-- 缺少模板必填信息的 Issue 会被自动关闭，补充完整后可以请求重开；
+- CLI/API 提交可使用相同段落标题；类型为“Bug 报告 / Bug report”时机器人会补齐 `bug` 标签，无需提交者拥有标签权限；
+- 模板检查仅提示补充缺失的基础信息，不关闭 Issue。直接编辑原正文补充信息，机器人会更新已有提示；进一步排查或关闭由维护者决定；
 - 标签体系、分类和关闭标准见[Issue 分类标准](./ISSUE_TRIAGE.zh-CN.md)或英文版 [Issue Triage](./ISSUE_TRIAGE.md)；
 - 安全漏洞必须按 [SECURITY.md](./SECURITY.md) 私下报告，不要创建公开 Issue。
 

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -8,7 +8,7 @@ This document defines the dsh-mnemon Issue label system, classification, informa
 
 | Label | Meaning | When to use it |
 | --- | --- | --- |
-| `bug` | Unexpected behavior, an error, regression, or compatibility problem | The report has a clear symptom, reproduction, and evidence |
+| `bug` | A report of unexpected behavior, an error, regression, or compatibility problem | The reporter selects Bug report; maintainers verify the symptom and reproduction during triage |
 | `enhancement` | A new capability or improvement to an existing capability | The request has a clear use case, constraints, and acceptance result |
 | `documentation` | Missing, obsolete, or inconsistent README, docs, or comments | No runtime behavior changes |
 | `question` | A usage or design question | The Issue asks how something works or why it behaves that way |
@@ -25,9 +25,9 @@ Labels use GitHub's default names. When adding a long-lived label, update the Is
 Triage new Issues in this order:
 
 1. **Security check**: if the Issue contains a vulnerability, token, credential, private memory, or sensitive log, remove the public material and direct the reporter to `SECURITY.md`.
-2. **Template check**: confirm that required sections exist and are non-empty. Bugs require evidence, smoke tests, code references, and a patch proposal.
+2. **Information check**: look for the symptom, expected outcome, reproduction steps and environment, plus classification and duplicate-search confirmation. Ask for specific missing details without closing the Issue. Evidence may be plain text, JSON or other code blocks anywhere in the report; separate evidence, smoke tests, code references and patch proposals are optional.
 3. **Duplicate check**: search open and closed Issues and merged PRs. Label duplicates with `duplicate`, link the original Issue in a comment, and close the duplicate.
-4. **Assign a type**: apply `bug`, `enhancement`, `documentation`, or `question` based on the objective.
+4. **Assign a type**: apply `bug`, `enhancement`, `documentation`, or `question` based on the objective. The information check adds `bug` for the Bug report type, including CLI/API submissions; this is classification, not confirmation that a defect has been verified.
 5. **Verify current state**: reproduce against current `main` and the latest release. If another PR or release already solved the problem, cite its commit, PR, or version and close the Issue.
 6. **Confirm scope**: route problems that require DSH core or an upstream Provider change to the upstream project. Keep only a concrete compatibility-layer or workaround task here.
 7. **Open for contribution**: add `help wanted` when the scope is clear and external implementation is accepted; add `good first issue` when it is also suitable for a new contributor.
@@ -42,9 +42,11 @@ Close an Issue when any of these conditions apply, and always leave a traceable 
 - **Answered**: provide the conclusion and an authoritative documentation link;
 - **Obsolete**: the dependency, interface, or design has changed;
 - **Out of scope**: an upstream DSH, Mnemon, or Provider change is required; identify the upstream destination;
-- **Information missing long-term**: the reporter did not supply required evidence; apply `invalid`.
+- **Information missing long-term**: after a maintainer requests specific details and allows time to respond, the report still cannot be investigated; explain the unresolved gap and apply `invalid`.
 
 Use GitHub's `completed` or `not_planned` closure reason. Do not close without an explanation. Reporters may request reopening after adding new evidence.
+
+Formatting, the location of a log, a missing code reference or the absence of a patch alone are not closure reasons. A reopened Issue stays available for maintainer review; the template check never closes it.
 
 ## Pull Request linkage
 
@@ -67,7 +69,7 @@ gh issue list -R omdsh-dev/dsh-mnemon --state open \
 
 ## Automation
 
-- `.github/workflows/issue-template-enforcer.yml` posts a bilingual explanation and closes Issues with missing required Issue Form sections or invalid Bug evidence as `not_planned`;
+- `.github/workflows/issue-template-enforcer.yml` reads current state on opening, reopening and editing, adds `bug` for Bug reports, and maintains one bilingual reminder for missing basic information. The reminder updates after corrections; this check never changes Issue state;
 - `.github/workflows/issue-dedup.yml` posts a bilingual explanation, links the original Issue, labels a highly similar open Issue as a possible duplicate, and closes it;
 - `.github/workflows/pr-contribution-rules.yml` validates PR titles, the bilingual template, AI disclosure, local verification, compatibility information, and user-visible evidence;
 - `.github/workflows/reject-docs-pr.yml` posts a bilingual explanation and closes documentation-only PRs from external contributors; repository collaborators with `write`, `maintain`, or `admin` permission are exempt.

--- a/ISSUE_TRIAGE.zh-CN.md
+++ b/ISSUE_TRIAGE.zh-CN.md
@@ -8,7 +8,7 @@
 
 | 标签 | 含义 | 何时使用 |
 | --- | --- | --- |
-| `bug` | 功能不符合预期、报错、回归或兼容性问题 | 有明确现象、复现和证据 |
+| `bug` | 报告功能不符合预期、报错、回归或兼容性问题 | 提交者选择 Bug 报告；维护者在分类过程中核实具体表现和复现 |
 | `enhancement` | 新能力或现有能力改进 | 有清楚场景、约束和验收结果 |
 | `documentation` | README、docs 或注释缺失、过时、不一致 | 不改变运行时行为 |
 | `question` | 使用或设计疑问 | 需要回答“怎么用”或“为什么” |
@@ -25,9 +25,9 @@
 新 Issue 按以下顺序处理：
 
 1. **安全检查**：若包含漏洞、token、凭据、私有记忆或敏感日志，立即移除公开内容并引导至 `SECURITY.md`。
-2. **模板检查**：确认必填段落存在且非空；Bug 必须包含证据、冒烟测试、代码引用和补丁草案。
+2. **信息检查**：查看现象、预期结果、复现步骤、环境、分类和查重确认。缺少具体信息时提示补充，不关闭 Issue。证据可用普通文本、JSON 或其他代码块，放在正文任意位置；单独的证据、冒烟测试、代码引用和补丁草案均为选填。
 3. **查重**：搜索 open/closed Issue 和已合并 PR；重复项标记 `duplicate`，评论原 Issue 后关闭。
-4. **定类型**：根据目标标记 `bug`、`enhancement`、`documentation` 或 `question`。
+4. **定类型**：根据目标标记 `bug`、`enhancement`、`documentation` 或 `question`。信息检查会为 Bug 报告补齐 `bug` 标签，包括 CLI/API 提交；该标签表示分类，不代表已验证缺陷成立。
 5. **验证当前状态**：以当前 `main` 和最新发布版本复现；已经由其他 PR 或版本解决的 Issue 直接注明 commit、PR 或版本并关闭。
 6. **确认范围**：需要修改 DSH 核心或上游 Provider 的问题转交上游；本仓库只保留兼容层或绕过方案的明确任务。
 7. **开放认领**：范围清楚且接受外部实现时添加 `help wanted`；适合入门时再添加 `good first issue`。
@@ -42,9 +42,11 @@
 - **已回答**：给出结论和权威文档链接；
 - **过时**：依赖、接口或设计已经变化；
 - **超范围**：需要上游 DSH、Mnemon 或 Provider 修改，说明转交位置；
-- **长期缺信息**：作者未补齐模板所需证据，标记 `invalid`。
+- **长期缺信息**：维护者提出具体补充要求并给予回复时间后，报告仍无法排查；说明尚缺的信息并标记 `invalid`。
 
 关闭理由使用 GitHub 的 `completed` 或 `not_planned`，不要无说明关闭。作者补充新证据后可以请求重开。
+
+仅有排版、日志位置、缺少代码引用或没有补丁方案等问题，不构成关闭理由。重开的 Issue 保留给维护者继续处理，模板检查不会将其关闭。
 
 ## PR 关联规则
 
@@ -67,7 +69,7 @@ gh issue list -R omdsh-dev/dsh-mnemon --state open \
 
 ## 自动化
 
-- `.github/workflows/issue-template-enforcer.yml`：缺少 Issue Form 必填段落或 Bug 证据无效时，发布双语说明并以 `not_planned` 自动关闭；
+- `.github/workflows/issue-template-enforcer.yml`：在创建、重开和编辑时读取最新状态，为 Bug 报告补齐 `bug` 标签，并维护一条缺少基础信息的双语提示。正文补充后更新提示；该检查不修改 Issue 状态；
 - `.github/workflows/issue-dedup.yml`：标题与已有 open Issue 高度相似时，发布双语说明、附原 Issue、标记疑似重复并关闭；
 - `.github/workflows/pr-contribution-rules.yml`：校验 PR 标题、双语模板、AI 披露、本地验证、兼容说明和用户可见证据；
 - `.github/workflows/reject-docs-pr.yml`：发布双语说明并自动关闭外部贡献者的仅文档 PR；具有 `write`、`maintain` 或 `admin` 权限的仓库协作者不受该规则限制。

--- a/tests/issue-template-enforcer.spec.mjs
+++ b/tests/issue-template-enforcer.spec.mjs
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const workflow = readFileSync(new URL('../.github/workflows/issue-template-enforcer.yml', import.meta.url), 'utf8')
 const script = workflow.match(/^          script: \|\n((?: {12}.*\n|\n)*)/m)?.[1]
@@ -13,21 +13,26 @@ const baseSections = [
   ['Issue 类型 / Issue type', 'Bug 报告 / Bug report'],
   ['摘要 / Summary', 'Archiving fails after runtime memory reaches its capacity.'],
   ['预期结果 / Expected outcome', 'Archive the entries and complete the write.'],
-  ['详情或复现步骤 / Details or reproduction steps', 'Fill runtime memory and add another entry.'],
+  ['详情或复现步骤 / Details or reproduction steps', 'Fill runtime memory and add another entry. The write fails.'],
   ['环境信息 / Environment', 'macOS, Node.js 24, two active Memory Spaces.'],
 ]
-const bugSections = [
-  ['Bug 证据 / Bug evidence', '```log\nError: runtime memory migration route coverage is invalid\n```'],
-  ['冒烟测试 / Smoke test', 'Reproduced with multiple entries; changing the routing model succeeds.'],
-  ['引用代码 / Code references', 'src/host/subagent.ts, runtime memory routing validation.'],
-  ['补丁草案 / Patch proposal', 'Include route validation in the deterministic fallback.'],
-]
 const body = (sections) => sections.map(([heading, value]) => `### ${heading}\n\n${value}`).join('\n\n')
-const bugBody = body([...baseSections, ...bugSections])
+const bugBody = body(baseSections)
+const questionBody = bugBody.replace('Bug 报告 / Bug report', '问题 / Question')
 const issue = (overrides = {}) => ({ number: 235, state: 'open', body: bugBody, labels: [{ name: 'bug' }], ...overrides })
 const missingLabel = () => issue({ labels: [] })
+const incomplete = () => issue({ body: bugBody.replace(baseSections[6][1], '_No response_') })
+const marker = '<!-- dsh-mnemon:issue-template-check -->'
+const botComment = (body) => ({ id: 123, body, user: { login: 'github-actions[bot]', type: 'Bot' } })
+const checks = []
 
-function harness(eventIssue, snapshots = [eventIssue]) {
+afterEach(() => {
+  for (const check of checks.splice(0)) {
+    expect(check.update, 'template checks must never change issue state').not.toHaveBeenCalled()
+  }
+})
+
+function harness(eventIssue, { snapshots = [eventIssue], comments = [], action = 'opened' } = {}) {
   let reads = 0
   const get = vi.fn(async () => {
     const snapshot = snapshots[Math.min(reads++, snapshots.length - 1)]
@@ -35,109 +40,184 @@ function harness(eventIssue, snapshots = [eventIssue]) {
     return { data: structuredClone(snapshot) }
   })
   const update = vi.fn(async () => ({ data: {} }))
+  const addLabels = vi.fn(async () => ({ data: [{ name: 'bug' }] }))
   const createComment = vi.fn(async () => ({ data: {} }))
-  const context = { repo: { owner: 'omdsh-dev', repo: 'dsh-mnemon' }, payload: { issue: eventIssue } }
-  return {
-    get, update, createComment,
-    run: () => runWorkflow(context, { rest: { issues: { get, update, createComment } } }),
+  const updateComment = vi.fn(async () => ({ data: {} }))
+  const listComments = vi.fn(async () => ({ data: comments }))
+  const paginate = vi.fn(async (method, params) => (await method(params)).data)
+  const context = { repo: { owner: 'omdsh-dev', repo: 'dsh-mnemon' }, payload: { issue: eventIssue, action } }
+  const check = {
+    get, update, addLabels, createComment, updateComment, listComments, paginate,
+    run: () => runWorkflow(context, { paginate, rest: { issues: { get, update, addLabels, createComment, updateComment, listComments } } }),
   }
+  checks.push(check)
+  return check
 }
 
-describe('issue template enforcement against current issue state', () => {
-  it('keeps an issue open when the bug label was added after the event, before the job starts', async () => {
-    const check = harness(missingLabel(), [issue()])
+describe('advisory issue template checks', () => {
+  it('accepts a report without separate evidence, smoke tests, code references or a patch', async () => {
+    const check = harness(issue())
     await check.run()
-    expect(check.update).not.toHaveBeenCalled()
     expect(check.createComment).not.toHaveBeenCalled()
-  })
-
-  it('keeps an issue open when the bug label is added during validation', async () => {
-    const check = harness(missingLabel(), [missingLabel(), issue()])
-    await check.run()
-    expect(check.update).not.toHaveBeenCalled()
-    expect(check.createComment).not.toHaveBeenCalled()
-  })
-
-  it('accepts required information filled in during validation', async () => {
-    const incomplete = issue({ body: body(baseSections) })
-    const check = harness(incomplete, [incomplete, issue()])
-    await check.run()
-    expect(check.update).not.toHaveBeenCalled()
-    expect(check.createComment).not.toHaveBeenCalled()
-  })
-
-  it.each(['before the job starts', 'during validation'])('skips an issue closed %s', async (timing) => {
-    const closed = missingLabel()
-    closed.state = 'closed'
-    const check = harness(missingLabel(), timing === 'during validation' ? [missingLabel(), closed] : [closed])
-    await check.run()
-    expect(check.update).not.toHaveBeenCalled()
-    expect(check.createComment).not.toHaveBeenCalled()
-  })
-
-  it('still closes a bug report whose label remains missing', async () => {
-    const check = harness(missingLabel())
-    await check.run()
-    expect(check.update).toHaveBeenCalledExactlyOnceWith({
-      owner: 'omdsh-dev', repo: 'dsh-mnemon', issue_number: 235,
-      state: 'closed', state_reason: 'not_planned',
-    })
-    expect(check.createComment).toHaveBeenCalledTimes(1)
-    expect(check.createComment.mock.calls[0][0].body).toContain('include the `bug` label')
-    expect(check.createComment.mock.calls[0][0].body).not.toContain('Missing or empty required sections')
-  })
-
-  it('reports only the remaining errors after a partial correction', async () => {
-    const incompleteBody = body(baseSections)
-    const check = harness(issue({ body: incompleteBody, labels: [] }), [
-      issue({ body: incompleteBody, labels: [] }),
-      issue({ body: incompleteBody }),
-    ])
-    await check.run()
-    expect(check.update).toHaveBeenCalledTimes(1)
-    expect(check.createComment.mock.calls[0][0].body).toContain('Missing or empty required sections')
-    expect(check.createComment.mock.calls[0][0].body).not.toContain('include the `bug` label')
-  })
-
-  it('accepts a complete question without a bug label', async () => {
-    const question = body(baseSections.map(([heading, value]) => [heading, value === 'Bug 报告 / Bug report' ? '问题 / Question' : value]))
-    const check = harness(issue({ body: question, labels: [] }))
-    await check.run()
-    expect(check.update).not.toHaveBeenCalled()
-    expect(check.createComment).not.toHaveBeenCalled()
+    expect(check.addLabels).not.toHaveBeenCalled()
   })
 
   it.each([
-    ['an unchecked duplicate search', bugBody.replace('- [x]', '- [ ]'), 'You must confirm that you searched'],
-    ['evidence without a log or attachment', bugBody.replace(bugSections[0][1], 'It fails.'), 'Bug evidence must include'],
-    ['an empty required section', bugBody.replace(baseSections[6][1], '_No response_'), 'Missing or empty required sections'],
-  ])('still rejects %s', async (_name, invalidBody, message) => {
-    const check = harness(issue({ body: invalidBody }))
+    ['JSON logs (#210)', '```json\n{"code":"CONTEXT_WINDOW_EXCEEDED","n_prompt_tokens":145508,"n_ctx":98304}\n```'],
+    ['plain-text errors (#217)', 'Error: Multiple memory entries contain "X"; use a unique substring.'],
+    ['short errors', 'Error: X'],
+    ['other code block languages', '```typescript\nthrow new Error("Failed to archive")\n```'],
+  ])('accepts %s as supporting information', async (_name, evidence) => {
+    const check = harness(issue({ body: body([...baseSections, ['Bug 证据 / Bug evidence', evidence]]) }))
     await check.run()
-    expect(check.update).toHaveBeenCalledTimes(1)
-    expect(check.createComment.mock.calls[0][0].body).toContain(message)
+    expect(check.createComment).not.toHaveBeenCalled()
   })
 
-  it.each(['initial read', 'final read'])('does not close or comment if the %s fails', async (timing) => {
+  it('accepts evidence in the reproduction steps without repeating it in another section (#211)', async () => {
+    const reproduction = baseSections.map(([heading, value]) => [heading, heading === '详情或复现步骤 / Details or reproduction steps'
+      ? value + '\n\n```text\naoci_overview: 6, glob: 1, read: 1; overview body_bytes: 112388\n```' : value])
+    const check = harness(issue({ body: body(reproduction) }))
+    await check.run()
+    expect(check.createComment).not.toHaveBeenCalled()
+  })
+
+  it('adds the bug label for a report submitted without label permissions', async () => {
+    const check = harness(issue({ labels: [{ name: 'help wanted' }] }))
+    await check.run()
+    expect(check.addLabels).toHaveBeenCalledExactlyOnceWith({
+      owner: 'omdsh-dev', repo: 'dsh-mnemon', issue_number: 235, labels: ['bug'],
+    })
+    expect(check.createComment).not.toHaveBeenCalled()
+  })
+
+  it.each(['before the job starts', 'during the job'])('uses a bug label added %s (#235)', async (timing) => {
+    const check = harness(missingLabel(), { snapshots: timing === 'during the job' ? [missingLabel(), issue()] : [issue()] })
+    await check.run()
+    expect(check.addLabels).not.toHaveBeenCalled()
+    expect(check.createComment).not.toHaveBeenCalled()
+  })
+
+  it('uses the latest report type when the author changes a bug to a question', async () => {
+    const check = harness(missingLabel(), { snapshots: [missingLabel(), issue({ body: questionBody, labels: [] })] })
+    await check.run()
+    expect(check.addLabels).not.toHaveBeenCalled()
+    expect(check.createComment).not.toHaveBeenCalled()
+  })
+
+  it('accepts required information filled in while comments are being loaded', async () => {
+    const check = harness(incomplete(), { snapshots: [incomplete(), issue()] })
+    await check.run()
+    expect(check.createComment).not.toHaveBeenCalled()
+  })
+
+  it('rechecks required information after adding the bug label', async () => {
+    const missing = { ...incomplete(), labels: [] }
+    const check = harness(missing, { snapshots: [missing, missing, issue()] })
+    await check.run()
+    expect(check.addLabels).toHaveBeenCalledTimes(1)
+    expect(check.createComment).not.toHaveBeenCalled()
+  })
+
+  it.each(['before the job starts', 'during the job', 'while adding the label'])('skips an issue closed %s', async (timing) => {
+    const missing = { ...incomplete(), labels: [] }
+    const closed = { ...missing, state: 'closed' }
+    const snapshots = timing === 'before the job starts' ? [closed]
+      : timing === 'during the job' ? [missing, closed] : [missing, missing, closed]
+    const check = harness(missing, { snapshots })
+    await check.run()
+    expect(check.createComment).not.toHaveBeenCalled()
+    expect(check.updateComment).not.toHaveBeenCalled()
+    if (timing !== 'while adding the label') expect(check.addLabels).not.toHaveBeenCalled()
+  })
+
+  it.each(['opened', 'reopened', 'edited'])('requests missing information without closing an %s issue', async (action) => {
+    const check = harness(incomplete(), { action })
+    await check.run()
+    expect(check.createComment).toHaveBeenCalledTimes(1)
+    const comment = check.createComment.mock.calls[0][0].body
+    expect(comment).toContain('环境信息 / Environment')
+    expect(comment).toContain('The issue remains open')
+    expect(comment).toContain(marker)
+  })
+
+  it('requests duplicate-search confirmation without closing the report', async () => {
+    const check = harness(issue({ body: bugBody.replace('- [x]', '- [ ]') }))
+    await check.run()
+    expect(check.createComment.mock.calls[0][0].body).toContain('confirm that you searched')
+  })
+
+  it('handles an empty API-created report without assuming it is a bug', async () => {
+    const check = harness(issue({ body: null, labels: [] }))
+    await check.run()
+    expect(check.addLabels).not.toHaveBeenCalled()
+    expect(check.createComment.mock.calls[0][0].body).toContain('摘要 / Summary')
+  })
+
+  it('updates its existing reminder instead of posting another one', async () => {
+    const check = harness(incomplete(), { comments: [botComment(marker + '\nOld reminder')] })
+    await check.run()
+    expect(check.createComment).not.toHaveBeenCalled()
+    expect(check.updateComment).toHaveBeenCalledExactlyOnceWith({
+      owner: 'omdsh-dev', repo: 'dsh-mnemon', comment_id: 123, body: expect.stringContaining('环境信息 / Environment'),
+    })
+  })
+
+  it('marks its reminder resolved after the author supplies the missing information', async () => {
+    const check = harness(issue(), { comments: [botComment(marker + '\nOld reminder')], action: 'edited' })
+    await check.run()
+    expect(check.createComment).not.toHaveBeenCalled()
+    expect(check.updateComment.mock.calls[0][0].body).toContain('Required report information is present')
+  })
+
+  it('leaves an unchanged reminder alone when an issue is reopened again', async () => {
+    const first = harness(incomplete())
+    await first.run()
+    const comment = botComment(first.createComment.mock.calls[0][0].body)
+    const next = harness(incomplete(), { comments: [comment], action: 'reopened' })
+    await next.run()
+    expect(next.createComment).not.toHaveBeenCalled()
+    expect(next.updateComment).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { login: 'reporter', type: 'User' },
+    { login: 'other-automation[bot]', type: 'Bot' },
+  ])('does not edit a marker copied by $login', async (user) => {
+    const check = harness(incomplete(), { comments: [{ ...botComment(marker), user }] })
+    await check.run()
+    expect(check.updateComment).not.toHaveBeenCalled()
+    expect(check.createComment).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['initial read', 'latest read'])('makes no changes when the %s fails', async (timing) => {
     const failure = new Error('GitHub is unavailable')
-    const check = harness(missingLabel(), timing === 'initial read' ? [failure] : [missingLabel(), failure])
+    const check = harness(incomplete(), { snapshots: timing === 'initial read' ? [failure] : [incomplete(), failure] })
     await expect(check.run()).rejects.toThrow('GitHub is unavailable')
-    expect(check.update).not.toHaveBeenCalled()
+    expect(check.addLabels).not.toHaveBeenCalled()
     expect(check.createComment).not.toHaveBeenCalled()
+    expect(check.updateComment).not.toHaveBeenCalled()
   })
 
-  it('does not claim an issue was closed if the close request fails', async () => {
+  it('does not post duplicate advice when comment lookup fails', async () => {
+    const check = harness(incomplete())
+    check.listComments.mockRejectedValueOnce(new Error('Comment lookup failed'))
+    await expect(check.run()).rejects.toThrow('Comment lookup failed')
+    expect(check.createComment).not.toHaveBeenCalled()
+    expect(check.updateComment).not.toHaveBeenCalled()
+  })
+
+  it('reports label API failures without closing or blaming the reporter', async () => {
     const check = harness(missingLabel())
-    check.update.mockRejectedValueOnce(new Error('Close request failed'))
-    await expect(check.run()).rejects.toThrow('Close request failed')
+    check.addLabels.mockRejectedValueOnce(new Error('Label request failed'))
+    await expect(check.run()).rejects.toThrow('Label request failed')
     expect(check.createComment).not.toHaveBeenCalled()
   })
 
-  it.each([undefined, issue({ pull_request: {} })])('ignores an event without a regular issue', async (eventIssue) => {
+  it.each([undefined, issue({ pull_request: {} })])('ignores events without a regular issue', async (eventIssue) => {
     const check = harness(eventIssue)
     await check.run()
     expect(check.get).not.toHaveBeenCalled()
-    expect(check.update).not.toHaveBeenCalled()
+    expect(check.addLabels).not.toHaveBeenCalled()
     expect(check.createComment).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
> 提交 PR 前请阅读[贡献指南](../CONTRIBUTING.zh-CN.md)、[Contributing Guide](../CONTRIBUTING.md)与[开发和验证指南](../docs/zh-CN/development/README.md) / [Development and Verification Guide](../docs/en/development/README.md)。
> Before opening a PR, read the [Contributing Guide](../CONTRIBUTING.md), [贡献指南](../CONTRIBUTING.zh-CN.md), and the [Development and Verification Guide](../docs/en/development/README.md) / [开发和验证指南](../docs/zh-CN/development/README.md).
> PR 标题和提交信息必须使用 Conventional Commits（`type(scope): subject`），且不得包含 emoji。 / PR titles and commits must use Conventional Commits (`type(scope): subject`) and must not contain emoji.
> 本仓库接受 Bug 修复、兼容性适配、现有能力增强、性能或体验优化和维护类 PR。全新能力、Provider、持久化格式或安全边界变更必须先提 Issue 并获得维护者确认。 / This repository accepts bug fixes, compatibility work, improvements to existing capabilities, performance or UX optimization, and maintenance. New capabilities, Providers, persistence formats, or security-boundary changes require prior maintainer approval in an Issue.
> 外部贡献者的仅文档类 PR 不直接接受；请先提 Issue 讨论。维护者的发布说明与文档维护不受此限制。 / Documentation-only PRs from external contributors are not accepted directly; open an Issue first. Maintainer release notes and documentation maintenance are exempt.

## 摘要 / Summary

有效报告因 JSON 日志、日志所在段落、普通文本报错或无法自行补标签而被自动关闭。模板检查现改为请求补充基础信息，自动为 Bug 报告补标签，并在编辑后更新同一条提示；证据、冒烟测试、代码引用和补丁草案改为选填。

Issue information checks now keep reports open and request missing basic details instead of enforcing evidence formatting. Bug labels are added automatically, one reminder is maintained across edits/reopens, and the forms and bilingual rules make supplemental fields optional.

## 关联 Issue 或背景 / Related Issue or Context

Refs #210, #211 and #217: their existing evidence was rejected for its code-block language, section or formatting. Follows #236, which corrected stale event-state reads.

本 PR 处理报告提交和分类规则；这些 issue 中的运行时问题继续单独跟踪。 / This PR addresses report intake and triage policy; the runtime defects in those issues remain independently tracked.

## 涉及区域 / Affected Areas

<!-- 至少勾选一项。 / Check at least one item. -->

- [ ] Host 激活、Headless 或 bundle / Host activation, Headless, or bundle
- [ ] 运行时记忆 / Runtime Memory
- [ ] 项目档案 / Project Documents
- [ ] 记忆空间或 Provider / Memory Spaces or Providers
- [ ] 子 Agent 或 Agent 工作流 / Subagent or Agent workflow
- [ ] Web UI 或对话交互 / Web UI or conversation interaction
- [ ] 设置、存储或安全 / Settings, storage, or security
- [ ] CLI、RPC、命令或工具 / CLI, RPC, commands, or tools
- [ ] 安装、更新或发布 / Installation, update, or release
- [x] 测试、构建或文档 / Tests, build, or documentation
- [x] 其他（请说明）/ Other (explain below)

其他 / Other: GitHub Issue Forms and triage automation.

## PR 类型 / PR Type

<!-- 至少勾选一项；仅文档类 PR 的限制见文件顶部说明。 / Check at least one item; see the note above for documentation-only PRs. -->

- [ ] 面向用户的功能或行为变更 / User-facing feature or behavior change
- [x] Bug 修复 / Bug fix
- [ ] 增强或优化 / Enhancement or optimization
- [ ] 兼容性适配 / Compatibility change
- [x] 维护或重构 / Maintenance or refactor
- [x] 测试或构建 / Tests or build

## 最新代码确认 / Latest Codebase Confirmation

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase 或合并最新 `main`。 / I developed from the latest `main`, or rebased or merged the latest `main` before submitting.

同步命令 / Sync command:

```bash
git fetch origin main
git worktree add -b codex/relax-issue-template-validation ../dsh-mnemon-issue-triage-policy origin/main
```

Base: `de05a6fff17024919a50284702ec35dd726e2ee3`. Implementation and verification used a separate worktree.

## AI 编码披露 / AI Coding Disclosure

<!-- 必填。勾选且仅勾选一项；模型和工具字段不得留空。 / Required. Check exactly one option; the model and tool fields must not be blank. -->

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受和审查。 / Fully AI-coded: AI produced all programming changes, which the contributor accepted and reviewed.
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分内容。 / Partially AI-assisted: AI helped write or modify part of the change.
- [ ] 未使用 AI 编码辅助。 / No AI coding assistance was used.

使用的 AI 模型 / AI model used:

GPT-6

使用的编码 Agent 工具 / Coding Agent tool used:

Codex

## 仓库规范检查 / Repository Rules

<!-- 本仓库硬性规范，请逐项确认。 / Confirm every mandatory repository rule. -->

- [x] 未修改 DSH 官方源码，未让 tsconfig 指向 DSH 源码 checkout，仅使用正式的 `@deepseek-ai/*` NPM 契约。 / I did not modify DSH source or point tsconfig at a DSH source checkout, and used only published `@deepseek-ai/*` NPM contracts.
- [x] Client 与 Host 边界仍以浏览器安全的 `src/host/protocol.ts` 为准，没有在两侧重复定义 wire DTO。 / The Client and Host boundary still uses browser-safe `src/host/protocol.ts` as the source for wire DTOs.
- [x] 持久化格式、RPC 权限、路径或凭据处理的变更包含兼容或拒绝路径、安全分析和相应测试。 / Changes to persistence formats, RPC authority, paths, or credentials include compatibility or rejection paths, security analysis, and tests.
- [x] 没有提交 token、密钥、私有记忆、未脱敏日志或生成的 `lib/` 文件。 / I did not commit tokens, credentials, private memory, unredacted logs, or generated `lib/` files.
- [x] 用户可见文案和长期文档已同步维护中文与英文版本，命令、配置键和路径保持一致。 / User-facing copy and long-lived documentation are synchronized in Chinese and English, with matching commands, configuration keys, and paths.
- [x] 会改变发布制品或其元数据的 PR 已添加 changeset；仅测试、CI 或站点文档变更可不添加。 / A PR that changes a published artifact or its metadata includes a changeset; test-only, CI-only, and site-documentation-only changes may omit one.
- [x] 新增和修改的代码、注释、文档、提交信息不含 emoji。 / New and modified code, comments, documentation, and commits contain no emoji.

## 兼容性与数据安全 / Compatibility and Data Safety

仅修改 Issue Forms、信息检查工作流、双语贡献/分类说明及测试；无需 changeset。重复 Issue 检测和 PR 检查仍使用各自现有策略。

No runtime, Provider, storage, public API or package inputs change. The workflow retains current-state reads, skips closed issues, and never changes issue state. It uses additive label updates and edits only its own marked `github-actions[bot]` comment. Runs are serialized per issue to avoid duplicate reminders. Missing core fields still receive a specific request for information; evidence quality and closure are left to maintainer review.

## 本地验证 / Local Validation

执行的命令 / Commands run:

```bash
pnpm install --frozen-lockfile
pnpm exec vitest run tests/issue-template-enforcer.spec.mjs
pnpm run verify
git diff --check
```

结果摘要 / Result summary:

- Workflow regressions: 31 passed. The previous workflow failed 24 of these scenarios before the change.
- Full `pnpm run verify`: passed, including documentation checks, root/plugin types and builds, plugin tests, the root suite (926 passed), isolated Headless activation and package checks.
- Expected skips: 5 opt-in live Flash tests and 2 platform/native integration tests.
- Both forms and the workflow passed YAML parsing. Required core fields and optional supplemental fields were checked; JavaScript extracted from the parsed YAML passed Node syntax checking.
- The original bodies of #210, #211 and #217 passed a local replay with zero state changes or comments. A replay without the bug label added only `bug`.
- GitHub access during replay was read-only; all workflow mutations were mocked. No existing issue was edited or reopened for testing.
- `git diff --check` passed. Environment: macOS, Node.js v25.1.0, pnpm 11.19.0.

## 用户可见变更证据 / Local Feature Evidence

<!--
面向用户的功能或行为变更必填。 / Required for user-facing feature or behavior changes.
附截图或短视频，展示 / Attach screenshots or a short video showing:
- 使用的是本 PR 或最新代码 / the PR or latest code is running
- 功能已启用或配置 / the feature is enabled or configured
- 操作成功并出现可见结果 / the action succeeds with a visible result
- 没有泄露凭据、私有记忆或敏感路径 / no credentials, private memory, or sensitive paths are exposed
纯内部改动可填 N/A 并解释。 / For internal-only changes, enter N/A and explain.
-->

证据 / Evidence:

The tests execute the actual inline workflow script. They cover JSON and plain-text evidence, evidence in reproduction steps, omitted supplemental sections, automatic labeling, stale snapshots, maintainer reopening, updating/resolving one reminder, copied comment markers and API failures. Every scenario asserts that no issue-state update occurs.

```text
Previous workflow: 24 failed, 7 passed (31)
Updated workflow: 31 passed (31)
Full root suite: 926 passed, 5 opt-in tests skipped
Issue #210 replay: stateChanges=0, comments=0
Issue #211 replay: stateChanges=0, comments=0
Issue #217 replay: stateChanges=0, comments=0
Issue #210 without labels: stateChanges=0, comments=0, addedLabels=[bug]
```
